### PR TITLE
simplify testNoUnusedTemporaryVariablesLeft

### DIFF
--- a/src/Soil-Core-Tests/SOCleanCodeTest.class.st
+++ b/src/Soil-Core-Tests/SOCleanCodeTest.class.st
@@ -111,10 +111,8 @@ SOCleanCodeTest >> testNoUnusedInstanceVariablesLeft [
 SOCleanCodeTest >> testNoUnusedTemporaryVariablesLeft [
 	"Fail if there are methods who have unused temporary variables"
 	| found  |
-	found := Soil package methods select: [ :m |
-		"before creating the AST (slow), check if there are temps" 
-		((m numTemps - m numArgs) > 0) and: [  
-		m ast temporaries anySatisfy: [ :x | x binding isUsed not] ] ].
+	found := Soil package methods select: [ :m | 
+		m hasTemporaries and: [ m ast temporaries anySatisfy: [ :x | x binding isUsed not] ] ].
 							
 	self 
 		assert: found isEmpty 


### PR DESCRIPTION
as we do not support Pharo, we can simplify testNoUnusedTemporaryVariablesLeft