### PR TITLE
23-ObjectsoilBasicSerialize-should-delegate-to-the-AbstractLayout-Hierarchy 

### DIFF
--- a/src/Soil-Core/AbstractLayout.extension.st
+++ b/src/Soil-Core/AbstractLayout.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #AbstractLayout }
+
+{ #category : #'*Soil-Core' }
+AbstractLayout >> soilBasicSerialize: anObject with: serializer [
+	self subclassResponsibility
+]

--- a/src/Soil-Core/ByteLayout.extension.st
+++ b/src/Soil-Core/ByteLayout.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #ByteLayout }
+
+{ #category : #'*Soil-Core' }
+ByteLayout >> soilBasicSerialize: anObject with: serializer [
+	| classInfo |
+	classInfo := serializer classDescriptionFor: anObject class.
+	serializer 
+		nextPutObjectType;
+		basicNextPutString: classInfo name.
+
+	serializer nextPutLengthEncodedInteger: anObject basicSize.
+	serializer nextPutBytesFrom: anObject len: anObject basicSize
+]

--- a/src/Soil-Core/DoubleByteLayout.extension.st
+++ b/src/Soil-Core/DoubleByteLayout.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : #DoubleByteLayout }
+
+{ #category : #'*Soil-Core' }
+DoubleByteLayout >> soilBasicSerialize: anObject with: serializer [
+	| classInfo instSize |
+	classInfo := serializer classDescriptionFor: anObject class.
+	serializer 
+		nextPutObjectType;
+		basicNextPutString: classInfo name.
+	serializer nextPutLengthEncodedInteger: anObject basicSize.
+	
+	classInfo instVarIndexes do: [:i | (anObject instVarAt: i) soilSerialize: serializer ].
+		instSize := anObject class instSize.
+		"on variable sized objects size > instVars"
+		instSize + 1 to: instSize + anObject basicSize do: [:i | 
+		(anObject instVarAt: i) soilSerialize: serializer ]
+]

--- a/src/Soil-Core/DoubleWordLayout.extension.st
+++ b/src/Soil-Core/DoubleWordLayout.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : #DoubleWordLayout }
+
+{ #category : #'*Soil-Core' }
+DoubleWordLayout >> soilBasicSerialize: anObject with: serializer [
+	| classInfo instSize |
+	classInfo := serializer classDescriptionFor: anObject class.
+	serializer 
+		nextPutObjectType;
+		basicNextPutString: classInfo name.
+	serializer nextPutLengthEncodedInteger: anObject basicSize.
+	
+	classInfo instVarIndexes do: [:i | (anObject instVarAt: i) soilSerialize: serializer ].
+		instSize := anObject class instSize.
+		"on variable sized objects size > instVars"
+		instSize + 1 to: instSize + anObject basicSize do: [:i | 
+		(anObject instVarAt: i) soilSerialize: serializer ]
+]

--- a/src/Soil-Core/Object.extension.st
+++ b/src/Soil-Core/Object.extension.st
@@ -1,28 +1,9 @@
 Extension { #name : #Object }
 
 { #category : #'*Soil-Core' }
-Object >> soilBasicSerialize: serializer [ 
-	| classInfo instSize |
-	classInfo := serializer classDescriptionFor: self class.
-	serializer 
-		nextPutObjectType;
-		basicNextPutString: classInfo name.
-	 
-	self flag: #question.
-	"How many layouts there are??"
-	classInfo isVariable ifTrue: [ serializer nextPutLengthEncodedInteger: self basicSize ].
-	"classInfo isBytes ifTrue: [ self halt ]."
-	classInfo isBytes ifFalse: [
-		classInfo instVarIndexes do: [:i | (self instVarAt: i) soilSerialize: serializer ].
-		instSize := self class instSize.
-		"on variable sized objects size > instVars"
-		instSize + 1 to: instSize + self basicSize do: [:i | 
-			(self instVarAt: i) soilSerialize: serializer ].
-	^self].
-	self class isWords
-		ifFalse: [ serializer nextPutBytesFrom: self len: self basicSize ]
-		ifTrue: [ 1 to: self basicSize do: [:i | serializer nextPutLengthEncodedInteger: (self basicAt: i)]].
-		
+Object >> soilBasicSerialize: serializer [
+	"Delegate serialization to the class layout"
+	self class classLayout soilBasicSerialize: self with: serializer
 ]
 
 { #category : #'*Soil-Core' }

--- a/src/Soil-Core/PointerLayout.extension.st
+++ b/src/Soil-Core/PointerLayout.extension.st
@@ -1,0 +1,16 @@
+Extension { #name : #PointerLayout }
+
+{ #category : #'*Soil-Core' }
+PointerLayout >> soilBasicSerialize: anObject with: serializer [
+	| classInfo instSize |
+	classInfo := serializer classDescriptionFor: anObject class.
+	serializer 
+		nextPutObjectType;
+		basicNextPutString: classInfo name.
+	
+	classInfo instVarIndexes do: [:i | (anObject instVarAt: i) soilSerialize: serializer ].
+		instSize := anObject class instSize.
+		"on variable sized objects size > instVars"
+		instSize + 1 to: instSize + anObject basicSize do: [:i | 
+		(anObject instVarAt: i) soilSerialize: serializer ]
+]

--- a/src/Soil-Core/VariableLayout.extension.st
+++ b/src/Soil-Core/VariableLayout.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : #VariableLayout }
+
+{ #category : #'*Soil-Core' }
+VariableLayout >> soilBasicSerialize: anObject with: serializer [
+	| classInfo instSize |
+	classInfo := serializer classDescriptionFor: anObject class.
+	serializer 
+		nextPutObjectType;
+		basicNextPutString: classInfo name.
+	 serializer nextPutLengthEncodedInteger: anObject basicSize.
+	
+	classInfo instVarIndexes do: [:i | (anObject instVarAt: i) soilSerialize: serializer ].
+		instSize := anObject class instSize.
+		"on variable sized objects size > instVars"
+		instSize + 1 to: instSize + anObject basicSize do: [:i | 
+		(anObject instVarAt: i) soilSerialize: serializer ]
+]

--- a/src/Soil-Core/WeakLayout.extension.st
+++ b/src/Soil-Core/WeakLayout.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : #WeakLayout }
+
+{ #category : #'*Soil-Core' }
+WeakLayout >> soilBasicSerialize: anObject with: serializer [
+	| classInfo instSize |
+	classInfo := serializer classDescriptionFor: anObject class.
+	serializer 
+		nextPutObjectType;
+		basicNextPutString: classInfo name.
+	 serializer nextPutLengthEncodedInteger: anObject basicSize.
+	
+	classInfo instVarIndexes do: [:i | (anObject instVarAt: i) soilSerialize: serializer ].
+		instSize := anObject class instSize.
+		"on variable sized objects size > instVars"
+		instSize + 1 to: instSize + anObject basicSize do: [:i | 
+		(anObject instVarAt: i) soilSerialize: serializer ]
+]

--- a/src/Soil-Core/WordLayout.extension.st
+++ b/src/Soil-Core/WordLayout.extension.st
@@ -1,0 +1,17 @@
+Extension { #name : #WordLayout }
+
+{ #category : #'*Soil-Core' }
+WordLayout >> soilBasicSerialize: anObject with: serializer [
+	| classInfo instSize |
+	classInfo := serializer classDescriptionFor: anObject class.
+	serializer 
+		nextPutObjectType;
+		basicNextPutString: classInfo name.
+	 serializer nextPutLengthEncodedInteger: anObject basicSize.
+	
+	classInfo instVarIndexes do: [:i | (anObject instVarAt: i) soilSerialize: serializer ].
+		instSize := anObject class instSize.
+		"on variable sized objects size > instVars"
+		instSize + 1 to: instSize + anObject basicSize do: [:i | 
+		(anObject instVarAt: i) soilSerialize: serializer ]
+]


### PR DESCRIPTION
This PR moves the code of Object>>#soilBasicSerialize: to the AbstractLayout Hierarchy

This is just a first step: it moves the code over, but keep exactly what was executed before. 

- We can see that some things are very odd, e.g. we use instVarAt: for many cases where we actually do not store pointers (see e.g  WordLayout>>#soilBasicSerialize:with: )
- Some layouts have no implementation yet