### PR TITLE
Refactoring: Move code of ivar migration to Layout

### DIFF
--- a/src/Soil-Core-Tests/SoilMigrationTest.class.st
+++ b/src/Soil-Core-Tests/SoilMigrationTest.class.st
@@ -15,6 +15,14 @@ SoilMigrationTest >> createMigrationClass [
 		package: self class package name) install
 ]
 
+{ #category : #'as yet unclassified' }
+SoilMigrationTest >> createMigrationClassVariableLayout [
+	^ (SOBaseTestObject << #SOMigrationObject
+		layout: VariableLayout;
+		slots: { #one . #two }; 
+		package: self class package name) install
+]
+
 { #category : #accessing }
 SoilMigrationTest >> path [ 
 	^ 'soil-tests'
@@ -34,6 +42,27 @@ SoilMigrationTest >> setUp [
 SoilMigrationTest >> tearDown [ 
 	super tearDown.
 	migrationClass removeFromSystem 
+]
+
+{ #category : #tests }
+SoilMigrationTest >> testMaterializingObjectVariableLayputWithChangedShape [
+	| tx tx2 materializedRoot object |
+	object := self createMigrationClassVariableLayout new.
+	self assert: object class isVariable.
+	object 
+		instVarNamed: #one put: 1;
+		instVarNamed: #two put: 2.
+	tx := soil newTransaction.
+	tx root: object. 
+	tx commit.
+	migrationClass 
+		removeSlot: (migrationClass slotNamed: #two);
+		addSlot: #three asSlot.
+
+	tx2 := soil newTransaction.
+	materializedRoot := tx2 root.
+	self assert: (materializedRoot instVarNamed: #one) equals: 1.
+	self assert: (materializedRoot instVarNamed: #three) equals: nil.	
 ]
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilMigrationTest.class.st
+++ b/src/Soil-Core-Tests/SoilMigrationTest.class.st
@@ -29,7 +29,7 @@ SoilMigrationTest >> path [
 	^ 'soil-tests'
 ]
 
-{ #category : #initialization }
+{ #category : #running }
 SoilMigrationTest >> setUp [ 
 	super setUp.
 	soil := Soil path: self path.
@@ -41,8 +41,8 @@ SoilMigrationTest >> setUp [
 
 { #category : #running }
 SoilMigrationTest >> tearDown [ 
-	super tearDown.
-	migrationClass removeFromSystem 
+	migrationClass removeFromSystem.
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilMigrationTest.class.st
+++ b/src/Soil-Core-Tests/SoilMigrationTest.class.st
@@ -8,14 +8,15 @@ Class {
 	#category : #'Soil-Core-Tests'
 }
 
-{ #category : #'as yet unclassified' }
-SoilMigrationTest >> createMigrationClass [
-	^ (SOBaseTestObject << #SOMigrationObject 
+{ #category : #helpers }
+SoilMigrationTest >> createMigrationClassFixedLayout [
+	^ (SOBaseTestObject << #SOMigrationObject
+		layout: FixedLayout;
 		slots: { #one . #two }; 
 		package: self class package name) install
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #helpers }
 SoilMigrationTest >> createMigrationClassVariableLayout [
 	^ (SOBaseTestObject << #SOMigrationObject
 		layout: VariableLayout;
@@ -35,7 +36,7 @@ SoilMigrationTest >> setUp [
 	soil 
 		destroy;
 		initializeFilesystem.
-	migrationClass := self createMigrationClass
+	migrationClass := self createMigrationClassFixedLayout
 ]
 
 { #category : #running }

--- a/src/Soil-Core/AbstractLayout.extension.st
+++ b/src/Soil-Core/AbstractLayout.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : #AbstractLayout }
 
 { #category : #'*Soil-Core' }
-AbstractLayout >> soilBasicMaterialize: objectClass with: serializer [
+AbstractLayout >> soilBasicMaterialize: objectClass with: materializer [
 	self subclassResponsibility
 ]
 

--- a/src/Soil-Core/ByteLayout.extension.st
+++ b/src/Soil-Core/ByteLayout.extension.st
@@ -1,12 +1,12 @@
 Extension { #name : #ByteLayout }
 
 { #category : #'*Soil-Core' }
-ByteLayout >> soilBasicMaterialize: objectClass with: serializer [
+ByteLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object basicSize |
-	 object := objectClass basicNew: (basicSize := serializer nextLengthEncodedInteger).
-	serializer registerObject: object.
+	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
+	materializer registerObject: object.
 	
-	serializer stream readInto: object startingAt: 1 count: basicSize.
+	materializer stream readInto: object startingAt: 1 count: basicSize.
 	^object
 
 ]

--- a/src/Soil-Core/CompiledMethodLayout.extension.st
+++ b/src/Soil-Core/CompiledMethodLayout.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : #CompiledMethodLayout }
 
 { #category : #'*Soil-Core' }
-CompiledMethodLayout >> soilBasicMaterialize: objectClass with: serializer [
+CompiledMethodLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	<ignoreForCoverage>
 	"CompiledMethod Objects are all serialized with their own TypeCode"
 	self error: 'this should never be called'

--- a/src/Soil-Core/DoubleByteLayout.extension.st
+++ b/src/Soil-Core/DoubleByteLayout.extension.st
@@ -1,12 +1,12 @@
 Extension { #name : #DoubleByteLayout }
 
 { #category : #'*Soil-Core' }
-DoubleByteLayout >> soilBasicMaterialize: objectClass with: serializer [
+DoubleByteLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object basicSize |
-	 object := objectClass basicNew: (basicSize := serializer nextLengthEncodedInteger).
-	serializer registerObject: object.
+	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
+	materializer registerObject: object.
 	
-	serializer stream readInto: object startingAt: 1 count: basicSize.
+	materializer stream readInto: object startingAt: 1 count: basicSize.
 	^object
 
 ]

--- a/src/Soil-Core/DoubleWordLayout.extension.st
+++ b/src/Soil-Core/DoubleWordLayout.extension.st
@@ -1,12 +1,12 @@
 Extension { #name : #DoubleWordLayout }
 
 { #category : #'*Soil-Core' }
-DoubleWordLayout >> soilBasicMaterialize: objectClass with: serializer [
+DoubleWordLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object basicSize |
-	object := objectClass basicNew: (basicSize := serializer nextLengthEncodedInteger).
-	serializer registerObject: object.
+	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
+	materializer registerObject: object.
 	
-	1 to: basicSize do: [:i | object basicAt: i put: serializer nextLengthEncodedInteger].
+	1 to: basicSize do: [:i | object basicAt: i put: materializer nextLengthEncodedInteger].
 	^object
 ]
 

--- a/src/Soil-Core/EmptyLayout.extension.st
+++ b/src/Soil-Core/EmptyLayout.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : #EmptyLayout }
 
 { #category : #'*Soil-Core' }
-EmptyLayout >> soilBasicMaterialize: objectClass with: serializer [
+EmptyLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	<ignoreForCoverage>
 	self error: 'this should never be called'
 ]

--- a/src/Soil-Core/EphemeronLayout.extension.st
+++ b/src/Soil-Core/EphemeronLayout.extension.st
@@ -2,14 +2,13 @@ Extension { #name : #EphemeronLayout }
 
 { #category : #'*Soil-Core' }
 EphemeronLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
-	| object basicSize instSize|
+	| object basicSize |
 
 	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
 	
 	materializer registerObject: object.
-	instSize := object class soilPersistentInstVars size.
-	1 to: instSize do: [:i | object instVarAt: i put: (materializer nextSoilObject) ].
+	
+	self updateIvars: aBehaviorDescription with: materializer for: object.
 	1 to: basicSize do: [:i | object basicAt: i put: materializer nextSoilObject ].
-	object soilMaterialized: materializer.
-	^ object
+	^object soilMaterialized: materializer
 ]

--- a/src/Soil-Core/EphemeronLayout.extension.st
+++ b/src/Soil-Core/EphemeronLayout.extension.st
@@ -1,15 +1,15 @@
 Extension { #name : #EphemeronLayout }
 
 { #category : #'*Soil-Core' }
-EphemeronLayout >> soilBasicMaterialize: objectClass with: serializer [
+EphemeronLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object basicSize instSize|
 
-	object := objectClass basicNew: (basicSize := serializer nextLengthEncodedInteger).
+	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
 	
-	serializer registerObject: object.
+	materializer registerObject: object.
 	instSize := object class soilPersistentInstVars size.
-	1 to: instSize do: [:i | object instVarAt: i put: (serializer nextSoilObject) ].
-	1 to: basicSize do: [:i | object basicAt: i put: serializer nextSoilObject ].
-	object soilMaterialized: serializer.
+	1 to: instSize do: [:i | object instVarAt: i put: (materializer nextSoilObject) ].
+	1 to: basicSize do: [:i | object basicAt: i put: materializer nextSoilObject ].
+	object soilMaterialized: materializer.
 	^ object
 ]

--- a/src/Soil-Core/FixedLayout.extension.st
+++ b/src/Soil-Core/FixedLayout.extension.st
@@ -1,13 +1,25 @@
 Extension { #name : #FixedLayout }
 
 { #category : #'*Soil-Core' }
-FixedLayout >> soilBasicMaterialize: objectClass with: serializer [
+FixedLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object instSize|
-	object := objectClass basicNew.
-	serializer registerObject: object.
+	object := aBehaviorDescription objectClass basicNew.
+	materializer registerObject: object.
 
-	instSize := object class soilPersistentInstVars size.
-	1 to: instSize do: [:i | object instVarAt: i put: (serializer nextSoilObject) ].
-	object soilMaterialized: serializer.
+
+	aBehaviorDescription isCurrent
+		ifTrue: [ 
+				instSize := object class soilPersistentInstVars size.
+				1 to: instSize do: [:i | object instVarAt: i put: (materializer nextSoilObject) ]]
+		ifFalse: [
+			| versions |
+			versions := materializer behaviorVersionsUpTo: aBehaviorDescription.
+			versions last instVarNames do: [ :instVar | | value |
+				value := materializer nextSoilObject.
+				(versions allSatisfy: [ :version | version instVarNames includes: instVar ]) ifTrue: [ 
+					 object instVarNamed: instVar put: value ] ]
+			].
+	
+	object soilMaterialized: materializer.
 	^ object
 ]

--- a/src/Soil-Core/FixedLayout.extension.st
+++ b/src/Soil-Core/FixedLayout.extension.st
@@ -2,24 +2,10 @@ Extension { #name : #FixedLayout }
 
 { #category : #'*Soil-Core' }
 FixedLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
-	| object instSize|
+	| object |
 	object := aBehaviorDescription objectClass basicNew.
 	materializer registerObject: object.
-
-
-	aBehaviorDescription isCurrent
-		ifTrue: [ 
-				instSize := object class soilPersistentInstVars size.
-				1 to: instSize do: [:i | object instVarAt: i put: (materializer nextSoilObject) ]]
-		ifFalse: [
-			| versions |
-			versions := materializer behaviorVersionsUpTo: aBehaviorDescription.
-			versions last instVarNames do: [ :instVar | | value |
-				value := materializer nextSoilObject.
-				(versions allSatisfy: [ :version | version instVarNames includes: instVar ]) ifTrue: [ 
-					 object instVarNamed: instVar put: value ] ]
-			].
 	
-	object soilMaterialized: materializer.
-	^ object
+	self updateIvars: aBehaviorDescription with: materializer for: object.
+	^ object soilMaterialized: materializer
 ]

--- a/src/Soil-Core/ImmediateLayout.extension.st
+++ b/src/Soil-Core/ImmediateLayout.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : #ImmediateLayout }
 
 { #category : #'*Soil-Core' }
-ImmediateLayout >> soilBasicMaterialize: objectClass with: serializer [
+ImmediateLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	<ignoreForCoverage>
 	"Immediate Objects are all serialized with their own TypeCode"
 	self error: 'this should never be called'

--- a/src/Soil-Core/PointerLayout.extension.st
+++ b/src/Soil-Core/PointerLayout.extension.st
@@ -12,3 +12,21 @@ PointerLayout >> soilBasicSerialize: anObject with: serializer [
 	
 	description instVarIndexes do: [:i | (anObject instVarAt: i) soilSerialize: serializer ].
 ]
+
+{ #category : #'*Soil-Core' }
+PointerLayout >> updateIvars: aBehaviorDescription with: materializer for: object [
+	| instSize |
+	instSize := object class soilPersistentInstVars size.
+	aBehaviorDescription isCurrent
+		ifTrue: [ 
+				instSize := object class soilPersistentInstVars size.
+				1 to: instSize do: [:i | object instVarAt: i put: (materializer nextSoilObject) ]]
+		ifFalse: [
+			| versions |
+			versions := materializer behaviorVersionsUpTo: aBehaviorDescription.
+			versions last instVarNames do: [ :instVar | | value |
+				value := materializer nextSoilObject.
+				(versions allSatisfy: [ :version | version instVarNames includes: instVar ]) ifTrue: [ 
+					 object instVarNamed: instVar put: value ] ]
+			].
+]

--- a/src/Soil-Core/PointerLayout.extension.st
+++ b/src/Soil-Core/PointerLayout.extension.st
@@ -15,18 +15,15 @@ PointerLayout >> soilBasicSerialize: anObject with: serializer [
 
 { #category : #'*Soil-Core' }
 PointerLayout >> updateIvars: aBehaviorDescription with: materializer for: object [
-	| instSize |
-	instSize := object class soilPersistentInstVars size.
+	
 	aBehaviorDescription isCurrent
-		ifTrue: [ 
-				instSize := object class soilPersistentInstVars size.
-				1 to: instSize do: [:i | object instVarAt: i put: (materializer nextSoilObject) ]]
+		ifTrue: [
+				1 to: object class soilPersistentInstVars size do: [:i | object instVarAt: i put: (materializer nextSoilObject) ]]
 		ifFalse: [
 			| versions |
 			versions := materializer behaviorVersionsUpTo: aBehaviorDescription.
-			versions last instVarNames do: [ :instVar | | value |
-				value := materializer nextSoilObject.
+			versions last instVarNames do: [ :instVar | 
 				(versions allSatisfy: [ :version | version instVarNames includes: instVar ]) ifTrue: [ 
-					 object instVarNamed: instVar put: value ] ]
+					 object instVarNamed: instVar put: materializer nextSoilObject ] ]
 			].
 ]

--- a/src/Soil-Core/SOBehaviorDescription.class.st
+++ b/src/Soil-Core/SOBehaviorDescription.class.st
@@ -48,7 +48,7 @@ SOBehaviorDescription >> initializeFromBehavior: aClass [
 SOBehaviorDescription >> instVarIndexes [
 	| class |
 	class := Smalltalk at: behaviorIdentifier asSymbol. 
-	^ (class allInstVarNames difference: class soilTransientInstVars) 
+	^ class soilPersistentInstVars
 		collect: [ :n | class allInstVarNames indexOf: n ]
 ]
 

--- a/src/Soil-Core/SoilMaterializer.class.st
+++ b/src/Soil-Core/SoilMaterializer.class.st
@@ -24,12 +24,17 @@ SoilMaterializer >> basicNextString [
 	^ buf asString
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #public }
+SoilMaterializer >> behaviorVersionsUpTo: aDescription [ 
+	^ transaction behaviorVersionsUpTo: aDescription 
+]
+
+{ #category : #public }
 SoilMaterializer >> materialize [
 	^ self nextSoilObject
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #public }
 SoilMaterializer >> materializeFromBytes: aByteArray [
 	^ (self stream: aByteArray readStream)
 		materialize
@@ -37,7 +42,7 @@ SoilMaterializer >> materializeFromBytes: aByteArray [
 
 { #category : #'instance creation' }
 SoilMaterializer >> newObject [
-	| objectClass description objectIndex versions obj |
+	| description objectIndex|
 	objectIndex := self nextLengthEncodedInteger.
 	description := objectIndex isZero
 		ifTrue: [ SOBehaviorDescription meta ]
@@ -45,20 +50,7 @@ SoilMaterializer >> newObject [
 			transaction 
 				behaviorDescriptionWithId: (externalObjectRegistry basicReferenceAt: objectIndex) 
 				ifNone: [ self halt  ] ].
-		objectClass := description objectClass.
-	^ description isCurrent 
-		ifTrue: [ 
-			objectClass classLayout soilBasicMaterialize: objectClass with: self ]
-		ifFalse: [ 
-			versions := transaction behaviorVersionsUpTo: description.
-			obj := objectClass basicNew.
-			self registerObject: obj.
-			versions last instVarNames do: [ :instVar | | value |
-				value := self nextSoilObject.
-				(versions allSatisfy: [ :version | version instVarNames includes: instVar ]) ifTrue: [ 
-					 obj instVarNamed: instVar put: value ] ].
-			obj ]
-	 
+	^ description objectClass classLayout soilBasicMaterialize: description with: self
 ]
 
 { #category : #reading }

--- a/src/Soil-Core/SoilSerializer.class.st
+++ b/src/Soil-Core/SoilSerializer.class.st
@@ -344,7 +344,7 @@ SoilSerializer >> notSupportedError: anObject [
 	Error signal: 'serialization of class ', anObject class name asString , ' is not supported'
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #public }
 SoilSerializer >> referenceIndexOf: aSOClassDescription [ 
 	^ externalObjectRegistry indexOfExternalReference: aSOClassDescription 
 ]

--- a/src/Soil-Core/VariableLayout.extension.st
+++ b/src/Soil-Core/VariableLayout.extension.st
@@ -2,16 +2,15 @@ Extension { #name : #VariableLayout }
 
 { #category : #'*Soil-Core' }
 VariableLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
-	| object basicSize instSize|
+	| object basicSize |
 
 	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
 	
 	materializer registerObject: object.
-	instSize := object class soilPersistentInstVars size.
-	1 to: instSize do: [:i | object instVarAt: i put: (materializer nextSoilObject) ].
+	
+	self updateIvars: aBehaviorDescription with: materializer for: object.
 	1 to: basicSize do: [:i | object basicAt: i put: materializer nextSoilObject ].
-	object soilMaterialized: materializer.
-	^ object
+	^object soilMaterialized: materializer
 ]
 
 { #category : #'*Soil-Core' }

--- a/src/Soil-Core/VariableLayout.extension.st
+++ b/src/Soil-Core/VariableLayout.extension.st
@@ -1,16 +1,16 @@
 Extension { #name : #VariableLayout }
 
 { #category : #'*Soil-Core' }
-VariableLayout >> soilBasicMaterialize: objectClass with: serializer [
+VariableLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object basicSize instSize|
 
-	object := objectClass basicNew: (basicSize := serializer nextLengthEncodedInteger).
+	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
 	
-	serializer registerObject: object.
+	materializer registerObject: object.
 	instSize := object class soilPersistentInstVars size.
-	1 to: instSize do: [:i | object instVarAt: i put: (serializer nextSoilObject) ].
-	1 to: basicSize do: [:i | object basicAt: i put: serializer nextSoilObject ].
-	object soilMaterialized: serializer.
+	1 to: instSize do: [:i | object instVarAt: i put: (materializer nextSoilObject) ].
+	1 to: basicSize do: [:i | object basicAt: i put: materializer nextSoilObject ].
+	object soilMaterialized: materializer.
 	^ object
 ]
 

--- a/src/Soil-Core/WeakLayout.extension.st
+++ b/src/Soil-Core/WeakLayout.extension.st
@@ -1,16 +1,16 @@
 Extension { #name : #WeakLayout }
 
 { #category : #'*Soil-Core' }
-WeakLayout >> soilBasicMaterialize: objectClass with: serializer [
+WeakLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object basicSize instSize|
 
-	object := objectClass basicNew: (basicSize := serializer nextLengthEncodedInteger).
+	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
 	
-	serializer registerObject: object.
+	materializer registerObject: object.
 	instSize := object class soilPersistentInstVars size.
-	1 to: instSize do: [:i | object instVarAt: i put: (serializer nextSoilObject) ].
-	1 to: basicSize do: [:i | object basicAt: i put: serializer nextSoilObject ].
-	object soilMaterialized: serializer.
+	1 to: instSize do: [:i | object instVarAt: i put: (materializer nextSoilObject) ].
+	1 to: basicSize do: [:i | object basicAt: i put: materializer nextSoilObject ].
+	object soilMaterialized: materializer.
 	^ object
 ]
 

--- a/src/Soil-Core/WeakLayout.extension.st
+++ b/src/Soil-Core/WeakLayout.extension.st
@@ -2,16 +2,15 @@ Extension { #name : #WeakLayout }
 
 { #category : #'*Soil-Core' }
 WeakLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
-	| object basicSize instSize|
+	| object basicSize |
 
 	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
 	
 	materializer registerObject: object.
-	instSize := object class soilPersistentInstVars size.
-	1 to: instSize do: [:i | object instVarAt: i put: (materializer nextSoilObject) ].
+	
+	self updateIvars: aBehaviorDescription with: materializer for: object.
 	1 to: basicSize do: [:i | object basicAt: i put: materializer nextSoilObject ].
-	object soilMaterialized: materializer.
-	^ object
+	^ object soilMaterialized: materializer
 ]
 
 { #category : #'*Soil-Core' }

--- a/src/Soil-Core/WordLayout.extension.st
+++ b/src/Soil-Core/WordLayout.extension.st
@@ -1,12 +1,12 @@
 Extension { #name : #WordLayout }
 
 { #category : #'*Soil-Core' }
-WordLayout >> soilBasicMaterialize: objectClass with: serializer [
+WordLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object basicSize |
-	 object := objectClass basicNew: (basicSize := serializer nextLengthEncodedInteger).
-	serializer registerObject: object.
+	 object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
+	materializer registerObject: object.
 	
-	1 to: basicSize do: [:i | object basicAt: i put: serializer nextLengthEncodedInteger].
+	1 to: basicSize do: [:i | object basicAt: i put: materializer nextLengthEncodedInteger].
 	^object
 ]
 


### PR DESCRIPTION
This PR is just a refactoring:

- change  #soilBasicMaterialize: with: to get the description, not the class as the first argument
- Move the code that migrate with history to the layout