### PR TITLE
105-Migration-support-changing-class-Layouts 

### DIFF
--- a/src/Soil-Core-Tests/SoilMigrationTest.class.st
+++ b/src/Soil-Core-Tests/SoilMigrationTest.class.st
@@ -9,6 +9,13 @@ Class {
 }
 
 { #category : #helpers }
+SoilMigrationTest >> createMigrationClassByteLayout [
+	^ (SOBaseTestObject << #SOMigrationObject
+		layout: ByteLayout;
+		package: self class package name) install
+]
+
+{ #category : #helpers }
 SoilMigrationTest >> createMigrationClassFixedLayout [
 	^ (SOBaseTestObject << #SOMigrationObject
 		layout: FixedLayout;
@@ -49,6 +56,45 @@ SoilMigrationTest >> setUp [
 SoilMigrationTest >> tearDown [ 
 	migrationClass removeFromSystem.
 	super tearDown
+]
+
+{ #category : #'tests - change classlayout' }
+SoilMigrationTest >> testMaterializingObjectByteLayputFromFixedLayout [
+	| tx tx2 materializedRoot object |
+	object := self createMigrationClassFixedLayout new.
+	self deny: object class isVariable.
+	object
+		instVarNamed: #one put: 1;
+		instVarNamed: #two put: 2.
+	tx := soil newTransaction.
+	tx root: object.
+	tx commit.
+
+	"now we change the class to be a variable class with the same ivars"
+	migrationClass := self createMigrationClassByteLayout.
+	tx2 := soil newTransaction.
+
+	self should: [materializedRoot := tx2 root] raise: SOLayoutMigrationError
+
+]
+
+{ #category : #'tests - change classlayout' }
+SoilMigrationTest >> testMaterializingObjectFixedLayputFromByteLayout [
+	| tx tx2 materializedRoot object |
+
+	"We can load Variable Byte object as a Fixed object, we raise an error"
+
+	object := self createMigrationClassByteLayout new: 10.
+	self assert: object class isVariable.
+	tx := soil newTransaction.
+	tx root: object.
+	tx commit.
+
+	"now we change the class to be a fixed class with the same ivars"
+	migrationClass := self createMigrationClassFixedLayout.
+	tx2 := soil newTransaction.
+
+	self should: [materializedRoot := tx2 root] raise: SOLayoutMigrationError
 ]
 
 { #category : #'tests - change classlayout' }

--- a/src/Soil-Core/ByteLayout.extension.st
+++ b/src/Soil-Core/ByteLayout.extension.st
@@ -4,11 +4,12 @@ Extension { #name : #ByteLayout }
 ByteLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object basicSize |
 	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
+	aBehaviorDescription compatibilityCheck: object class classLayout.
+
 	materializer registerObject: object.
-	
+
 	materializer stream readInto: object startingAt: 1 count: basicSize.
 	^object soilMaterialized: materializer
-
 ]
 
 { #category : #'*Soil-Core' }

--- a/src/Soil-Core/DoubleByteLayout.extension.st
+++ b/src/Soil-Core/DoubleByteLayout.extension.st
@@ -5,10 +5,9 @@ DoubleByteLayout >> soilBasicMaterialize: aBehaviorDescription with: materialize
 	| object basicSize |
 	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
 	materializer registerObject: object.
-	
+
 	materializer stream readInto: object startingAt: 1 count: basicSize.
 	^object soilMaterialized: materializer
-
 ]
 
 { #category : #'*Soil-Core' }

--- a/src/Soil-Core/DoubleWordLayout.extension.st
+++ b/src/Soil-Core/DoubleWordLayout.extension.st
@@ -4,8 +4,9 @@ Extension { #name : #DoubleWordLayout }
 DoubleWordLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object basicSize |
 	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
+	aBehaviorDescription compatibilityCheck: object class classLayout.
 	materializer registerObject: object.
-	
+
 	1 to: basicSize do: [:i | object basicAt: i put: materializer nextLengthEncodedInteger].
 	^object soilMaterialized: materializer
 ]

--- a/src/Soil-Core/EphemeronLayout.extension.st
+++ b/src/Soil-Core/EphemeronLayout.extension.st
@@ -5,9 +5,10 @@ EphemeronLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer
 	| object basicSize |
 
 	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
-	
+	aBehaviorDescription compatibilityCheck: object class classLayout.
+
 	materializer registerObject: object.
-	
+
 	self updateIvars: aBehaviorDescription with: materializer for: object.
 	1 to: basicSize do: [:i | object basicAt: i put: materializer nextSoilObject ].
 	^object soilMaterialized: materializer

--- a/src/Soil-Core/FixedLayout.extension.st
+++ b/src/Soil-Core/FixedLayout.extension.st
@@ -4,8 +4,9 @@ Extension { #name : #FixedLayout }
 FixedLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object |
 	object := aBehaviorDescription objectClass basicNew.
+	aBehaviorDescription compatibilityCheck: object class classLayout.
 	materializer registerObject: object.
-	
+
 	self updateIvars: aBehaviorDescription with: materializer for: object.
 	^ object soilMaterialized: materializer
 ]

--- a/src/Soil-Core/SOBehaviorDescription.class.st
+++ b/src/Soil-Core/SOBehaviorDescription.class.st
@@ -48,6 +48,18 @@ SOBehaviorDescription >> classLayout [
 	^ classLayout
 ]
 
+{ #category : #testing }
+SOBehaviorDescription >> compatibilityCheck: aClassLayout [
+
+	"we can read if the layout is the same"
+	classLayout == aClassLayout class name ifTrue: [ ^true ].
+	"we support turning variable objects into fixed onces (and vice versa)"
+	(self isVariableLayout and: [ aClassLayout isFixedLayout]) ifTrue: [ ^true ].
+	(aClassLayout isVariable and: [ aClassLayout isBits not and: [self isFixedLayout]]) ifTrue: [ ^true ].
+	"for now we raise errors for the others. We could instead create and empty object and log a warning"
+	SOLayoutMigrationError signal: 'Incompatible layout detected: trying to read a ', classLayout , ' current code uses ', aClassLayout class name asString
+]
+
 { #category : #initialization }
 SOBehaviorDescription >> initializeFromBehavior: aClass [
 	behaviorIdentifier := aClass soilBehaviorIdentifier.
@@ -88,7 +100,10 @@ SOBehaviorDescription >> isMeta [
 
 { #category : #testing }
 SOBehaviorDescription >> isVariableLayout [
-	^ classLayout == #VariableLayout
+	"WeakLayout and EphemeronLayout answer implement isVariable, too"
+
+	^ classLayout == #VariableLayout or: [
+		  classLayout == #WeakLayout or: [ classLayout == #EphemeronLayout ] ]
 ]
 
 { #category : #testing }

--- a/src/Soil-Core/SOLayoutMigrationError.class.st
+++ b/src/Soil-Core/SOLayoutMigrationError.class.st
@@ -1,0 +1,8 @@
+"
+class was re-defined and the layout was changed to a layout that we can not migrate
+"
+Class {
+	#name : #SOLayoutMigrationError,
+	#superclass : #SOError,
+	#category : #'Soil-Core-Error'
+}

--- a/src/Soil-Core/VariableLayout.extension.st
+++ b/src/Soil-Core/VariableLayout.extension.st
@@ -9,6 +9,7 @@ VariableLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer 
 		ifTrue: [ 0 ]
 		ifFalse: [ materializer nextLengthEncodedInteger ].
 	object := aBehaviorDescription objectClass basicNew: basicSize.
+	aBehaviorDescription compatibilityCheck: object class classLayout.
 
 	materializer registerObject: object.
 

--- a/src/Soil-Core/WeakLayout.extension.st
+++ b/src/Soil-Core/WeakLayout.extension.st
@@ -5,9 +5,9 @@ WeakLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object basicSize |
 
 	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
-	
+	aBehaviorDescription compatibilityCheck: object class classLayout.
 	materializer registerObject: object.
-	
+
 	self updateIvars: aBehaviorDescription with: materializer for: object.
 	1 to: basicSize do: [:i | object basicAt: i put: materializer nextSoilObject ].
 	^ object soilMaterialized: materializer

--- a/src/Soil-Core/WordLayout.extension.st
+++ b/src/Soil-Core/WordLayout.extension.st
@@ -3,9 +3,10 @@ Extension { #name : #WordLayout }
 { #category : #'*Soil-Core' }
 WordLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object basicSize |
-	 object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
+	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
+	aBehaviorDescription compatibilityCheck: object class classLayout.
 	materializer registerObject: object.
-	
+
 	1 to: basicSize do: [:i | object basicAt: i put: materializer nextLengthEncodedInteger].
 	^object soilMaterialized: materializer
 ]


### PR DESCRIPTION
Raise an error when materializing an object and the layput of the class changed e.g from ByteLayout to Fixed.

(we can think about improving this later as needed in practice)

fixes #105