### PR TITLE
35-Code-Coverage-ignore-OS-specific-classes-for-now 

### DIFF
--- a/src/Soil-Core-Tests/SoilTest.class.st
+++ b/src/Soil-Core-Tests/SoilTest.class.st
@@ -8,6 +8,12 @@ Class {
 }
 
 { #category : #accessing }
+SoilTest class >> classNamesNotUnderTest [
+	"we for now ignore flock as this is platform specific"
+	^ #(SOBSDFLock SOFLock)
+]
+
+{ #category : #accessing }
 SoilTest class >> packageNamesUnderTest [
 	^ #(#'Soil-Core')
 ]


### PR DESCRIPTION
SOBSDFLock SOFLock are platform specific. This means that depending on the platform, one of the two will never be covered.

As a workaround, I think we should disable it for now by adding SoilTest class>>#packageNamesUnderTest