### PR TITLE
Fix: committing objects whose class have changed

### DIFF
--- a/src/Soil-Core-Tests/SoilBehaviorRegistryTest.class.st
+++ b/src/Soil-Core-Tests/SoilBehaviorRegistryTest.class.st
@@ -29,3 +29,9 @@ SoilBehaviorRegistryTest >> testRegisterNewClass [
 	self assert: (registry nameAt: #Object ifAbsent: nil) equals: (SOObjectId example).
 
 ]
+
+{ #category : #tests }
+SoilBehaviorRegistryTest >> testSOBehaviorDescription [
+	"SOBehaviorDescription (the class) itself is always there with index 2"
+	self assert: (registry nameAt: #SOBehaviorDescription ifAbsent: nil) index equals: 2
+]

--- a/src/Soil-Core-Tests/SoilMigrationTest.class.st
+++ b/src/Soil-Core-Tests/SoilMigrationTest.class.st
@@ -134,6 +134,31 @@ SoilMigrationTest >> testMaterializingObjectWithIvarRemoved2 [
 ]
 
 { #category : #tests }
+SoilMigrationTest >> testMaterializingObjectWithIvarRemovedThenCommit [
+	"We can load an object that was saved with two ivars even if the current class has just one"
+	| tx tx2 materializedRoot object |
+	object := migrationClass new.
+	object
+		instVarNamed: #one put: 1;
+		instVarNamed: #two put: 2.
+	tx := soil newTransaction.
+	tx root: object.
+	tx commit.
+	migrationClass
+		removeSlot: (migrationClass slotNamed: #two).
+
+	"lets try to commit with the class changed"
+	tx := soil newTransaction.
+	tx root: object.
+	tx commit.
+
+	tx2 := soil newTransaction.
+	materializedRoot := tx2 root.
+	self assert: materializedRoot class instVarNames size equals: 1.
+	self assert: (materializedRoot instVarNamed: #one) equals: 1
+]
+
+{ #category : #tests }
 SoilMigrationTest >> testMaterializingObjectWithReOrderedIvars [
 	| tx tx2 materializedRoot object |
 	

--- a/src/Soil-Core/SOBehaviorDescription.class.st
+++ b/src/Soil-Core/SOBehaviorDescription.class.st
@@ -26,6 +26,12 @@ SOBehaviorDescription class >> meta [
 	^ self for: self
 ]
 
+{ #category : #combining }
+SOBehaviorDescription class >> metaId [
+	"the id of the class is alway 2 and pre-initialized to break recursion"
+	^ SOObjectId segment: 1 index: 2
+]
+
 { #category : #'as yet unclassified' }
 SOBehaviorDescription class >> soilTransientInstVars [ 
 	^ #( objectId ) 

--- a/src/Soil-Core/SOTransaction.class.st
+++ b/src/Soil-Core/SOTransaction.class.st
@@ -45,32 +45,34 @@ SOTransaction >> atObjectId: objectId putObject: anObject [
 { #category : #public }
 SOTransaction >> behaviorDescriptionFor: aClass [
 	| classDescription id |
-	classDescriptions 
-		at: aClass soilBehaviorIdentifier 
+	classDescriptions
+		at: aClass soilBehaviorIdentifier
 		ifPresent: [ :description | ^ description ].
-	soil behaviorRegistry 
-		nameAt: aClass soilBehaviorIdentifier 
+	soil behaviorRegistry
+		nameAt: aClass soilBehaviorIdentifier
 		ifPresent: [ :oid | | desc |
-			desc := (oid index = 2) 
-				ifTrue: [(SOBehaviorDescription for: SOBehaviorDescription) objectId: oid ]
-				ifFalse: [ (self objectWithId: oid ifNone: [Error signal ]) objectId: oid; yourself ].
+			desc := (oid index = 2)
+				ifTrue: [SOBehaviorDescription meta objectId: oid ]
+				ifFalse: [ | foundDesc |
+					 "the description in the database might not be current, if not, we create a new one with the same ID"
+					 foundDesc := (self objectWithId: oid ifNone: [Error signal ]) objectId: oid; yourself.
+					 foundDesc isCurrent ifFalse: [ (SOBehaviorDescription for: aClass) objectId: oid ] ifTrue: [foundDesc]].
 			^ desc ].
-	(aClass = SOBehaviorDescription) ifTrue: [  self halt ].
-	classDescription := (SOBehaviorDescription for: aClass).
+
+	classDescription := SOBehaviorDescription for: aClass.
 	id := self newObjectId.
 	id initializeId: soil objectRepository.
 	classDescription objectId: id.
 	self atObjectId: id putObject: classDescription.
 	classDescriptions
-		at: aClass soilBehaviorIdentifier 
+		at: aClass soilBehaviorIdentifier
 		put: classDescription.
-	^ classDescription 
-	
+	^ classDescription
 ]
 
 { #category : #'as yet unclassified' }
-SOTransaction >> behaviorDescriptionWithId: aSOObjectId ifNone: aBlock [ 
-	(aSOObjectId index = 2) ifTrue: [ ^ SOBehaviorDescription for: SOBehaviorDescription ].
+SOTransaction >> behaviorDescriptionWithId: aSOObjectId ifNone: aBlock [
+	(aSOObjectId index = 2) ifTrue: [ ^ SOBehaviorDescription meta ].
 	^ self objectWithId: aSOObjectId ifNone: aBlock
 ]
 

--- a/src/Soil-Core/SoilBehaviorRegistry.class.st
+++ b/src/Soil-Core/SoilBehaviorRegistry.class.st
@@ -11,9 +11,9 @@ Class {
 
 { #category : #adding }
 SoilBehaviorRegistry >> addSpecialObjects [
-	self 
-		nameAt: SOBehaviorDescription name 
-		put: (SOObjectId segment: 1 index: 2)
+	self
+		nameAt: #SOBehaviorDescription
+		put: SOBehaviorDescription metaId
 ]
 
 { #category : #'as yet unclassified' }


### PR DESCRIPTION
This PR makes sure that we can commit after a class changed shape, see #testMaterializingObjectWithIvarRemovedThenCommit

What was missing? We get the behavior description via #behaviorDescriptionFor: from the behaviorRegistry, but that one is the old one (with the ivar not removed) Solution: create a new SOBehaviorDescription with the same objectID. 

This has to be moved to the registry later so we can find the history of a desciption, but it makes committing objects with changed classes possible now The code in behaviorDescriptionFor: will be refactored later.

Small changes not related:

- testSOBehaviorDescription
- use SOBehaviorDescription meta", add #metaId that returns the id with index 2