### PR TITLE
 109-add-second-testSerializationObjectWithTransient-where-it-is-the-first-var 

### DIFF
--- a/src/Soil-Core-Tests/SOTestClassWithTransient.class.st
+++ b/src/Soil-Core-Tests/SOTestClassWithTransient.class.st
@@ -1,3 +1,6 @@
+"
+Example class where one ivar is tagged as transient, see class side method #soilTransientInstVars
+"
 Class {
 	#name : #SOTestClassWithTransient,
 	#superclass : #Object,

--- a/src/Soil-Core-Tests/SOTestClassWithTransient.class.st
+++ b/src/Soil-Core-Tests/SOTestClassWithTransient.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'one',
-		'two'
+		'two',
+		'three'
 	],
 	#category : #'Soil-Core-Tests'
 }
@@ -24,6 +25,18 @@ SOTestClassWithTransient >> one [
 SOTestClassWithTransient >> one: anObject [
 
 	one := anObject
+]
+
+{ #category : #accessing }
+SOTestClassWithTransient >> three [
+
+	^ three
+]
+
+{ #category : #accessing }
+SOTestClassWithTransient >> three: anObject [
+
+	three := anObject
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Core-Tests/SoilSerializationTest.class.st
@@ -218,11 +218,12 @@ SoilSerializationTest >> testSerializationObjectTwice [
 SoilSerializationTest >> testSerializationObjectWithTransient [
 	| object serialized materialized |
 	object := SOTestClassWithTransient new.
-	object one: 1; two: 2.
+	object one: 1; two: 2; three: 3.
 	serialized := self serializeToBytes: object.
 	materialized := self materializeFromBytes: serialized.
 	self assert: materialized one equals: 1.
-	self assert: materialized two isNil
+	self assert: materialized two isNil.
+	self assert: materialized three equals: 3
 ]
 
 { #category : #'tests-hashed' }


### PR DESCRIPTION
Small improvement for the test of transient ivars: do not use the last ivar, but one in the middle.

fixes #109 