### PR TITLE
Add testSerializationObjectWithTransient to have a test case for the …

### DIFF
--- a/src/Soil-Core-Tests/SOTestClassWithTransient.class.st
+++ b/src/Soil-Core-Tests/SOTestClassWithTransient.class.st
@@ -1,0 +1,39 @@
+Class {
+	#name : #SOTestClassWithTransient,
+	#superclass : #Object,
+	#instVars : [
+		'one',
+		'two'
+	],
+	#category : #'Soil-Core-Tests'
+}
+
+{ #category : #accessing }
+SOTestClassWithTransient class >> soilTransientInstVars [
+
+	^ #(two)
+]
+
+{ #category : #accessing }
+SOTestClassWithTransient >> one [
+
+	^ one
+]
+
+{ #category : #accessing }
+SOTestClassWithTransient >> one: anObject [
+
+	one := anObject
+]
+
+{ #category : #accessing }
+SOTestClassWithTransient >> two [
+
+	^ two
+]
+
+{ #category : #accessing }
+SOTestClassWithTransient >> two: anObject [
+
+	two := anObject
+]

--- a/src/Soil-Core-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Core-Tests/SoilSerializationTest.class.st
@@ -210,6 +210,17 @@ SoilSerializationTest >> testSerializationObjectTwice [
 	self assert: materialized first identicalTo: materialized second.
 ]
 
+{ #category : #tests }
+SoilSerializationTest >> testSerializationObjectWithTransient [
+	| object serialized materialized |
+	object := SOTestClassWithTransient new.
+	object one: 1; two: 2.
+	serialized := self serializeToBytes: object.
+	materialized := self materializeFromBytes: serialized.
+	self assert: materialized one equals: 1.
+	self assert: materialized two isNil
+]
+
 { #category : #'tests-hashed' }
 SoilSerializationTest >> testSerializationSet [
 	"Set uses the hash to find elements, this might be identity, which changes"


### PR DESCRIPTION
…#soilTransientInstVars feature, and to make it easier to discover