### PR TITLE
Cleanup-SoilObjectCodec 

### DIFF
--- a/src/Soil-Core/SoilMaterializer.class.st
+++ b/src/Soil-Core/SoilMaterializer.class.st
@@ -4,16 +4,9 @@ Class {
 	#category : #'Soil-Core-Serialization'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SoilMaterializer class >> materializeFromBytes: aByteArray [
-	^ (self on: aByteArray readStream)
-		materialize
-]
-
-{ #category : #'as yet unclassified' }
-SoilMaterializer class >> on: aReadStream [
-	^ self new 
-		stream: aReadStream 
+	^ self new materializeFromBytes: aByteArray
 ]
 
 { #category : #'reading - basic' }

--- a/src/Soil-Core/SoilObjectCodec.class.st
+++ b/src/Soil-Core/SoilObjectCodec.class.st
@@ -1,3 +1,6 @@
+"
+Abstract superclass for Serializer and Materializer
+"
 Class {
 	#name : #SoilObjectCodec,
 	#superclass : #Object,
@@ -36,6 +39,18 @@ SoilObjectCodec class >> decodeBytes: aByteArray [
 { #category : #convenience }
 SoilObjectCodec class >> encodeString: aString [ 
 	^ CharacterEncoder encodeString: aString
+]
+
+{ #category : #testing }
+SoilObjectCodec class >> isAbstract [
+
+	^ self == SoilObjectCodec
+]
+
+{ #category : #'instance creation' }
+SoilObjectCodec class >> on: aStream [
+	^ self new
+		stream: aStream
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilSerializer.class.st
+++ b/src/Soil-Core/SoilSerializer.class.st
@@ -7,18 +7,10 @@ Class {
 	#category : #'Soil-Core-Serialization'
 }
 
-{ #category : #'instance creation' }
-SoilSerializer class >> on: aStream [ 
-	^ self new 
-		stream: aStream 
-]
-
 { #category : #public }
-SoilSerializer class >> serializeToBytes: anObject [ 
+SoilSerializer class >> serializeToBytes: anObject [
 
-	^ (self on: ByteArray new writeStream) 
-		serialize: anObject
-
+	^ self new serializeToBytes: anObject
 ]
 
 { #category : #'writing - basic' }


### PR DESCRIPTION
- push up #on:
- tag SoilObjectCodec as abstract
- make sure serializeToBytes: and materializeFromBytes: call the same methods on the instance side (improves code coverage)