### PR TITLE
Recover some methods from the OmniBase port: FileLocking

### DIFF
--- a/src/Soil-Core-Tests/SOCleanCodeTest.class.st
+++ b/src/Soil-Core-Tests/SOCleanCodeTest.class.st
@@ -120,18 +120,18 @@ SOCleanCodeTest >> testNoUnimplementedCalls [
 SOCleanCodeTest >> testNoUnsentMessages [
 	"Fail if there are methods implemented whose selectors is not sent anywhere in Pharo.
 	Please add a test or remove the method!"
-	
+
 	| found knownviolations |
 	found := Soil package allUnsentMessages.
-	
+
 	"To be fixed, see https://github.com/ApptiveGrid/Soil/issues/24"
 	knownviolations :=
-	 #('versionSize' 'flock:operation:' 'canLock:from:to:exclusive:' 'setNonBlock:' 'unlock:from:to:' 'transaction' 'lock:from:to:' 'soilLoadedIn:' 'idOf:' 'inspectionObject' 'soilRawSerialize:' 'soilRawMaterialize:').
-	
+	 #('versionSize' 'flock:operation:' 'canLock:from:to:exclusive:' 'setNonBlock:' 'transaction' 'releaseLockAndClose' 'canLock:from:to:exclusive:' 'soilLoadedIn:' 'idOf:' 'inspectionObject' 'soilRawSerialize:' 'soilRawMaterialize:' 'unlockAt:length:' 'lockAt:length:').
+
 	found := found copyWithoutAll: knownviolations.
-	
-	self 
-		assert: found isEmpty 
+
+	self
+		assert: found isEmpty
 		description: ('the following selectors are implemented, but never send', found asString)
 ]
 
@@ -142,8 +142,7 @@ SOCleanCodeTest >> testNoUnusedClasses [
 	| found  knownviolations |
 	found := Soil package definedClasses reject: [ :class | class isUsed]. 
 	
-	"To be fixed"
-	knownviolations := #(SOFLock SOBSDFLock).
+	knownviolations := #().
 	found := found reject: [:class | knownviolations includes: class name  ].
 	
 	self 

--- a/src/Soil-Core/BinaryFileStream.extension.st
+++ b/src/Soil-Core/BinaryFileStream.extension.st
@@ -1,0 +1,46 @@
+Extension { #name : #BinaryFileStream }
+
+{ #category : #'*Soil-Core' }
+BinaryFileStream >> fileHandle [
+
+	^ handle pointerAt: 9
+]
+
+{ #category : #'*Soil-Core' }
+BinaryFileStream >> flockClass [
+	^ OSPlatform current flockClass
+]
+
+{ #category : #'*Soil-Core' }
+BinaryFileStream >> lockAt: position length: length [
+	^ self flockClass
+		lock: self fileHandle
+		from: position
+		to: position + length - 1
+]
+
+{ #category : #'*Soil-Core' }
+BinaryFileStream >> releaseLockAndClose [
+	"Close file associatied with receiver."
+
+	self unlock.
+	self closed
+		ifFalse: [ self close ]
+]
+
+{ #category : #'*Soil-Core' }
+BinaryFileStream >> unlock [
+	^ self flockClass
+		unlock: self fileHandle
+		from: 0
+		to: self size
+]
+
+{ #category : #'*Soil-Core' }
+BinaryFileStream >> unlockAt: position length: length [
+
+	^ self flockClass
+		unlock: self fileHandle
+		from: position
+		to: position + length - 1
+]

--- a/src/Soil-Core/MacOSPlatform.extension.st
+++ b/src/Soil-Core/MacOSPlatform.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #MacOSPlatform }
+
+{ #category : #'*Soil-Core' }
+MacOSPlatform >> flockClass [
+	^ SOBSDFLock
+]

--- a/src/Soil-Core/OSPlatform.extension.st
+++ b/src/Soil-Core/OSPlatform.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #OSPlatform }
+
+{ #category : #'*Soil-Core' }
+OSPlatform >> flockClass [
+	Error signal: 'no support for file locking on this platform'
+]

--- a/src/Soil-Core/UnixPlatform.extension.st
+++ b/src/Soil-Core/UnixPlatform.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #UnixPlatform }
+
+{ #category : #'*Soil-Core' }
+UnixPlatform >> flockClass [
+	^ SOFLock
+]


### PR DESCRIPTION
- extension on BinaryFileStream
- #flockClass extension methods on OSPlatform

as this touches #testNoUnsentMessages, it will have to be updated after https://github.com/ApptiveGrid/Soil/pull/114 is merged