### PR TITLE
Serialize-CleanBlocks 

### DIFF
--- a/src/Soil-Core-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Core-Tests/SoilSerializationTest.class.st
@@ -69,11 +69,13 @@ SoilSerializationTest >> testSerializationCleanBlockClosure [
 	<compilerOptions: #(+ optionCleanBlockClosure)>
 	| object serialized  materialized |
 	(SystemVersion current major == 11) ifFalse: [ self skip ].
-	object := [].
+	object := [1+2].
 	
 	serialized := self serializeToBytes: object.
 	materialized := self materializeFromBytes: serialized.
-	self assert: materialized class equals: CleanBlockClosure
+	self assert: materialized class equals: CleanBlockClosure.
+	"and we can execute it!"
+	self assert: object value equals: 3
 ]
 
 { #category : #'tests-layouts' }

--- a/src/Soil-Core-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Core-Tests/SoilSerializationTest.class.st
@@ -64,11 +64,22 @@ SoilSerializationTest >> testSerializationByteLayout [
 	self assert: materialized class classLayout class equals: ByteLayout.
 ]
 
+{ #category : #'test-blocks' }
+SoilSerializationTest >> testSerializationCleanBlockClosure [
+	<compilerOptions: #(+ optionCleanBlockClosure)>
+	| object serialized  materialized |
+	(SystemVersion current major == 11) ifFalse: [ self skip ].
+	object := [].
+	
+	serialized := self serializeToBytes: object.
+	materialized := self materializeFromBytes: serialized.
+	self assert: materialized class equals: CleanBlockClosure
+]
+
 { #category : #'tests-layouts' }
 SoilSerializationTest >> testSerializationCompiledMethodLayout [
 
 	| object serialized materialized |
-	self skip.
 	"We use CompiledMethod as an exampe of a class with a CompiledMethodLayout"
 	object := (OrderedCollection >> #do:) copy.
 
@@ -78,10 +89,7 @@ SoilSerializationTest >> testSerializationCompiledMethodLayout [
 	serialized := self serializeToBytes: object.
 	materialized := self materializeFromBytes: serialized.
 
-	(SystemVersion current major == 11)
-		ifTrue: [ self assert: materialized bytecodes equals: object bytecodes. ]
-		ifFalse: [ self assert: materialized bytecode equals: object bytecode. ].
-	
+	self assert: materialized bytecodes equals: object bytecodes.
 	self assert: materialized literals equals: object literals.
 	self assert: materialized equals: object.
 	self
@@ -218,6 +226,25 @@ SoilSerializationTest >> testSerializationSortedCollection [
 
 	materialized := self materializeFromBytes: serialized.
 	self assert: materialized equals: object
+]
+
+{ #category : #tests }
+SoilSerializationTest >> testSerializationSortedCollectionWithSortBlock [
+	"SortedCollection ixs a subclass of OrderedCollection, make sure it works"
+	<compilerOptions: #(+ optionCleanBlockClosure)>
+
+	| object serialized materialized |
+	(SystemVersion current major == 11) ifFalse: [ self skip ].
+	object := SortedCollection new sortBlock: [ :a :b | a > b ].
+	serialized := self serializeToBytes: object.
+	
+	"this is NOT serialized using TypeCodeOrderedCollection"
+	self deny: (serialized at: 1) equals: TypeCodeOrderedCollection.
+
+	materialized := self materializeFromBytes: serialized.
+	self assert: materialized class equals: object class.
+	"not yet equal as the blocks have wrong outerCode, but ok for execution"
+	self assert: materialized sortBlock compiledBlock bytecodes equals: object sortBlock compiledBlock bytecodes.	
 ]
 
 { #category : #'tests-encoded-subclasses' }

--- a/src/Soil-Core-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Core-Tests/SoilSerializationTest.class.st
@@ -109,9 +109,7 @@ SoilSerializationTest >> testSerializationCompiledMethodLayoutCompiledBlock [
  	materialized := self materializeFromBytes: serialized.
 
  	"for #= we need equal outercode to be the same, too"
- 	(SystemVersion current major == 11)
-		ifTrue: [ self assert: materialized bytecodes equals: object bytecodes. ]
-		ifFalse: [ self assert: materialized bytecode equals: object bytecode. ].
+	self assert: materialized bytecodes equals: object bytecodes.
  	self assert: materialized literals equals: object literals.
  	self assert: materialized class classLayout class equals: CompiledMethodLayout
 ]

--- a/src/Soil-Core-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Core-Tests/SoilSerializationTest.class.st
@@ -116,6 +116,20 @@ SoilSerializationTest >> testSerializationCompiledMethodLayoutCompiledBlock [
  	self assert: materialized class classLayout class equals: CompiledMethodLayout
 ]
 
+{ #category : #'test-blocks' }
+SoilSerializationTest >> testSerializationConstantBlockClosure [
+	<compilerOptions: #(+ optionConstantBlockClosure)>
+	| object serialized  materialized |
+	(SystemVersion current major == 11) ifFalse: [ self skip ].
+	object := [1].
+	
+	serialized := self serializeToBytes: object.
+	materialized := self materializeFromBytes: serialized.
+	self assert: (materialized isKindOf: ConstantBlockClosure).
+	"and we can execute it!"
+	self assert: object value equals: 1
+]
+
 { #category : #'tests-layouts' }
 SoilSerializationTest >> testSerializationDoubleByteLayout [
 	| object serialized materialized |

--- a/src/Soil-Core/BlockClosure.extension.st
+++ b/src/Soil-Core/BlockClosure.extension.st
@@ -4,9 +4,3 @@ Extension { #name : #BlockClosure }
 BlockClosure >> soilMaterialize: materializer [ 
 	^ self value: materializer
 ]
-
-{ #category : #'*Soil-Core' }
-BlockClosure >> soilSerialize: serializer [
-	"Not stored, thus no registration needed"
-	serializer notSupportedError: self
-]

--- a/src/Soil-Core/FullBlockClosure.extension.st
+++ b/src/Soil-Core/FullBlockClosure.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #FullBlockClosure }
+
+{ #category : #'*Soil-Core' }
+FullBlockClosure >> soilSerialize: serializer [
+	"Not stored, thus no registration needed"
+	serializer notSupportedError: self
+]

--- a/src/Soil-Core/SoilSerializer.class.st
+++ b/src/Soil-Core/SoilSerializer.class.st
@@ -121,10 +121,8 @@ SoilSerializer >> nextPutCompiledBlock: aCompiledMethod [
 	1 to: aCompiledMethod numLiterals do: [ :i | 
 		(aCompiledMethod literalAt: i) soilSerialize: self ].
 	"variable part"
-	(SystemVersion current major == 11)
-	ifTrue: [self nextPutBytesFrom: aCompiledMethod bytecodes  ]
-	ifFalse: [ self nextPutBytesFrom: aCompiledMethod bytecode ]
-	
+	self nextPutBytesFrom: aCompiledMethod bytecodes
+
 ]
 
 { #category : #writing }
@@ -143,9 +141,8 @@ SoilSerializer >> nextPutCompiledMethod: aCompiledMethod [
 	1 to: aCompiledMethod numLiterals do: [ :i | 
 		(aCompiledMethod literalAt: i) soilSerialize: self ].
 	"variable part"
-		(SystemVersion current major == 11)
-	ifTrue: [self nextPutBytesFrom: aCompiledMethod bytecodes  ]
-	ifFalse: [ self nextPutBytesFrom: aCompiledMethod bytecode ]
+	self nextPutBytesFrom: aCompiledMethod bytecodes
+	
 ]
 
 { #category : #writing }

--- a/src/Soil-Core/VariableLayout.extension.st
+++ b/src/Soil-Core/VariableLayout.extension.st
@@ -16,12 +16,19 @@ VariableLayout >> soilBasicMaterialize: objectClass with: serializer [
 
 { #category : #'*Soil-Core' }
 VariableLayout >> soilBasicSerialize: anObject with: serializer [
-	| basicSize |
-	super soilBasicSerialize: anObject with: serializer.
+	|  description basicSize|
 	
+	description := serializer classDescriptionFor: anObject class.
+	serializer 
+		nextPutObjectType;
+		nextPutLengthEncodedInteger: (description isMeta 
+			ifTrue: [ 0 ]
+			ifFalse: [ serializer referenceIndexOf: description]).
+
+
 	basicSize := anObject basicSize.
-	
 	serializer nextPutLengthEncodedInteger: basicSize.
-	1 to: basicSize do: [:i | 
-		(anObject basicAt: i) soilSerialize: serializer ]
+	
+	description instVarIndexes do: [:i | (anObject instVarAt: i) soilSerialize: serializer ].
+	1 to: basicSize do: [:i | (anObject basicAt: i) soilSerialize: serializer ]
 ]

--- a/src/Soil-Core/WeakLayout.extension.st
+++ b/src/Soil-Core/WeakLayout.extension.st
@@ -16,12 +16,19 @@ WeakLayout >> soilBasicMaterialize: objectClass with: serializer [
 
 { #category : #'*Soil-Core' }
 WeakLayout >> soilBasicSerialize: anObject with: serializer [
-	| instSize |
-	super soilBasicSerialize: anObject with: serializer.
+	|  description basicSize|
 	
-	serializer nextPutLengthEncodedInteger: anObject basicSize.
-	"on variable sized objects size > instVars"
-	instSize := anObject class instSize.
-	instSize + 1 to: instSize + anObject basicSize do: [:i | 
-	(anObject basicAt: i) soilSerialize: serializer ]
+	description := serializer classDescriptionFor: anObject class.
+	serializer 
+		nextPutObjectType;
+		nextPutLengthEncodedInteger: (description isMeta 
+			ifTrue: [ 0 ]
+			ifFalse: [ serializer referenceIndexOf: description]).
+
+
+	basicSize := anObject basicSize.
+	serializer nextPutLengthEncodedInteger: basicSize.
+	
+	description instVarIndexes do: [:i | (anObject instVarAt: i) soilSerialize: serializer ].
+	1 to: basicSize do: [:i | (anObject basicAt: i) soilSerialize: serializer ]
 ]


### PR DESCRIPTION
- Allow Serialization of CleanBlocks
- add a test for serializing SortedCollection using a clean block
- Fix VariableLayout Serialization
- unskip test CompiledMethod serialize which is now green
- remove not needed version checks for Pharo10 after a trivial backport 
