### PR TITLE
Serialize-Materialize-ivars-by-Name-always 

### DIFF
--- a/src/Soil-Core/PointerLayout.extension.st
+++ b/src/Soil-Core/PointerLayout.extension.st
@@ -10,7 +10,7 @@ PointerLayout >> soilBasicSerialize: anObject with: serializer [
 			ifTrue: [ 0 ]
 			ifFalse: [ serializer referenceIndexOf: description]).
 	
-	description instVarIndexes do: [:i | (anObject instVarAt: i) soilSerialize: serializer ].
+	description instVarNames do: [:ivarName | (anObject instVarNamed: ivarName) soilSerialize: serializer ].
 ]
 
 { #category : #'*Soil-Core' }
@@ -18,12 +18,12 @@ PointerLayout >> updateIvars: aBehaviorDescription with: materializer for: objec
 	
 	aBehaviorDescription isCurrent
 		ifTrue: [
-				1 to: object class soilPersistentInstVars size do: [:i | object instVarAt: i put: (materializer nextSoilObject) ]]
+				aBehaviorDescription instVarNames do: [:instVar | 
+					object instVarNamed: instVar put: (materializer nextSoilObject) ]]
 		ifFalse: [
 			| versions |
 			versions := materializer behaviorVersionsUpTo: aBehaviorDescription.
 			versions last instVarNames do: [ :instVar | 
 				(versions allSatisfy: [ :version | version instVarNames includes: instVar ]) ifTrue: [ 
-					 object instVarNamed: instVar put: materializer nextSoilObject ] ]
-			].
+					 object instVarNamed: instVar put: materializer nextSoilObject ] ] ]
 ]

--- a/src/Soil-Core/SOBehaviorDescription.class.st
+++ b/src/Soil-Core/SOBehaviorDescription.class.st
@@ -31,25 +31,16 @@ SOBehaviorDescription class >> soilTransientInstVars [
 	^ #( objectId ) 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SOBehaviorDescription >> behaviorIdentifier [ 
 	^ behaviorIdentifier 
 ]
 
 { #category : #initialization }
 SOBehaviorDescription >> initializeFromBehavior: aClass [ 
-	"class := aClass."
 	behaviorIdentifier := aClass soilBehaviorIdentifier.
-	
-	instVarNames := aClass instVarNames
-]
-
-{ #category : #public }
-SOBehaviorDescription >> instVarIndexes [
-	| class |
-	class := Smalltalk at: behaviorIdentifier asSymbol. 
-	^ class soilPersistentInstVars
-		collect: [ :n | class allInstVarNames indexOf: n ]
+	"we record only the persistent ivar names, in order"
+	instVarNames := aClass soilPersistentInstVars
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/VariableLayout.extension.st
+++ b/src/Soil-Core/VariableLayout.extension.st
@@ -28,6 +28,6 @@ VariableLayout >> soilBasicSerialize: anObject with: serializer [
 	basicSize := anObject basicSize.
 	serializer nextPutLengthEncodedInteger: basicSize.
 	
-	description instVarIndexes do: [:i | (anObject instVarAt: i) soilSerialize: serializer ].
+	description instVarNames do: [:ivarName | (anObject instVarNamed: ivarName) soilSerialize: serializer ].
 	1 to: basicSize do: [:i | (anObject basicAt: i) soilSerialize: serializer ]
 ]

--- a/src/Soil-Core/WeakLayout.extension.st
+++ b/src/Soil-Core/WeakLayout.extension.st
@@ -28,6 +28,6 @@ WeakLayout >> soilBasicSerialize: anObject with: serializer [
 	basicSize := anObject basicSize.
 	serializer nextPutLengthEncodedInteger: basicSize.
 	
-	description instVarIndexes do: [:i | (anObject instVarAt: i) soilSerialize: serializer ].
+	description instVarNames do: [:ivarName | (anObject instVarNamed: ivarName) soilSerialize: serializer ].
 	1 to: basicSize do: [:i | (anObject basicAt: i) soilSerialize: serializer ]
 ]


### PR DESCRIPTION
When updating ivars with history, we where using names, for the other case, offsets. This PR makes sure to use names always

- we store ivars in name order, omitting the ones that we do not store
- we read by name, so we do not care about the non-stored ivars or any order changes

remove #instVarIndexes from the behavior description