### PR TITLE
Cleanup Tests: #bytecodes check Pharo10 vs Pharo11 not needed

### DIFF
--- a/src/Soil-Core-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Core-Tests/SoilSerializationTest.class.st
@@ -78,10 +78,7 @@ SoilSerializationTest >> testSerializationCompiledMethodLayout [
 	serialized := self serializeToBytes: object.
 	materialized := self materializeFromBytes: serialized.
 
-	(SystemVersion current major == 11)
-		ifTrue: [ self assert: materialized bytecodes equals: object bytecodes. ]
-		ifFalse: [ self assert: materialized bytecode equals: object bytecode. ].
-	
+	self assert: materialized bytecodes equals: object bytecodes.
 	self assert: materialized literals equals: object literals.
 	self assert: materialized equals: object.
 	self
@@ -101,9 +98,8 @@ SoilSerializationTest >> testSerializationCompiledMethodLayoutCompiledBlock [
  	materialized := self materializeFromBytes: serialized.
 
  	"for #= we need equal outercode to be the same, too"
- 	(SystemVersion current major == 11)
-		ifTrue: [ self assert: materialized bytecodes equals: object bytecodes. ]
-		ifFalse: [ self assert: materialized bytecode equals: object bytecode. ].
+ 	self assert: materialized bytecodes equals: object bytecodes.
+
  	self assert: materialized literals equals: object literals.
  	self assert: materialized class classLayout class equals: CompiledMethodLayout
 ]

--- a/src/Soil-Core/SoilSerializer.class.st
+++ b/src/Soil-Core/SoilSerializer.class.st
@@ -121,9 +121,8 @@ SoilSerializer >> nextPutCompiledBlock: aCompiledMethod [
 	1 to: aCompiledMethod numLiterals do: [ :i | 
 		(aCompiledMethod literalAt: i) soilSerialize: self ].
 	"variable part"
-	(SystemVersion current major == 11)
-	ifTrue: [self nextPutBytesFrom: aCompiledMethod bytecodes  ]
-	ifFalse: [ self nextPutBytesFrom: aCompiledMethod bytecode ]
+	self nextPutBytesFrom: aCompiledMethod bytecodes
+
 	
 ]
 
@@ -143,9 +142,7 @@ SoilSerializer >> nextPutCompiledMethod: aCompiledMethod [
 	1 to: aCompiledMethod numLiterals do: [ :i | 
 		(aCompiledMethod literalAt: i) soilSerialize: self ].
 	"variable part"
-		(SystemVersion current major == 11)
-	ifTrue: [self nextPutBytesFrom: aCompiledMethod bytecodes  ]
-	ifFalse: [ self nextPutBytesFrom: aCompiledMethod bytecode ]
+	self nextPutBytesFrom: aCompiledMethod bytecodes
 ]
 
 { #category : #writing }


### PR DESCRIPTION
I backported the #bytecodes methot to Pharo10, so we can remove the versions checks