### PR TITLE
52-Clean-Code-unused-ivars-in-SOObjectSegment--SOObjectFile

### DIFF
--- a/src/Soil-Core-Tests/SOCleanCodeTest.class.st
+++ b/src/Soil-Core-Tests/SOCleanCodeTest.class.st
@@ -162,7 +162,7 @@ SOCleanCodeTest >> testNoUnusedInstanceVariablesLeft [
 	
 	classes := variables collect: [ :each | each definingClass ] as: Set.
 	
-	validExceptions := { SOObjectSegment . SOObjectFile}.	
+	validExceptions := {}.	
 	
 	remaining := classes asOrderedCollection removeAll: validExceptions; yourself.
 	self assert: remaining isEmpty description: ('the following classes have unused instance variables and should be cleaned: ', remaining asString)

--- a/src/Soil-Core/SOObjectFile.class.st
+++ b/src/Soil-Core/SOObjectFile.class.st
@@ -2,7 +2,6 @@ Class {
 	#name : #SOObjectFile,
 	#superclass : #SOSegmentFile,
 	#instVars : [
-		'id',
 		'fuelVersion'
 	],
 	#category : #'Soil-Core-Files'

--- a/src/Soil-Core/SOObjectSegment.class.st
+++ b/src/Soil-Core/SOObjectSegment.class.st
@@ -5,8 +5,6 @@ Class {
 		'id',
 		'soil',
 		'objectRepository',
-		'index',
-		'objects',
 		'indexFile',
 		'objectFile'
 	],
@@ -109,7 +107,7 @@ SOObjectSegment >> newObjectId [
 	^ SOObjectId segment: id index: 0 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SOObjectSegment >> objectFile [
 	^ objectFile ifNil: [ 
 		objectFile := SOObjectFile new


### PR DESCRIPTION
- remvove exceptions from  testNoUnusedInstanceVariablesLeft 
- remove the unused ivars

fixes #52