### PR TITLE
simplify #soilBasicSerialize:with:

### DIFF
--- a/src/Soil-Core/AbstractLayout.extension.st
+++ b/src/Soil-Core/AbstractLayout.extension.st
@@ -9,3 +9,15 @@ AbstractLayout >> soilBasicMaterialize: objectClass with: materializer [
 AbstractLayout >> soilBasicSerialize: anObject with: serializer [
 	self subclassResponsibility
 ]
+
+{ #category : #'*Soil-Core' }
+AbstractLayout >> soilSerializeBehaviorDescription: anObject with: serializer [
+	| description |
+	description := serializer behaviorDescriptionFor: anObject class.
+	serializer 
+		nextPutObjectType;
+		nextPutLengthEncodedInteger: (description isMeta 
+			ifTrue: [ 0 ]
+			ifFalse: [ serializer referenceIndexOf: description]).
+	^ description
+]

--- a/src/Soil-Core/ByteLayout.extension.st
+++ b/src/Soil-Core/ByteLayout.extension.st
@@ -13,15 +13,11 @@ ByteLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 
 { #category : #'*Soil-Core' }
 ByteLayout >> soilBasicSerialize: anObject with: serializer [
-	| description |
-	description := serializer behaviorDescriptionFor: anObject class.
-	serializer 
-		nextPutObjectType;
-		nextPutLengthEncodedInteger: (description isMeta 
-			ifTrue: [ 0 ]
-			ifFalse: [ serializer referenceIndexOf: description]).
-
-	serializer nextPutLengthEncodedInteger: anObject basicSize.
-	1 to: anObject basicSize do: [:i |
-		serializer nextPutByte: (anObject at: i)].
+	| description basicSize |
+	description := self soilSerializeBehaviorDescription: anObject with: serializer.
+	basicSize := anObject basicSize.
+	
+	serializer nextPutLengthEncodedInteger: basicSize.
+	1 to: basicSize do: [:i |
+		serializer nextPutByte: (anObject at: i)]
 ]

--- a/src/Soil-Core/DoubleByteLayout.extension.st
+++ b/src/Soil-Core/DoubleByteLayout.extension.st
@@ -13,15 +13,11 @@ DoubleByteLayout >> soilBasicMaterialize: aBehaviorDescription with: materialize
 
 { #category : #'*Soil-Core' }
 DoubleByteLayout >> soilBasicSerialize: anObject with: serializer [
-	| description |
-	description := serializer behaviorDescriptionFor: anObject class.
-	serializer 
-		nextPutObjectType;
-		nextPutLengthEncodedInteger: (description isMeta 
-			ifTrue: [ 0 ]
-			ifFalse: [ serializer referenceIndexOf: description]).
+	| description basicSize |
+	description := self soilSerializeBehaviorDescription: anObject with: serializer.
+	basicSize := anObject basicSize.
 	
-	serializer nextPutLengthEncodedInteger: anObject basicSize.
-	1 to: anObject basicSize do: [:i |
-		serializer nextPutByte: (anObject at: i)].
+	serializer nextPutLengthEncodedInteger: basicSize.
+	1 to: basicSize do: [:i | 
+		serializer nextPutByte: (anObject at: i)]
 ]

--- a/src/Soil-Core/DoubleWordLayout.extension.st
+++ b/src/Soil-Core/DoubleWordLayout.extension.st
@@ -12,15 +12,11 @@ DoubleWordLayout >> soilBasicMaterialize: aBehaviorDescription with: materialize
 
 { #category : #'*Soil-Core' }
 DoubleWordLayout >> soilBasicSerialize: anObject with: serializer [
-	| instSize description |
-	description := serializer behaviorDescriptionFor: anObject class.
-	serializer 
-		nextPutObjectType;
-		nextPutLengthEncodedInteger: (description isMeta 
-			ifTrue: [ 0 ]
-			ifFalse: [ serializer referenceIndexOf: description]).
-
-	instSize := anObject basicSize.
-	serializer nextPutLengthEncodedInteger: instSize.
-	1 to: instSize do: [:i | serializer nextPutLengthEncodedInteger: (anObject basicAt: i)]
+	| description basicSize |
+	description := self soilSerializeBehaviorDescription: anObject with: serializer.
+	basicSize := anObject basicSize.
+	
+	serializer nextPutLengthEncodedInteger: basicSize.
+	1 to: basicSize do: [:i | 
+		serializer nextPutLengthEncodedInteger: (anObject basicAt: i)]
 ]

--- a/src/Soil-Core/EphemeronLayout.extension.st
+++ b/src/Soil-Core/EphemeronLayout.extension.st
@@ -12,3 +12,15 @@ EphemeronLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer
 	1 to: basicSize do: [:i | object basicAt: i put: materializer nextSoilObject ].
 	^object soilMaterialized: materializer
 ]
+
+{ #category : #'*Soil-Core' }
+EphemeronLayout >> soilBasicSerialize: anObject with: serializer [
+	| description basicSize|
+	
+	description := self soilSerializeBehaviorDescription: anObject with: serializer.
+	basicSize := anObject basicSize.
+	
+	serializer nextPutLengthEncodedInteger: basicSize.
+	description instVarNames do: [:ivarName | (anObject instVarNamed: ivarName) soilSerialize: serializer ].
+	1 to: basicSize do: [:i | (anObject basicAt: i) soilSerialize: serializer ]
+]

--- a/src/Soil-Core/PointerLayout.extension.st
+++ b/src/Soil-Core/PointerLayout.extension.st
@@ -2,15 +2,10 @@ Extension { #name : #PointerLayout }
 
 { #category : #'*Soil-Core' }
 PointerLayout >> soilBasicSerialize: anObject with: serializer [
-	|  description |
-	description := serializer behaviorDescriptionFor: anObject class.
-	serializer 
-		nextPutObjectType;
-		nextPutLengthEncodedInteger: (description isMeta 
-			ifTrue: [ 0 ]
-			ifFalse: [ serializer referenceIndexOf: description]).
+	| description |
+	description := self soilSerializeBehaviorDescription: anObject with: serializer.
 	
-	description instVarNames do: [:ivarName | (anObject instVarNamed: ivarName) soilSerialize: serializer ].
+	description instVarNames do: [:ivarName | (anObject instVarNamed: ivarName) soilSerialize: serializer ]
 ]
 
 { #category : #'*Soil-Core' }

--- a/src/Soil-Core/VariableLayout.extension.st
+++ b/src/Soil-Core/VariableLayout.extension.st
@@ -15,19 +15,12 @@ VariableLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer 
 
 { #category : #'*Soil-Core' }
 VariableLayout >> soilBasicSerialize: anObject with: serializer [
-	|  description basicSize|
+	| description basicSize|
 	
-	description := serializer behaviorDescriptionFor: anObject class.
-	serializer 
-		nextPutObjectType;
-		nextPutLengthEncodedInteger: (description isMeta 
-			ifTrue: [ 0 ]
-			ifFalse: [ serializer referenceIndexOf: description]).
-
-
+	description := self soilSerializeBehaviorDescription: anObject with: serializer.
 	basicSize := anObject basicSize.
-	serializer nextPutLengthEncodedInteger: basicSize.
 	
+	serializer nextPutLengthEncodedInteger: basicSize.
 	description instVarNames do: [:ivarName | (anObject instVarNamed: ivarName) soilSerialize: serializer ].
 	1 to: basicSize do: [:i | (anObject basicAt: i) soilSerialize: serializer ]
 ]

--- a/src/Soil-Core/WeakLayout.extension.st
+++ b/src/Soil-Core/WeakLayout.extension.st
@@ -15,19 +15,12 @@ WeakLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 
 { #category : #'*Soil-Core' }
 WeakLayout >> soilBasicSerialize: anObject with: serializer [
-	|  description basicSize|
+	| description basicSize|
 	
-	description := serializer behaviorDescriptionFor: anObject class.
-	serializer 
-		nextPutObjectType;
-		nextPutLengthEncodedInteger: (description isMeta 
-			ifTrue: [ 0 ]
-			ifFalse: [ serializer referenceIndexOf: description]).
-
-
+	description := self soilSerializeBehaviorDescription: anObject with: serializer.
 	basicSize := anObject basicSize.
-	serializer nextPutLengthEncodedInteger: basicSize.
 	
+	serializer nextPutLengthEncodedInteger: basicSize.
 	description instVarNames do: [:ivarName | (anObject instVarNamed: ivarName) soilSerialize: serializer ].
 	1 to: basicSize do: [:i | (anObject basicAt: i) soilSerialize: serializer ]
 ]

--- a/src/Soil-Core/WordLayout.extension.st
+++ b/src/Soil-Core/WordLayout.extension.st
@@ -12,15 +12,11 @@ WordLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 
 { #category : #'*Soil-Core' }
 WordLayout >> soilBasicSerialize: anObject with: serializer [
-	| instSize description |
-	description := serializer behaviorDescriptionFor: anObject class.
-	serializer 
-		nextPutObjectType;
-		nextPutLengthEncodedInteger: (description isMeta 
-			ifTrue: [ 0 ]
-			ifFalse: [ serializer referenceIndexOf: description]).
+	| description basicSize |
 	
-	instSize := anObject basicSize.
-	serializer nextPutLengthEncodedInteger: instSize.
-	1 to: instSize do: [:i | serializer nextPutLengthEncodedInteger: (anObject basicAt: i)]
+	description := self soilSerializeBehaviorDescription: anObject with: serializer.
+	basicSize := anObject basicSize.
+	
+	serializer nextPutLengthEncodedInteger: basicSize.
+	1 to: basicSize do: [:i | serializer nextPutLengthEncodedInteger: (anObject basicAt: i)]
 ]


### PR DESCRIPTION
simplify #soilBasicSerialize:with: by creating one method that creates and writes the behavior description.