### PR TITLE
175-Serializer-needs-to-check-using-identityIndexOf-if-it-has-seen-an-object-already

### DIFF
--- a/src/Soil-Serializer-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilSerializationTest.class.st
@@ -193,6 +193,30 @@ SoilSerializationTest >> testSerializationObject [
 ]
 
 { #category : #'tests-twice' }
+SoilSerializationTest >> testSerializationObjectEqualTwice [
+	| object array serialized materialized |
+
+	"try to serialize an object that references two objects that are equal"
+	object := 'test'.
+	array := {object. object copy}.
+
+	serialized := self serializeToBytes: array.
+
+	"First the Array"
+	self assert: (serialized at: 5) equals: TypeCodeArray.
+	"array of size 2"
+	self assert: (serialized at: 6) equals: 2.
+	materialized := self materializeFromBytes: serialized.
+	self deny: array first identicalTo: array second.
+	self assert:  array first equals: array second.
+	"we do store the two strings correctly"
+	self assert:  materialized first equals: object.
+	self assert:  materialized first equals: materialized second.
+	"non-identity is preserved"
+	self deny: materialized first identicalTo: materialized second
+]
+
+{ #category : #'tests-twice' }
 SoilSerializationTest >> testSerializationObjectTwice [
 	| object array serialized materialized |
 	

--- a/src/Soil-Serializer/SoilSerializer.class.st
+++ b/src/Soil-Serializer/SoilSerializer.class.st
@@ -179,30 +179,29 @@ SoilSerializer >> notSupportedError: anObject [
 { #category : #registry }
 SoilSerializer >> registerObject: anObject ifAbsent: aBlock [
 	| index externalIndex |
-	(anObject == clusterRoot) ifTrue: [ 
+	(anObject == clusterRoot) ifTrue: [
 		"later references could reference the cluster root so we put
 		it as first object to be able to have an internal reference to it"
 		objects add: anObject.
-		^ aBlock value ]. 
-	index := objects indexOf: anObject.
-	(index > 0) ifTrue: [ 
+		^ aBlock value ].
+	index := objects identityIndexOf: anObject.
+	(index > 0) ifTrue: [
 		self nextPutInternalReference: index.
 		^ self ].
 	externalIndex := externalObjectRegistry
 		ifNotNil: [ externalObjectRegistry indexOfExternalReference: anObject ]
 		ifNil: [
 			"if there is no external object repository we cannot
-			resolve external objects, hence we treat them as  
+			resolve external objects, hence we treat them as
 			internal. This might be too dangerous later and might
-			be removed" 
+			be removed"
 			0 ].
-	((anObject == clusterRoot) not and: [ externalIndex > 0 ])
-		ifTrue: [ 
+	(anObject ~= clusterRoot and: [ externalIndex > 0 ])
+		ifTrue: [
 			self nextPutExternalReference: externalIndex ]
-		ifFalse: [  
+		ifFalse: [
 			objects add: anObject.
-			aBlock value ] 
-
+			aBlock value ]
 ]
 
 { #category : #private }


### PR DESCRIPTION
fixes #175