### PR TITLE
Fixes for WordLayout  Serialization and Deserialization

### DIFF
--- a/src/Soil-Core-Tests/SOCleanCodeTest.class.st
+++ b/src/Soil-Core-Tests/SOCleanCodeTest.class.st
@@ -64,7 +64,6 @@ SOCleanCodeTest >> testNoUncategorizedMethods [
 SOCleanCodeTest >> testNoUnimplementedCalls [
 
 	| remaining |
-	self skip.
 	remaining := Soil package methods select: [ :meth | 
 		             | ignored |
 		             ignored := (meth pragmaAt: #ignoreUnimplementedCalls:)

--- a/src/Soil-Core-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Core-Tests/SoilSerializationTest.class.st
@@ -124,7 +124,6 @@ SoilSerializationTest >> testSerializationByteArray [
 { #category : #'tests-layouts' }
 SoilSerializationTest >> testSerializationByteLayout [
 	| object serialized materialized |
-	self skip.
 	"We use SocketAddress as an exampe of a class with a ByteLayout but not specially encoded"
 	object := #[127 0 0 1] asSocketAddress.
 	
@@ -348,6 +347,21 @@ SoilSerializationTest >> testSerializationIdentityDictionary [
 	materialized := SoilMaterializer materializeFromBytes: serialized.
 	self assert: materialized class equals: IdentityDictionary.
 	self assert: materialized equals: object
+]
+
+{ #category : #'tests-layouts' }
+SoilSerializationTest >> testSerializationImmediateLayout [
+	| object serialized materialized |
+	"All Immediate classes are specially encoded, to have a test for every layout, use Character here"
+	object := $a.
+	
+	self assert: object class classLayout class equals: ImmediateLayout.
+	serialized := SoilSerializer serializeToBytes: object.
+
+	materialized := SoilMaterializer materializeFromBytes: serialized.
+	self assert: materialized equals: object.
+	self assert: materialized class equals: Character.
+	self assert: materialized class classLayout class equals: ImmediateLayout.
 ]
 
 { #category : #tests }
@@ -905,15 +919,15 @@ SoilSerializationTest >> testSerializationUndefindedObject [
 SoilSerializationTest >> testSerializationVariableLayout [
 	| object serialized materialized |
 	"All Immediate classes are specially encoded, to have a test for every layout, use Character here"
-	object := $a.
+	object := Path root.
 	
-	self assert: object class classLayout class equals: ImmediateLayout.
+	self assert: object class classLayout class equals: VariableLayout.
 	serialized := SoilSerializer serializeToBytes: object.
 
 	materialized := SoilMaterializer materializeFromBytes: serialized.
 	self assert: materialized equals: object.
-	self assert: materialized class equals: Character.
-	self assert: materialized class classLayout class equals: ImmediateLayout.
+	self assert: materialized class equals: AbsolutePath.
+	self assert: materialized class classLayout class equals: VariableLayout.
 ]
 
 { #category : #'tests-encoded-subclasses' }

--- a/src/Soil-Core/ByteLayout.extension.st
+++ b/src/Soil-Core/ByteLayout.extension.st
@@ -2,12 +2,14 @@ Extension { #name : #ByteLayout }
 
 { #category : #'*Soil-Core' }
 ByteLayout >> soilBasicSerialize: anObject with: serializer [
-	| classInfo |
+	| classInfo instSize |
+
 	classInfo := serializer classDescriptionFor: anObject class.
 	serializer 
 		nextPutObjectType;
 		basicNextPutString: classInfo name.
 
-	serializer nextPutLengthEncodedInteger: anObject basicSize.
-	serializer nextPutBytesFrom: anObject len: anObject basicSize
+	instSize := anObject basicSize.
+	serializer nextPutLengthEncodedInteger: instSize.
+	serializer nextPutBytesFrom: anObject len: instSize
 ]

--- a/src/Soil-Core/ByteLayout.extension.st
+++ b/src/Soil-Core/ByteLayout.extension.st
@@ -3,7 +3,6 @@ Extension { #name : #ByteLayout }
 { #category : #'*Soil-Core' }
 ByteLayout >> soilBasicSerialize: anObject with: serializer [
 	| classInfo instSize |
-
 	classInfo := serializer classDescriptionFor: anObject class.
 	serializer 
 		nextPutObjectType;

--- a/src/Soil-Core/CompiledMethodLayout.extension.st
+++ b/src/Soil-Core/CompiledMethodLayout.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #CompiledMethodLayout }
+
+{ #category : #'*Soil-Core' }
+CompiledMethodLayout >> soilBasicSerialize: anObject with: serializer [
+	self error: #todo
+]

--- a/src/Soil-Core/DoubleByteLayout.extension.st
+++ b/src/Soil-Core/DoubleByteLayout.extension.st
@@ -2,16 +2,12 @@ Extension { #name : #DoubleByteLayout }
 
 { #category : #'*Soil-Core' }
 DoubleByteLayout >> soilBasicSerialize: anObject with: serializer [
-	| classInfo instSize |
+	| classInfo |
 	classInfo := serializer classDescriptionFor: anObject class.
 	serializer 
 		nextPutObjectType;
 		basicNextPutString: classInfo name.
-	serializer nextPutLengthEncodedInteger: anObject basicSize.
 	
-	classInfo instVarIndexes do: [:i | (anObject instVarAt: i) soilSerialize: serializer ].
-		instSize := anObject class instSize.
-		"on variable sized objects size > instVars"
-		instSize + 1 to: instSize + anObject basicSize do: [:i | 
-		(anObject instVarAt: i) soilSerialize: serializer ]
+	serializer nextPutLengthEncodedInteger: anObject basicSize.
+	serializer nextPutBytesFrom: anObject len: anObject basicSize
 ]

--- a/src/Soil-Core/DoubleByteLayout.extension.st
+++ b/src/Soil-Core/DoubleByteLayout.extension.st
@@ -2,12 +2,13 @@ Extension { #name : #DoubleByteLayout }
 
 { #category : #'*Soil-Core' }
 DoubleByteLayout >> soilBasicSerialize: anObject with: serializer [
-	| classInfo |
+	| classInfo instSize |
 	classInfo := serializer classDescriptionFor: anObject class.
 	serializer 
 		nextPutObjectType;
 		basicNextPutString: classInfo name.
 	
-	serializer nextPutLengthEncodedInteger: anObject basicSize.
-	serializer nextPutBytesFrom: anObject len: anObject basicSize
+	instSize := anObject basicSize.
+	serializer nextPutLengthEncodedInteger: instSize.
+	serializer nextPutBytesFrom: anObject len: instSize
 ]

--- a/src/Soil-Core/DoubleWordLayout.extension.st
+++ b/src/Soil-Core/DoubleWordLayout.extension.st
@@ -2,12 +2,13 @@ Extension { #name : #DoubleWordLayout }
 
 { #category : #'*Soil-Core' }
 DoubleWordLayout >> soilBasicSerialize: anObject with: serializer [
-	| classInfo |
+	| classInfo instSize |
 	classInfo := serializer classDescriptionFor: anObject class.
 	serializer 
 		nextPutObjectType;
 		basicNextPutString: classInfo name.
 
-	serializer nextPutLengthEncodedInteger: anObject basicSize.
-	1 to: anObject basicSize do: [:i | serializer nextPutLengthEncodedInteger: (anObject basicAt: i)]
+	instSize := anObject basicSize.
+	serializer nextPutLengthEncodedInteger: instSize.
+	1 to: instSize do: [:i | serializer nextPutLengthEncodedInteger: (anObject basicAt: i)]
 ]

--- a/src/Soil-Core/DoubleWordLayout.extension.st
+++ b/src/Soil-Core/DoubleWordLayout.extension.st
@@ -2,16 +2,12 @@ Extension { #name : #DoubleWordLayout }
 
 { #category : #'*Soil-Core' }
 DoubleWordLayout >> soilBasicSerialize: anObject with: serializer [
-	| classInfo instSize |
+	| classInfo |
 	classInfo := serializer classDescriptionFor: anObject class.
 	serializer 
 		nextPutObjectType;
 		basicNextPutString: classInfo name.
+
 	serializer nextPutLengthEncodedInteger: anObject basicSize.
-	
-	classInfo instVarIndexes do: [:i | (anObject instVarAt: i) soilSerialize: serializer ].
-		instSize := anObject class instSize.
-		"on variable sized objects size > instVars"
-		instSize + 1 to: instSize + anObject basicSize do: [:i | 
-		(anObject instVarAt: i) soilSerialize: serializer ]
+	1 to: anObject basicSize do: [:i | serializer nextPutLengthEncodedInteger: (anObject basicAt: i)]
 ]

--- a/src/Soil-Core/EmptyLayout.extension.st
+++ b/src/Soil-Core/EmptyLayout.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #EmptyLayout }
+
+{ #category : #'*Soil-Core' }
+EmptyLayout >> soilBasicSerialize: anObject with: serializer [
+	self error: 'this should never be called'
+]

--- a/src/Soil-Core/ImmediateLayout.extension.st
+++ b/src/Soil-Core/ImmediateLayout.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #ImmediateLayout }
+
+{ #category : #'*Soil-Core' }
+ImmediateLayout >> soilBasicSerialize: anObject with: serializer [
+	"Immediate Objects are all serialized with their own TypeCode"
+	self error: 'this should never be called'
+]

--- a/src/Soil-Core/PointerLayout.extension.st
+++ b/src/Soil-Core/PointerLayout.extension.st
@@ -2,15 +2,11 @@ Extension { #name : #PointerLayout }
 
 { #category : #'*Soil-Core' }
 PointerLayout >> soilBasicSerialize: anObject with: serializer [
-	| classInfo instSize |
+	| classInfo |
 	classInfo := serializer classDescriptionFor: anObject class.
 	serializer 
 		nextPutObjectType;
 		basicNextPutString: classInfo name.
 	
 	classInfo instVarIndexes do: [:i | (anObject instVarAt: i) soilSerialize: serializer ].
-		instSize := anObject class instSize.
-		"on variable sized objects size > instVars"
-		instSize + 1 to: instSize + anObject basicSize do: [:i | 
-		(anObject instVarAt: i) soilSerialize: serializer ]
 ]

--- a/src/Soil-Core/SoilMaterializer.class.st
+++ b/src/Soil-Core/SoilMaterializer.class.st
@@ -44,9 +44,9 @@ SoilMaterializer >> newObject [
 			object := objectClass basicNew.
 		].
 	self registerObject: object.
-	object class isBytes ifTrue: [
+	object class isBits ifTrue: [
 		objectClass isWords 
-			ifTrue: [1 to: basicSize do: [:i | object basicAt: i put: stream primitive getInteger]]
+			ifTrue: [1 to: basicSize do: [:i | object basicAt: i put: self nextLengthEncodedInteger]]
 			ifFalse: [ stream readInto: object startingAt: 1 count: basicSize ].
 		^object
 	].

--- a/src/Soil-Core/VariableLayout.extension.st
+++ b/src/Soil-Core/VariableLayout.extension.st
@@ -2,16 +2,12 @@ Extension { #name : #VariableLayout }
 
 { #category : #'*Soil-Core' }
 VariableLayout >> soilBasicSerialize: anObject with: serializer [
-	| classInfo instSize |
-	classInfo := serializer classDescriptionFor: anObject class.
-	serializer 
-		nextPutObjectType;
-		basicNextPutString: classInfo name.
-	 serializer nextPutLengthEncodedInteger: anObject basicSize.
+	| instSize |
+	super soilBasicSerialize: anObject with: serializer.
 	
-	classInfo instVarIndexes do: [:i | (anObject instVarAt: i) soilSerialize: serializer ].
-		instSize := anObject class instSize.
-		"on variable sized objects size > instVars"
-		instSize + 1 to: instSize + anObject basicSize do: [:i | 
-		(anObject instVarAt: i) soilSerialize: serializer ]
+	serializer nextPutLengthEncodedInteger: anObject basicSize.
+	"on variable sized objects size > instVars"
+	instSize := anObject class instSize.
+	instSize + 1 to: instSize + anObject basicSize do: [:i | 
+	(anObject basicAt: i) soilSerialize: serializer ]
 ]

--- a/src/Soil-Core/WeakLayout.extension.st
+++ b/src/Soil-Core/WeakLayout.extension.st
@@ -2,16 +2,12 @@ Extension { #name : #WeakLayout }
 
 { #category : #'*Soil-Core' }
 WeakLayout >> soilBasicSerialize: anObject with: serializer [
-	| classInfo instSize |
-	classInfo := serializer classDescriptionFor: anObject class.
-	serializer 
-		nextPutObjectType;
-		basicNextPutString: classInfo name.
-	 serializer nextPutLengthEncodedInteger: anObject basicSize.
+	| instSize |
+	super soilBasicSerialize: anObject with: serializer.
 	
-	classInfo instVarIndexes do: [:i | (anObject instVarAt: i) soilSerialize: serializer ].
-		instSize := anObject class instSize.
-		"on variable sized objects size > instVars"
-		instSize + 1 to: instSize + anObject basicSize do: [:i | 
-		(anObject instVarAt: i) soilSerialize: serializer ]
+	serializer nextPutLengthEncodedInteger: anObject basicSize.
+	"on variable sized objects size > instVars"
+	instSize := anObject class instSize.
+	instSize + 1 to: instSize + anObject basicSize do: [:i | 
+	(anObject basicAt: i) soilSerialize: serializer ]
 ]

--- a/src/Soil-Core/WordLayout.extension.st
+++ b/src/Soil-Core/WordLayout.extension.st
@@ -2,12 +2,13 @@ Extension { #name : #WordLayout }
 
 { #category : #'*Soil-Core' }
 WordLayout >> soilBasicSerialize: anObject with: serializer [
-	| classInfo |
+	| classInfo instSize |
 	classInfo := serializer classDescriptionFor: anObject class.
 	serializer 
 		nextPutObjectType;
 		basicNextPutString: classInfo name.
 	
-	serializer nextPutLengthEncodedInteger: anObject basicSize.
-	1 to: anObject basicSize do: [:i | serializer nextPutLengthEncodedInteger: (anObject basicAt: i)]
+	instSize := anObject basicSize.
+	serializer nextPutLengthEncodedInteger: instSize.
+	1 to: instSize do: [:i | serializer nextPutLengthEncodedInteger: (anObject basicAt: i)]
 ]

--- a/src/Soil-Core/WordLayout.extension.st
+++ b/src/Soil-Core/WordLayout.extension.st
@@ -2,16 +2,12 @@ Extension { #name : #WordLayout }
 
 { #category : #'*Soil-Core' }
 WordLayout >> soilBasicSerialize: anObject with: serializer [
-	| classInfo instSize |
+	| classInfo |
 	classInfo := serializer classDescriptionFor: anObject class.
 	serializer 
 		nextPutObjectType;
 		basicNextPutString: classInfo name.
-	 serializer nextPutLengthEncodedInteger: anObject basicSize.
 	
-	classInfo instVarIndexes do: [:i | (anObject instVarAt: i) soilSerialize: serializer ].
-		instSize := anObject class instSize.
-		"on variable sized objects size > instVars"
-		instSize + 1 to: instSize + anObject basicSize do: [:i | 
-		(anObject instVarAt: i) soilSerialize: serializer ]
+	serializer nextPutLengthEncodedInteger: anObject basicSize.
+	1 to: anObject basicSize do: [:i | serializer nextPutLengthEncodedInteger: (anObject basicAt: i)]
 ]


### PR DESCRIPTION
- unskip testSerializationByteLayout
- add a real testSerializationVariableLayout,  rename existing to testSerializationImmediateLayout 
- Fix #newObject to work correctly for WordLayout
- fix serializing of WordLayout, and the DoubleWordLayout, DoubleByteLayout
- unskip testNoUnimplementedCalls (was just skipped for #isBits)
- make sure to add a #soilBasicSerialize:with method to every layout 
- VariableLayout: just call super for the fixed part
- VariableLayout: use #basicAt:, much easier to understand this way