### PR TITLE
testSerializationIdentityDictionary needs to check for both orders

### DIFF
--- a/src/Soil-Core-Tests/SOCleanCodeTest.class.st
+++ b/src/Soil-Core-Tests/SOCleanCodeTest.class.st
@@ -86,20 +86,10 @@ SOCleanCodeTest >> testNoUnsentMessages [
 	found := Soil package allUnsentMessages.
 	
 	"To be fixed, see https://github.com/ApptiveGrid/Soil/issues/24"
-	knownviolations := #(
-		#classId 
-		#versionSize 
-		#flock:operation: 
-		#canLock:from:to:exclusive: 
-		#setNonBlock: #at:putObject: 
-		#nextIdentityDictionary: 
-		#transaction 
-		#unlock:from:to: 
-		#nextDate 
-		#lock:from:to: 
-		#soilLoadedIn: 
-		#nextPutPositiveInteger: 
-		#idOf:).
+	knownviolations := #(classId #versionSize #flock:operation: #canLock:from:to:exclusive:
+#setNonBlock: #at:putObject: #unlock:from:to: #transaction #nextDate
+#lock:from:to: #soilLoadedIn: #nextPutPositiveInteger: #idOf:
+	).
 	
 	found := found copyWithoutAll: knownviolations.
 	

--- a/src/Soil-Core-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Core-Tests/SoilSerializationTest.class.st
@@ -342,8 +342,7 @@ SoilSerializationTest >> testSerializationIdentityDictionary [
  		or: [ 
  			serialized = 
  			#[19 2 27 3 110 111 119 3 4 27 4 116 101 115 116 3 2] ]).
-	
-	self assert: serialized equals: #[19 2 27 3 110 111 119 3 4 27 4 116 101 115 116 3 2].
+		
 	self assert: (serialized at: 1) equals: TypeCodeIdentityDictionary.
 
 	materialized := SoilMaterializer materializeFromBytes: serialized.

--- a/src/Soil-Core-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Core-Tests/SoilSerializationTest.class.st
@@ -334,6 +334,15 @@ SoilSerializationTest >> testSerializationIdentityDictionary [
 	| object serialized materialized |
 	object := IdentityDictionary newFrom: { #test->2 . #now->4 }.
 	serialized := SoilSerializer serializeToBytes: object.
+	
+	 self assert: (
+ 			serialized = 
+ 			"the order of association in the dict is different between Pharo10 and Pharo11"
+ 			#[19 2 27 4 116 101 115 116 3 2 27 3 110 111 119 3 4]
+ 		or: [ 
+ 			serialized = 
+ 			#[19 2 27 3 110 111 119 3 4 27 4 116 101 115 116 3 2] ]).
+	
 	self assert: serialized equals: #[19 2 27 3 110 111 119 3 4 27 4 116 101 115 116 3 2].
 	self assert: (serialized at: 1) equals: TypeCodeIdentityDictionary.
 


### PR DESCRIPTION
for (Pharo10/Pharo11)
- remove one case from testNoUnsentMessages