### PR TITLE
[WIP] Fix fnctl locking

### DIFF
--- a/src/Soil-File/BinaryFileStream.extension.st
+++ b/src/Soil-File/BinaryFileStream.extension.st
@@ -16,7 +16,7 @@ BinaryFileStream >> lockAt: position length: length [
 	^ self flockClass
 		lock: self fileHandle
 		from: position
-		to: position + length - 1
+		length: length
 ]
 
 { #category : #'*Soil-File' }
@@ -33,7 +33,7 @@ BinaryFileStream >> unlock [
 	^ self flockClass
 		unlock: self fileHandle
 		from: 0
-		to: self size
+		length: self size
 ]
 
 { #category : #'*Soil-File' }
@@ -42,5 +42,5 @@ BinaryFileStream >> unlockAt: position length: length [
 	^ self flockClass
 		unlock: self fileHandle
 		from: position
-		to: position + length - 1
+		length: length
 ]

--- a/src/Soil-File/SOMacOsFileLock.class.st
+++ b/src/Soil-File/SOMacOsFileLock.class.st
@@ -192,7 +192,7 @@ SOMacOsFileLock class >> setNonBlock: fileHandle [
 ]
 
 { #category : #'accessing locking' }
-SOMacOsFileLock class >> unlock: fileHandle from: start to: length [
+SOMacOsFileLock class >> unlock: fileHandle from: start length: length [
 	| lock result |
 	
 	lock := self newUnlockStart: start length: length.

--- a/src/Soil-File/SOMacOsFileLock.class.st
+++ b/src/Soil-File/SOMacOsFileLock.class.st
@@ -116,13 +116,26 @@ SOMacOsFileLock class >> initialize [
 ]
 
 { #category : #'accessing locking' }
-SOMacOsFileLock class >> lock: fileHandle from: start to: length [
+SOMacOsFileLock class >> lock: fileHandle from: start length: length [
 	
 	^ self 
 		lock: fileHandle 
 		from: start 
-		to: length
+		length: length
 		exclusive: true
+]
+
+{ #category : #'accessing locking' }
+SOMacOsFileLock class >> lock: fileHandle from: start length: length exclusive: exclusive [
+	| lock result |
+	
+	lock := self newLockExclusive: exclusive start: start length: length.
+	result := self 
+		fcntl: (self fileno: fileHandle) 
+		command: F_SETLK 
+		struct: lock.
+		
+	^ result ~= -1
 ]
 
 { #category : #'accessing locking' }

--- a/src/Soil-File/SOUnixFileLock.class.st
+++ b/src/Soil-File/SOUnixFileLock.class.st
@@ -26,7 +26,7 @@ Class {
 }
 
 { #category : #testing }
-SOUnixFileLock class >> canLock: fileHandle from: start to: length exclusive: exclusive [
+SOUnixFileLock class >> canLock: fileHandle from: start length: length exclusive: exclusive [
 	| lock result |
 	
 	lock := self newLockExclusive: exclusive start: start length: length.
@@ -117,17 +117,17 @@ SOUnixFileLock class >> initialize [
 ]
 
 { #category : #'accessing locking' }
-SOUnixFileLock class >> lock: fileHandle from: start to: length [
+SOUnixFileLock class >> lock: fileHandle from: start length: length [
 	
 	^ self 
 		lock: fileHandle 
 		from: start 
-		to: length
+		length: length
 		exclusive: true
 ]
 
 { #category : #'accessing locking' }
-SOUnixFileLock class >> lock: fileHandle from: start to: length exclusive: exclusive [
+SOUnixFileLock class >> lock: fileHandle from: start length: length exclusive: exclusive [
 	| lock result |
 	
 	lock := self newLockExclusive: exclusive start: start length: length.
@@ -180,7 +180,7 @@ SOUnixFileLock class >> setNonBlock: fileHandle [
 ]
 
 { #category : #'accessing locking' }
-SOUnixFileLock class >> unlock: fileHandle from: start to: length [
+SOUnixFileLock class >> unlock: fileHandle from: start length: length [
 	| lock result |
 	
 	lock := self newUnlockStart: start length: length.


### PR DESCRIPTION
I just discovered that lock calls go with from:to: but in the end the fcntl call uses from:length: and the to: argument is just passed as length