### PR TITLE
Cleanup-Serializer-IdentityDictionary 

### DIFF
--- a/src/Soil-Core-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Core-Tests/SoilSerializationTest.class.st
@@ -351,6 +351,7 @@ SoilSerializationTest >> testSerializationIdentityDictionary [
 	self assert: (serialized at: 1) equals: TypeCodeIdentityDictionary.
 
 	materialized := SoilMaterializer materializeFromBytes: serialized.
+	self assert: materialized class equals: IdentityDictionary.
 	self assert: materialized equals: object
 ]
 

--- a/src/Soil-Core-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Core-Tests/SoilSerializationTest.class.st
@@ -340,14 +340,7 @@ SoilSerializationTest >> testSerializationIdentityDictionary [
 	| object serialized materialized |
 	object := IdentityDictionary newFrom: { #test->2 . #now->4 }.
 	serialized := SoilSerializer serializeToBytes: object.
-	self assert: (
-			serialized = 
-			"the order of association in the dict is different between Pharo9 and Pharo10, no idea why"
-			#[19 2 27 4 116 101 115 116 3 2 27 3 110 111 119 3 4]
-		or: [ 
-			serialized = 
-			#[19 2 27 3 110 111 119 3 4 27 4 116 101 115 116 3 2] ]).
-
+	self assert: serialized equals: #[19 2 27 3 110 111 119 3 4 27 4 116 101 115 116 3 2].
 	self assert: (serialized at: 1) equals: TypeCodeIdentityDictionary.
 
 	materialized := SoilMaterializer materializeFromBytes: serialized.

--- a/src/Soil-Core/SoilMaterializer.class.st
+++ b/src/Soil-Core/SoilMaterializer.class.st
@@ -161,11 +161,6 @@ SoilMaterializer >> nextFraction: aClass [
 ]
 
 { #category : #'as yet unclassified' }
-SoilMaterializer >> nextIdentityDictionary: aClass [ 
-	self shouldBeImplemented.
-]
-
-{ #category : #'as yet unclassified' }
 SoilMaterializer >> nextInternalReference [
 	| index |
 	index := self nextLengthEncodedInteger.


### PR DESCRIPTION
SoilMaterializer>>nextIdentityDictionary: is not needed as we call nextDictionary: of the superclass with the class as a parameter