### PR TITLE
 102-Migration-support-class-rename 

### DIFF
--- a/src/Soil-Core-Tests/SoilMigrationTest.class.st
+++ b/src/Soil-Core-Tests/SoilMigrationTest.class.st
@@ -24,6 +24,14 @@ SoilMigrationTest >> createMigrationClassFixedLayout [
 ]
 
 { #category : #helpers }
+SoilMigrationTest >> createMigrationClassFixedLayout2 [
+	^ (SOBaseTestObject << #SOMigrationObject2
+		layout: FixedLayout;
+		slots: { #one . #two }; 
+		package: self class package name) install
+]
+
+{ #category : #helpers }
 SoilMigrationTest >> createMigrationClassVariableLayout [
 	^ (SOBaseTestObject << #SOMigrationObject
 		layout: VariableLayout;
@@ -117,6 +125,27 @@ SoilMigrationTest >> testMaterializingObjectFixedLayputFromVariableLayout [
 	self deny: materializedRoot class isVariable.
 	self assert: (materializedRoot instVarNamed: #one) equals: 1.
 	self assert: (materializedRoot instVarNamed: #two) equals: 2
+]
+
+{ #category : #tests }
+SoilMigrationTest >> testMaterializingObjectRenamedClass [
+		| tx tx2 materializedRoot object |
+
+	object := self createMigrationClassFixedLayout new.
+	self deny: object class isVariable.
+	tx := soil newTransaction.
+	tx root: object.
+	tx commit.
+	"now we remove the class and create a new one with a different name"
+	migrationClass removeFromSystem.
+	migrationClass := self createMigrationClassFixedLayout2.
+
+	"We have to tell soil that the class was renamed"
+	soil renameClassNamed: #SOMigrationObject to: #SOMigrationObject2.
+
+	tx2 := soil newTransaction.
+	materializedRoot := tx2 root.
+	self assert: materializedRoot class name equals: 'SOMigrationObject2'
 ]
 
 { #category : #'tests - change classlayout' }

--- a/src/Soil-Core/SOTransaction.class.st
+++ b/src/Soil-Core/SOTransaction.class.st
@@ -147,11 +147,12 @@ SOTransaction >> behaviorWithIndex: objectId andVersion: version ifNone: aBlock 
 	self flag: #todo.
 	"this is slow because it fetches always all versions"
 	list := self objectRepository allVersionsOf: (SOObjectId segment: 0 index: objectId).
+	"we search until we find a newer version or the exact version requested"
 	list do: [ :rec |
 		rec
 			transaction: self;
 			materializeObject.
-		(rec object version = version) ifTrue: [ ^ rec object ]  ].
+		(rec object version >= version) ifTrue: [ ^ rec object ]  ].
 	Error signal.
 ]
 

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -140,3 +140,28 @@ Soil >> path [
 Soil >> path: aString [ 
 	path := aString asFileReference
 ]
+
+{ #category : #refactorings }
+Soil >> renameClassNamed: oldName to: newName [
+	| transaction behaviorDescription objectId |
+
+	"we load the behaviorDescription of the oldName, change the name and commit"
+
+	transaction := self newTransaction.
+
+	objectId := self behaviorRegistry
+		nameAt: oldName
+		ifAbsent: [ self error: 'name not found in behavior registry' ].
+		
+	behaviorDescription := (transaction objectWithId: objectId ifNone: [Error signal ]) objectId: objectId.
+	"the description in the database might not be current, if not, we create a new one later"
+	
+	"modify existing description and increment version"
+	behaviorDescription initializeFromBehavior: (Smalltalk at: newName).
+	"we should increment the version, next step to do, see 
+	behaviorWithIndex:andVersionifNone:"		
+	"behaviorDescription incrementVersion."
+	
+	transaction markDirty: behaviorDescription.
+	transaction commit
+]

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -152,16 +152,18 @@ Soil >> renameClassNamed: oldName to: newName [
 	objectId := self behaviorRegistry
 		nameAt: oldName
 		ifAbsent: [ self error: 'name not found in behavior registry' ].
-		
+
 	behaviorDescription := (transaction objectWithId: objectId ifNone: [Error signal ]) objectId: objectId.
 	"the description in the database might not be current, if not, we create a new one later"
-	
+
 	"modify existing description and increment version"
 	behaviorDescription initializeFromBehavior: (Smalltalk at: newName).
-	"we should increment the version, next step to do, see 
-	behaviorWithIndex:andVersionifNone:"		
-	"behaviorDescription incrementVersion."
-	
+	behaviorDescription incrementVersion.
+
+	self behaviorRegistry
+		nameAt: newName
+		put: objectId.
+
 	transaction markDirty: behaviorDescription.
 	transaction commit
 ]


### PR DESCRIPTION
A first very simple class rename support

If a class is renamed, we have to tell soil by calling #renameClassNamed: to:

This can be called as part of a migration script, for example.