### PR TITLE
Some timezones are 30 or 45 minutes off the hour

### DIFF
--- a/src/Soil-Core-Tests/SoilPrimitiveSerializationTest.class.st
+++ b/src/Soil-Core-Tests/SoilPrimitiveSerializationTest.class.st
@@ -12,6 +12,14 @@ SoilPrimitiveSerializationTest >> newSerializer [
 	^ Soil inMemory newSerializer
 ]
 
+{ #category : #helpers }
+SoilPrimitiveSerializationTest >> restoreLocalTimeZoneAfter: aBlock [
+
+	| realTimeZone |
+	realTimeZone := DateAndTime localTimeZone.
+	aBlock ensure: [ DateAndTime localTimeZone: realTimeZone ].
+]
+
 { #category : #running }
 SoilPrimitiveSerializationTest >> setUp [
 	super setUp.
@@ -200,9 +208,9 @@ SoilPrimitiveSerializationTest >> testSerializationClass [
 { #category : #tests }
 SoilPrimitiveSerializationTest >> testSerializationDate [
 	| object serialized materialized |
-	object := Date newDay: 31 month: 10 year: 2022.
+	object := Date fromDays: 10.
 	serialized := SoilSerializer serializeToBytes: object.
-	self assert: serialized equals: #[14 236 145 150 1 208 140 1 176 150 4].
+	self assert: serialized equals: #[14 10 3 0].
 	self assert: (serialized at: 1) equals: TypeCodeDate.
 
 	materialized := SoilMaterializer materializeFromBytes: serialized.
@@ -210,31 +218,33 @@ SoilPrimitiveSerializationTest >> testSerializationDate [
 ]
 
 { #category : #tests }
-SoilPrimitiveSerializationTest >> testSerializationDateOffsetNegative [
-	| datetime object serialized materialized |
-	datetime := DateAndTime fromString: '2022-10-31T00:00:00-05:00'.
-	self assert: datetime offset asSeconds < 0.
-	object := Date starting: datetime.
-	serialized := SoilSerializer serializeToBytes: object.
-	self assert: serialized equals: #[14 236 145 150 1 208 140 1 176 150 4].
-	self assert: (serialized at: 1) equals: TypeCodeDate.
+SoilPrimitiveSerializationTest >> testSerializationDateWithLocalTimeZone [
+	| utc est bst object utc14plus utc545plus utc12minus utc330minus serialized materialized |
+	utc := TimeZone abbreviated: 'UTC'.
+	est := TimeZone abbreviated: 'EST'.
+	bst := TimeZone abbreviated: 'BST'.
+	utc12minus := TimeZone offset: -12 hours name: 'Baker Island Time' abbreviation: 'BIT'.
+	utc14plus := TimeZone offset: 14 hours name: 'Line Islands Time' abbreviation: 'LINT'.
+	utc330minus := TimeZone offset: (3 * 60 + 30) minutes negated name: 'Newfoundland Time' abbreviation: 'NT'.
+	utc545plus := TimeZone offset: (5 * 60 + 45) minutes name: 'Nepal Time' abbreviation: 'NPT'.
+	{
+		{ utc. utc }.
+		{ utc. est }. { est. utc }.
+		{ utc. bst }. { bst. utc }.
+		{ est. bst }. { bst. est }.
+		{ utc12minus. utc14plus }. { utc14plus. utc12minus }.
+		{ utc. utc330minus }. { utc330minus. utc }.
+		{ utc. utc545plus }. { utc545plus. utc }.
+	} do: [ :eachPair |
+		self useTimeZoneInstance: eachPair first during: [
+			object := Date year: 2022 month: 10 day: 31.
+			serialized := SoilSerializer serializeToBytes: object.
+			"self assert: serialized equals: eachCase value."
+			self assert: (serialized at: 1) equals: TypeCodeDate ].
 
-	materialized := SoilMaterializer materializeFromBytes: serialized.
-	self assert: materialized equals: object
-]
-
-{ #category : #tests }
-SoilPrimitiveSerializationTest >> testSerializationDateOffsetPositive [
-	| datetime object serialized materialized |
-	datetime := DateAndTime fromString: '2022-10-31T00:00:00+02:00'.
-	self assert: datetime offset asSeconds > 0.
-	object := Date starting: datetime.
-	serialized := SoilSerializer serializeToBytes: object.
-	self assert: serialized equals: #[14 235 145 150 1 224 234 4 160 219 5].
-	self assert: (serialized at: 1) equals: TypeCodeDate.
-
-	materialized := SoilMaterializer materializeFromBytes: serialized.
-	self assert: materialized equals: object
+		self useTimeZoneInstance: eachPair second during: [
+			materialized := SoilMaterializer materializeFromBytes: serialized.
+			self assert: materialized equals: object ] ]
 ]
 
 { #category : #tests }
@@ -837,4 +847,12 @@ SoilPrimitiveSerializationTest >> testSerializationWideSymbol [
 	
 	materialized := SoilMaterializer materializeFromBytes: serialized.
 	self assert: materialized equals: symbol
+]
+
+{ #category : #helpers }
+SoilPrimitiveSerializationTest >> useTimeZoneInstance: aTimeZone during: aBlock [
+
+  self restoreLocalTimeZoneAfter: [ 
+    DateAndTime localTimeZone: aTimeZone. 
+    aBlock cull: aTimeZone ].
 ]

--- a/src/Soil-Core-Tests/SoilPrimitiveSerializationTest.class.st
+++ b/src/Soil-Core-Tests/SoilPrimitiveSerializationTest.class.st
@@ -252,7 +252,7 @@ SoilPrimitiveSerializationTest >> testSerializationDateWithNegativeOffset [
 	| object serialized materialized |
 	object := (Date fromDays: 10) offset: -5 hours.
 	serialized := SoilSerializer serializeToBytes: object.
-	self assert: serialized equals: #[14 9 4 5].
+	self assert: serialized equals: #[14 9 4 172 2].
 	self assert: (serialized at: 1) equals: TypeCodeDate.
 
 	materialized := SoilMaterializer materializeFromBytes: serialized.

--- a/src/Soil-Core-Tests/SoilPrimitiveSerializationTest.class.st
+++ b/src/Soil-Core-Tests/SoilPrimitiveSerializationTest.class.st
@@ -200,9 +200,37 @@ SoilPrimitiveSerializationTest >> testSerializationClass [
 { #category : #tests }
 SoilPrimitiveSerializationTest >> testSerializationDate [
 	| object serialized materialized |
-	object := Date fromDays: 10.
+	object := Date newDay: 31 month: 10 year: 2022.
 	serialized := SoilSerializer serializeToBytes: object.
-	self assert: serialized equals: #[14 10 0].
+	self assert: serialized equals: #[14 236 145 150 1 208 140 1 176 150 4].
+	self assert: (serialized at: 1) equals: TypeCodeDate.
+
+	materialized := SoilMaterializer materializeFromBytes: serialized.
+	self assert: materialized equals: object
+]
+
+{ #category : #tests }
+SoilPrimitiveSerializationTest >> testSerializationDateOffsetNegative [
+	| datetime object serialized materialized |
+	datetime := DateAndTime fromString: '2022-10-31T00:00:00-05:00'.
+	self assert: datetime offset asSeconds < 0.
+	object := Date starting: datetime.
+	serialized := SoilSerializer serializeToBytes: object.
+	self assert: serialized equals: #[14 236 145 150 1 208 140 1 176 150 4].
+	self assert: (serialized at: 1) equals: TypeCodeDate.
+
+	materialized := SoilMaterializer materializeFromBytes: serialized.
+	self assert: materialized equals: object
+]
+
+{ #category : #tests }
+SoilPrimitiveSerializationTest >> testSerializationDateOffsetPositive [
+	| datetime object serialized materialized |
+	datetime := DateAndTime fromString: '2022-10-31T00:00:00+02:00'.
+	self assert: datetime offset asSeconds > 0.
+	object := Date starting: datetime.
+	serialized := SoilSerializer serializeToBytes: object.
+	self assert: serialized equals: #[14 235 145 150 1 224 234 4 160 219 5].
 	self assert: (serialized at: 1) equals: TypeCodeDate.
 
 	materialized := SoilMaterializer materializeFromBytes: serialized.

--- a/src/Soil-Core/SoilMaterializer.class.st
+++ b/src/Soil-Core/SoilMaterializer.class.st
@@ -167,22 +167,11 @@ SoilMaterializer >> nextCompiledMethod: aClass [
 ]
 
 { #category : #reading }
-SoilMaterializer >> nextDate: aClass [
-	| startJdn startSeconds startNano offsetSeconds offsetNanos dateStart date |
-
-	startJdn := self nextLengthEncodedInteger.
-	startSeconds := self nextLengthEncodedInteger.
-	"startNano := self nextLengthEncodedInteger".
-	offsetSeconds := self nextLengthEncodedInteger.
-	"offsetNanos := self nextLengthEncodedInteger".
-	dateStart := DateAndTime basicNew
-		setJdn: startJdn
-		seconds: startSeconds
-		nano: "startNano" 0
-		offset: (Duration seconds: offsetSeconds - 86400 nanoSeconds: "offsetNanos" 0);
-		yourself.
-
-	date := aClass starting: dateStart.
+SoilMaterializer >> nextDate: aClass [ 
+	| date |
+	date := aClass 
+		julianDayNumber: 2415386 + self nextLengthEncodedInteger 
+		offset: (Duration minutes: self nextSoilObject).
 	self registerObject: date.
 	^ date
 ]

--- a/src/Soil-Core/SoilMaterializer.class.st
+++ b/src/Soil-Core/SoilMaterializer.class.st
@@ -167,11 +167,22 @@ SoilMaterializer >> nextCompiledMethod: aClass [
 ]
 
 { #category : #reading }
-SoilMaterializer >> nextDate: aClass [ 
-	| date |
-	date := aClass 
-		julianDayNumber: 2415386 + self nextLengthEncodedInteger 
-		offset: (Duration hours: self nextLengthEncodedInteger).
+SoilMaterializer >> nextDate: aClass [
+	| startJdn startSeconds startNano offsetSeconds offsetNanos dateStart date |
+
+	startJdn := self nextLengthEncodedInteger.
+	startSeconds := self nextLengthEncodedInteger.
+	"startNano := self nextLengthEncodedInteger".
+	offsetSeconds := self nextLengthEncodedInteger.
+	"offsetNanos := self nextLengthEncodedInteger".
+	dateStart := DateAndTime basicNew
+		setJdn: startJdn
+		seconds: startSeconds
+		nano: "startNano" 0
+		offset: (Duration seconds: offsetSeconds - 86400 nanoSeconds: "offsetNanos" 0);
+		yourself.
+
+	date := aClass starting: dateStart.
 	self registerObject: date.
 	^ date
 ]

--- a/src/Soil-Core/SoilSerializer.class.st
+++ b/src/Soil-Core/SoilSerializer.class.st
@@ -149,11 +149,34 @@ SoilSerializer >> nextPutCompiledMethod: aCompiledMethod [
 ]
 
 { #category : #writing }
-SoilSerializer >> nextPutDate: aDate [ 
-	self 
-		nextPutByte: TypeCodeDate; 
-		nextPutLengthEncodedInteger: aDate julianDayNumber - 2415386; 
-		nextPutLengthEncodedInteger: aDate offset hours
+SoilSerializer >> nextPutDate: aDate [
+	"Save a Date representation.
+	In Pharo a Date is actually a TimeSpan of 24 hours from a starting DateAndTime.
+	The start of the Date is a DateAndTime, which will be stored as four integers:
+		julianDayNumber
+		seconds
+		nanos
+		offset 
+	The offset is a Duration, so store the seconds and nanos.
+	The offset can be negative, so normalize it to positive by adding 1 day asSeconds = 86400.
+	The TimeSpan duration of a day is always 24 hours, so no need to store it."
+
+	| dateStart |
+
+	dateStart := aDate start.
+
+	"self
+		nextPutByte: TypeCodeDate;
+		nextPutLengthEncodedInteger: dateStart julianDayNumberUTC;
+		nextPutLengthEncodedInteger: dateStart secondsSinceMidnightUTC;
+		nextPutLengthEncodedInteger: dateStart nanoSecond;
+		nextPutLengthEncodedInteger: dateStart offset asSeconds + 86400;
+		nextPutLengthEncodedInteger: dateStart offset nanoSeconds"
+	self
+		nextPutByte: TypeCodeDate;
+		nextPutLengthEncodedInteger: dateStart julianDayNumberUTC;
+		nextPutLengthEncodedInteger: dateStart secondsSinceMidnightUTC;
+		nextPutLengthEncodedInteger: dateStart offset asSeconds + 86400
 ]
 
 { #category : #writing }

--- a/src/Soil-Core/SoilSerializer.class.st
+++ b/src/Soil-Core/SoilSerializer.class.st
@@ -146,34 +146,11 @@ SoilSerializer >> nextPutCompiledMethod: aCompiledMethod [
 ]
 
 { #category : #writing }
-SoilSerializer >> nextPutDate: aDate [
-	"Save a Date representation.
-	In Pharo a Date is actually a TimeSpan of 24 hours from a starting DateAndTime.
-	The start of the Date is a DateAndTime, which will be stored as four integers:
-		julianDayNumber
-		seconds
-		nanos
-		offset 
-	The offset is a Duration, so store the seconds and nanos.
-	The offset can be negative, so normalize it to positive by adding 1 day asSeconds = 86400.
-	The TimeSpan duration of a day is always 24 hours, so no need to store it."
-
-	| dateStart |
-
-	dateStart := aDate start.
-
-	"self
-		nextPutByte: TypeCodeDate;
-		nextPutLengthEncodedInteger: dateStart julianDayNumberUTC;
-		nextPutLengthEncodedInteger: dateStart secondsSinceMidnightUTC;
-		nextPutLengthEncodedInteger: dateStart nanoSecond;
-		nextPutLengthEncodedInteger: dateStart offset asSeconds + 86400;
-		nextPutLengthEncodedInteger: dateStart offset nanoSeconds"
-	self
-		nextPutByte: TypeCodeDate;
-		nextPutLengthEncodedInteger: dateStart julianDayNumberUTC;
-		nextPutLengthEncodedInteger: dateStart secondsSinceMidnightUTC;
-		nextPutLengthEncodedInteger: dateStart offset asSeconds + 86400
+SoilSerializer >> nextPutDate: aDate [ 
+	self 
+		nextPutByte: TypeCodeDate; 
+		nextPutLengthEncodedInteger: aDate julianDayNumber - 2415386; 
+		nextPutInteger: ((aDate offset hours * 60) + aDate offset minutes)
 ]
 
 { #category : #writing }


### PR DESCRIPTION
Change the Date serialize/materialize to save offset in minutes, instead of hours. Add a test case for offset that is not a whole hour. Also test that a Date serialized in one timezone, can be materialized in a different local timezone, and is still equal.