### PR TITLE
Use only zero index

### DIFF
--- a/src/Soil-Core-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Core-Tests/SoilSerializationTest.class.st
@@ -184,8 +184,8 @@ SoilSerializationTest >> testSerializationObject [
 	| object serialized materialized |
 	object := Object new.
 	serialized := self serializeToBytes: object.
-	self assert: serialized equals:  #[0 0 0 1 0 0 0 0 0 0 0 3 0 0 0 0 0 0 0 2 1 1].
-	self assert: (serialized at: 21) equals: TypeCodeObject.
+	self assert: serialized equals:  #[0 0 0 0 0 0 0 0 0 0 0 2 1 3].
+	self assert: (serialized at: 13) equals: TypeCodeObject.
 
 	materialized := self materializeFromBytes: serialized.
 	self assert: materialized class equals: Object
@@ -202,12 +202,12 @@ SoilSerializationTest >> testSerializationObjectTwice [
 	serialized := self serializeToBytes: array.
 	
 	"First the Array"
-	self assert: (serialized at: 21) equals: TypeCodeArray.
+	self assert: (serialized at: 13) equals: TypeCodeArray.
 	"array of size 2"
-	self assert: (serialized at: 22) equals: 2.
+	self assert: (serialized at: 14) equals: 2.
 	"here the object ist stored (not tested)"
 	"Then we get a reference to the second instance"
-	self assert: (serialized at: 25) equals: TypeCodeInternalReference.
+	self assert: (serialized at: 17) equals: TypeCodeInternalReference.
 	materialized := self materializeFromBytes: serialized.
 	self assert: array first identicalTo: array second.
 	"identity is preserved"
@@ -307,7 +307,7 @@ SoilSerializationTest >> testSerializationUUID [
 	
 	self 
 		assert: serialized
-		equals:   #[0 0 0 1 0 0 0 0 0 0 0 3 0 0 0 0 0 0 0 19 1 1 16 228 43 3 248 62 154 13 0 134 46 191 23 1 180 187 206].
+		equals:    #[0 0 0 0 0 0 0 0 0 0 0 19 1 3 16 228 43 3 248 62 154 13 0 134 46 191 23 1 180 187 206].
 
 	materialized := self materializeFromBytes: serialized.
 	self assert: materialized equals: object

--- a/src/Soil-Core-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Core-Tests/SoilSerializationTest.class.st
@@ -184,8 +184,9 @@ SoilSerializationTest >> testSerializationObject [
 	| object serialized materialized |
 	object := Object new.
 	serialized := self serializeToBytes: object.
-	self assert: serialized equals:  #[0 0 0 0 0 0 0 0 0 0 0 2 1 3].
-	self assert: (serialized at: 13) equals: TypeCodeObject.
+	self assert: serialized equals:  #[0 0 2 1 3].
+	self assert: (serialized at: 4) equals: TypeCodeObject.
+
 	materialized := self materializeFromBytes: serialized.
 	self assert: materialized class equals: Object
 ]
@@ -201,12 +202,12 @@ SoilSerializationTest >> testSerializationObjectTwice [
 	serialized := self serializeToBytes: array.
 	
 	"First the Array"
-	self assert: (serialized at: 13) equals: TypeCodeArray.
+	self assert: (serialized at: 4) equals: TypeCodeArray.
 	"array of size 2"
-	self assert: (serialized at: 14) equals: 2.
+	self assert: (serialized at: 5) equals: 2.
 	"here the object ist stored (not tested)"
 	"Then we get a reference to the second instance"
-	self assert: (serialized at: 17) equals: TypeCodeInternalReference.
+	self assert: (serialized at: 8) equals: TypeCodeInternalReference.
 	materialized := self materializeFromBytes: serialized.
 	self assert: array first identicalTo: array second.
 	"identity is preserved"
@@ -306,7 +307,7 @@ SoilSerializationTest >> testSerializationUUID [
 	
 	self 
 		assert: serialized
-		equals:    #[0 0 0 0 0 0 0 0 0 0 0 19 1 3 16 228 43 3 248 62 154 13 0 134 46 191 23 1 180 187 206].
+		equals:    #[0 0 19 1 3 16 228 43 3 248 62 154 13 0 134 46 191 23 1 180 187 206].
 
 
 	materialized := self materializeFromBytes: serialized.

--- a/src/Soil-Core/AbstractLayout.extension.st
+++ b/src/Soil-Core/AbstractLayout.extension.st
@@ -16,6 +16,6 @@ AbstractLayout >> soilSerializeBehaviorDescription: anObject with: serializer [
 	description := serializer behaviorDescriptionFor: anObject class.
 	serializer
 		nextPutObjectType;
-		nextPutLengthEncodedInteger: (description referenceIndexWithSerializer: serializer).
+		nextPutLengthEncodedInteger: (description objectId index).
 	^ description
 ]

--- a/src/Soil-Core/SOBehaviorDescription.class.st
+++ b/src/Soil-Core/SOBehaviorDescription.class.st
@@ -129,11 +129,3 @@ SOBehaviorDescription >> objectId [
 SOBehaviorDescription >> objectId: aSOObjectId [
 	objectId := aSOObjectId
 ]
-
-{ #category : #references }
-SOBehaviorDescription >> referenceIndexWithSerializer: aSerializer [
-
-	^ self isMeta
-		  ifTrue: [ 0 ]
-		  ifFalse: [ aSerializer referenceIndexOf: self ]
-]

--- a/src/Soil-Core/SOBehaviorDescription.class.st
+++ b/src/Soil-Core/SOBehaviorDescription.class.st
@@ -23,8 +23,8 @@ SOBehaviorDescription class >> isSoilClusterRoot [
 ]
 
 { #category : #combining }
-SOBehaviorDescription class >> meta [ 
-	^ self for: self
+SOBehaviorDescription class >> meta [
+	^ (self for: self) objectId: self metaId
 ]
 
 { #category : #combining }

--- a/src/Soil-Core/SOClusterRecord.class.st
+++ b/src/Soil-Core/SOClusterRecord.class.st
@@ -32,11 +32,6 @@ SOClusterRecord >> assignObjectIds: aSOObjectRepository [
 ]
 
 { #category : #accessing }
-SOClusterRecord >> basicReferenceAt: anInteger [ 
-	^ references at: anInteger
-]
-
-{ #category : #accessing }
 SOClusterRecord >> bytes [
 	^ bytes
 ]

--- a/src/Soil-Core/SOTransaction.class.st
+++ b/src/Soil-Core/SOTransaction.class.st
@@ -53,16 +53,17 @@ SOTransaction >> behaviorDescriptionFor: aClass [
 	classDescriptions
 		at: aClass soilBehaviorIdentifier
 		ifPresent: [ :description | ^ description ].
+	classDescriptions
+		at: aClass soilBehaviorIdentifier
+		ifPresent: [ :description | ^ description ].
 	soil behaviorRegistry
 		nameAt: aClass soilBehaviorIdentifier
 		ifPresent: [ :oid | | desc |
 			desc := (oid index = 2)
-				ifTrue: [ SOBehaviorDescription meta objectId: oid ]
-				ifFalse: [ | foundDesc |
-					 "the description in the database might not be current, if not, we create a new one with the same ID"
-					 foundDesc := (self objectWithId: oid ifNone: [Error signal ]) objectId: oid; yourself.
-					 foundDesc isCurrent ifFalse: [ (SOBehaviorDescription for: aClass) objectId: oid ] ifTrue: [foundDesc]].
-			^ desc ].
+				ifTrue: [SOBehaviorDescription meta ]
+				ifFalse: [ (self objectWithId: oid ifNone: [Error signal ]) objectId: oid].
+	"the description in the database might not be current, if not, we create a new one with the same ID"
+				desc isCurrent ifTrue: [ ^ desc ]].
 
 	classDescription := SOBehaviorDescription for: aClass.
 	objectId := self newMetaObjectId.

--- a/src/Soil-Core/SOTransaction.class.st
+++ b/src/Soil-Core/SOTransaction.class.st
@@ -66,6 +66,7 @@ SOTransaction >> behaviorDescriptionFor: aClass [
 
 	classDescription := SOBehaviorDescription for: aClass.
 	objectId := self newMetaObjectId.
+	objectId initializeIndex: self objectRepository.
 	classDescription objectId: objectId.
 	self atObjectId: objectId putObject: classDescription.
 	classDescriptions
@@ -75,9 +76,9 @@ SOTransaction >> behaviorDescriptionFor: aClass [
 ]
 
 { #category : #'as yet unclassified' }
-SOTransaction >> behaviorDescriptionWithId: aSOObjectId ifNone: aBlock [
-	(aSOObjectId index = 2) ifTrue: [ ^ SOBehaviorDescription meta ].
-	^ self objectWithId: aSOObjectId ifNone: aBlock
+SOTransaction >> behaviorDescriptionWithIndex: index ifNone: aBlock [
+	(index = 2) ifTrue: [ ^ SOBehaviorDescription meta ].
+	^ self objectWithId: (SOObjectId segment: 0 index: index) ifNone: aBlock
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SOTransaction.class.st
+++ b/src/Soil-Core/SOTransaction.class.st
@@ -62,8 +62,8 @@ SOTransaction >> behaviorDescriptionFor: aClass [
 			desc := (oid index = 2)
 				ifTrue: [SOBehaviorDescription meta ]
 				ifFalse: [ (self objectWithId: oid ifNone: [Error signal ]) objectId: oid].
-	"the description in the database might not be current, if not, we create a new one with the same ID"
-				desc isCurrent ifTrue: [ ^ desc ]].
+			"the description in the database might not be current, if not, we create a new one later"
+			desc isCurrent ifTrue: [ ^ desc ]].
 
 	classDescription := SOBehaviorDescription for: aClass.
 	objectId := self newMetaObjectId.

--- a/src/Soil-Core/SoilMaterializer.class.st
+++ b/src/Soil-Core/SoilMaterializer.class.st
@@ -42,13 +42,13 @@ SoilMaterializer >> materializeFromBytes: aByteArray [
 
 { #category : #'instance creation' }
 SoilMaterializer >> newObject [
-	| description objectIndex|
-	objectIndex := self nextLengthEncodedInteger.
-	description := objectIndex isZero
+	| description behaviorIndex|
+	behaviorIndex := self nextLengthEncodedInteger.
+	description := behaviorIndex isZero
 		ifTrue: [ SOBehaviorDescription meta ]
 		ifFalse: [
 			transaction 
-				behaviorDescriptionWithId: (externalObjectRegistry basicReferenceAt: objectIndex) 
+				behaviorDescriptionWithIndex: behaviorIndex
 				ifNone: [ self halt  ] ].
 	^ description objectClass classLayout soilBasicMaterialize: description with: self
 ]

--- a/src/Soil-Core/SoilSerializer.class.st
+++ b/src/Soil-Core/SoilSerializer.class.st
@@ -346,11 +346,6 @@ SoilSerializer >> notSupportedError: anObject [
 	Error signal: 'serialization of class ', anObject class name asString , ' is not supported'
 ]
 
-{ #category : #public }
-SoilSerializer >> referenceIndexOf: aSOClassDescription [
-	^ externalObjectRegistry indexOfExternalReference: aSOClassDescription
-]
-
 { #category : #registry }
 SoilSerializer >> registerObject: anObject ifAbsent: aBlock [
 	| index externalIndex |


### PR DESCRIPTION
Serialize with segment zero index which is preknown. Don't store behaviors as external reference, this leads just to a lot of data to be stored