### PR TITLE
 179-SONewClusterVersionindexOfExternalReference-should-uses-identityIndexOf

### DIFF
--- a/src/Soil-Core/SONewClusterVersion.class.st
+++ b/src/Soil-Core/SONewClusterVersion.class.st
@@ -43,27 +43,27 @@ SONewClusterVersion >> hasChanged [
 SONewClusterVersion >> indexOfExternalReference: anObject [
 	| index |
 	(anObject == object) ifTrue: [ ^ 0 ].
-	index := externalObjects indexOf: anObject.
-	(index > 0) ifTrue: [ 
+	index := externalObjects identityIndexOf: anObject.
+	(index > 0) ifTrue: [
 		"anObject is an external object but has already been registered. Just
 		returning the index of the registered reference"
 		^ index ].
-	transaction objectIndex 
+	transaction objectIndex
 		at: anObject
-		ifPresent: [ :record | 
-			"anObject is an external object. Allocate a new local index and 
+		ifPresent: [ :record |
+			"anObject is an external object. Allocate a new local index and
 			return that"
 			self addObject: record object reference: record objectId.
 			^ references size ]
 		ifAbsent: [ | record |
-			(anObject class isSoilClusterRoot) ifTrue: [ 
-				"anObject could be made cluster root per class side setting. In that 
+			(anObject class isSoilClusterRoot) ifTrue: [
+				"anObject could be made cluster root per class side setting. In that
 				case we add it as cluster root to the transaction so the following
 				will find it"
 				transaction addClusterObject: anObject.
 				record := transaction objectIndex at: anObject.
-				self addObject: record object reference: record objectId. 
-				^ references size ]. 
+				self addObject: record object reference: record objectId.
+				^ references size ].
 			].
 	^ 0
 ]


### PR DESCRIPTION
use #identityIndexOf:

fixes #179