### PR TITLE
Migration-between-fixed-and-variable 

### DIFF
--- a/src/Soil-Core-Tests/SoilMigrationTest.class.st
+++ b/src/Soil-Core-Tests/SoilMigrationTest.class.st
@@ -51,6 +51,56 @@ SoilMigrationTest >> tearDown [
 	super tearDown
 ]
 
+{ #category : #'tests - change classlayout' }
+SoilMigrationTest >> testMaterializingObjectFixedLayputFromVariableLayout [
+	| tx tx2 materializedRoot object |
+	object := self createMigrationClassVariableLayout new.
+	self assert: object class isVariable.
+	object
+		instVarNamed: #one put: 1;
+		instVarNamed: #two put: 2.
+	tx := soil newTransaction.
+	tx root: object.
+	tx commit.
+
+	"now we change the class to be a variable class with the same ivars"
+	migrationClass := self createMigrationClassFixedLayout.
+	tx2 := soil newTransaction.
+	"
+	Problem: we read as Variable, which would store the length...
+
+	"
+	materializedRoot := tx2 root.
+	self deny: materializedRoot class isVariable.
+	self assert: (materializedRoot instVarNamed: #one) equals: 1.
+	self assert: (materializedRoot instVarNamed: #two) equals: 2
+]
+
+{ #category : #'tests - change classlayout' }
+SoilMigrationTest >> testMaterializingObjectVariableLayputFromFixedLayout [
+	| tx tx2 materializedRoot object |
+	object := self createMigrationClassFixedLayout new.
+	self deny: object class isVariable.
+	object
+		instVarNamed: #one put: 1;
+		instVarNamed: #two put: 2.
+	tx := soil newTransaction.
+	tx root: object.
+	tx commit.
+
+	"now we change the class to be a variable class with the same ivars"
+	migrationClass := self createMigrationClassVariableLayout.
+	tx2 := soil newTransaction.
+	"
+	Problem: we read as Variable, which would store the length...
+
+	"
+	materializedRoot := tx2 root.
+	self assert: materializedRoot class isVariable.
+	self assert: (materializedRoot instVarNamed: #one) equals: 1.
+	self assert: (materializedRoot instVarNamed: #two) equals: 2
+]
+
 { #category : #tests }
 SoilMigrationTest >> testMaterializingObjectVariableLayputWithChangedShape [
 	| tx tx2 materializedRoot object |

--- a/src/Soil-Core-Tests/SoilMigrationTest.class.st
+++ b/src/Soil-Core-Tests/SoilMigrationTest.class.st
@@ -63,13 +63,10 @@ SoilMigrationTest >> testMaterializingObjectFixedLayputFromVariableLayout [
 	tx root: object.
 	tx commit.
 
-	"now we change the class to be a variable class with the same ivars"
+	"now we change the class to be a fixed class with the same ivars"
 	migrationClass := self createMigrationClassFixedLayout.
 	tx2 := soil newTransaction.
-	"
-	Problem: we read as Variable, which would store the length...
 
-	"
 	materializedRoot := tx2 root.
 	self deny: materializedRoot class isVariable.
 	self assert: (materializedRoot instVarNamed: #one) equals: 1.
@@ -91,10 +88,7 @@ SoilMigrationTest >> testMaterializingObjectVariableLayputFromFixedLayout [
 	"now we change the class to be a variable class with the same ivars"
 	migrationClass := self createMigrationClassVariableLayout.
 	tx2 := soil newTransaction.
-	"
-	Problem: we read as Variable, which would store the length...
 
-	"
 	materializedRoot := tx2 root.
 	self assert: materializedRoot class isVariable.
 	self assert: (materializedRoot instVarNamed: #one) equals: 1.

--- a/src/Soil-Core/FixedLayout.extension.st
+++ b/src/Soil-Core/FixedLayout.extension.st
@@ -9,3 +9,12 @@ FixedLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	self updateIvars: aBehaviorDescription with: materializer for: object.
 	^ object soilMaterialized: materializer
 ]
+
+{ #category : #'*Soil-Core' }
+FixedLayout >> updateIvars: aBehaviorDescription with: materializer for: object [
+
+	"if we read an object that was stored with a variable layout, ignore the stored size"
+	aBehaviorDescription isVariableLayout ifTrue: [ materializer nextLengthEncodedInteger ].
+
+	super updateIvars: aBehaviorDescription with: materializer for: object
+]

--- a/src/Soil-Core/SOBehaviorDescription.class.st
+++ b/src/Soil-Core/SOBehaviorDescription.class.st
@@ -5,7 +5,8 @@ Class {
 		'name',
 		'instVarNames',
 		'behaviorIdentifier',
-		'objectId'
+		'objectId',
+		'classLayout'
 	],
 	#category : #'Soil-Core-Model'
 }
@@ -42,11 +43,18 @@ SOBehaviorDescription >> behaviorIdentifier [
 	^ behaviorIdentifier 
 ]
 
+{ #category : #accessing }
+SOBehaviorDescription >> classLayout [
+	^ classLayout
+]
+
 { #category : #initialization }
 SOBehaviorDescription >> initializeFromBehavior: aClass [
 	behaviorIdentifier := aClass soilBehaviorIdentifier.
 	"we record only the persistent ivar names, in order"
-	instVarNames := aClass soilPersistentInstVars
+	instVarNames := aClass soilPersistentInstVars.
+	"we record the Layout to be able to detect if the layout changed"
+	classLayout := aClass classLayout class name
 ]
 
 { #category : #accessing }
@@ -63,13 +71,24 @@ SOBehaviorDescription >> isCurrent [
 			"this assumption is only valid until SOBehaviorDescription changes
 			shape itselt. But this is unlikely to be handled automatically"
 			true ]
-		ifFalse: [
-			self matchesBehavior: (Smalltalk at: behaviorIdentifier) ]
+		ifFalse: [ | currentClass |
+			currentClass := Smalltalk globals at: behaviorIdentifier.
+			classLayout == currentClass classLayout class name and: [ self matchesBehavior: currentClass ] ]
+]
+
+{ #category : #testing }
+SOBehaviorDescription >> isFixedLayout [
+	^ classLayout == #FixedLayout
 ]
 
 { #category : #testing }
 SOBehaviorDescription >> isMeta [
 	^ behaviorIdentifier = self class name
+]
+
+{ #category : #testing }
+SOBehaviorDescription >> isVariableLayout [
+	^ classLayout == #VariableLayout
 ]
 
 { #category : #testing }

--- a/src/Soil-Core/VariableLayout.extension.st
+++ b/src/Soil-Core/VariableLayout.extension.st
@@ -4,10 +4,14 @@ Extension { #name : #VariableLayout }
 VariableLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object basicSize |
 
-	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
-	
+	"if we read an object that was stored with a fixed layout, there is no size written"
+	basicSize := aBehaviorDescription isFixedLayout
+		ifTrue: [ 0 ]
+		ifFalse: [ materializer nextLengthEncodedInteger ].
+	object := aBehaviorDescription objectClass basicNew: basicSize.
+
 	materializer registerObject: object.
-	
+
 	self updateIvars: aBehaviorDescription with: materializer for: object.
 	1 to: basicSize do: [:i | object basicAt: i put: materializer nextSoilObject ].
 	^object soilMaterialized: materializer


### PR DESCRIPTION
This PR add two tests and fixes migrating objects from Variable to Fixed and Fixed to Variable layouts.

Both Variable and fixed layouts have ivars, so if we change the layout, we should be able to read back the ivar data, but with the layout changed

(one step for #105)