### PR TITLE
Move behavior description read and write to the Serializer/Materializer

### DIFF
--- a/src/Soil-Serializer/AbstractLayout.extension.st
+++ b/src/Soil-Serializer/AbstractLayout.extension.st
@@ -9,14 +9,3 @@ AbstractLayout >> soilBasicMaterialize: objectClass with: materializer [
 AbstractLayout >> soilBasicSerialize: anObject with: serializer [
 	self subclassResponsibility
 ]
-
-{ #category : #'*Soil-Serializer' }
-AbstractLayout >> soilSerializeBehaviorDescription: anObject with: serializer [
-	| description |
-	description := serializer behaviorDescriptionFor: anObject class.
-	serializer
-		nextPutObjectType;
-		nextPutLengthEncodedInteger: (description objectId index);
-		nextPutLengthEncodedInteger: (description version).
-	^ description
-]

--- a/src/Soil-Serializer/ByteLayout.extension.st
+++ b/src/Soil-Serializer/ByteLayout.extension.st
@@ -15,7 +15,7 @@ ByteLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 { #category : #'*Soil-Serializer' }
 ByteLayout >> soilBasicSerialize: anObject with: serializer [
 	| description basicSize |
-	description := self soilSerializeBehaviorDescription: anObject with: serializer.
+	description := serializer serializeBehaviorDescriptionFor: anObject.
 	basicSize := anObject basicSize.
 
 	serializer nextPutLengthEncodedInteger: basicSize.

--- a/src/Soil-Serializer/DoubleByteLayout.extension.st
+++ b/src/Soil-Serializer/DoubleByteLayout.extension.st
@@ -13,7 +13,7 @@ DoubleByteLayout >> soilBasicMaterialize: aBehaviorDescription with: materialize
 { #category : #'*Soil-Serializer' }
 DoubleByteLayout >> soilBasicSerialize: anObject with: serializer [
 	| description basicSize |
-	description := self soilSerializeBehaviorDescription: anObject with: serializer.
+	description := serializer serializeBehaviorDescriptionFor: anObject.
 	basicSize := anObject basicSize.
 
 	serializer nextPutLengthEncodedInteger: basicSize.

--- a/src/Soil-Serializer/DoubleWordLayout.extension.st
+++ b/src/Soil-Serializer/DoubleWordLayout.extension.st
@@ -14,7 +14,7 @@ DoubleWordLayout >> soilBasicMaterialize: aBehaviorDescription with: materialize
 { #category : #'*Soil-Serializer' }
 DoubleWordLayout >> soilBasicSerialize: anObject with: serializer [
 	| description basicSize |
-	description := self soilSerializeBehaviorDescription: anObject with: serializer.
+	description := serializer serializeBehaviorDescriptionFor: anObject.
 	basicSize := anObject basicSize.
 
 	serializer nextPutLengthEncodedInteger: basicSize.

--- a/src/Soil-Serializer/EphemeronLayout.extension.st
+++ b/src/Soil-Serializer/EphemeronLayout.extension.st
@@ -18,7 +18,7 @@ EphemeronLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer
 EphemeronLayout >> soilBasicSerialize: anObject with: serializer [
 	| description basicSize|
 
-	description := self soilSerializeBehaviorDescription: anObject with: serializer.
+	description := serializer serializeBehaviorDescriptionFor: anObject.
 	basicSize := anObject basicSize.
 
 	serializer nextPutLengthEncodedInteger: basicSize.

--- a/src/Soil-Serializer/PointerLayout.extension.st
+++ b/src/Soil-Serializer/PointerLayout.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #PointerLayout }
 { #category : #'*Soil-Serializer' }
 PointerLayout >> soilBasicSerialize: anObject with: serializer [
 	| description |
-	description := self soilSerializeBehaviorDescription: anObject with: serializer.
+	description := serializer serializeBehaviorDescriptionFor: anObject.
 
 	description instVarNames do: [:ivarName | (anObject instVarNamed: ivarName) soilSerialize: serializer ]
 ]

--- a/src/Soil-Serializer/SoilMaterializer.class.st
+++ b/src/Soil-Serializer/SoilMaterializer.class.st
@@ -45,15 +45,8 @@ SoilMaterializer >> materializeFromBytes: aByteArray [
 
 { #category : #'instance creation' }
 SoilMaterializer >> newObject [
-	| description behaviorIndex behaviorVersion |
-	behaviorIndex := self nextLengthEncodedInteger.
-	behaviorVersion := self nextLengthEncodedInteger.
-	description := behaviorIndex isZero
-		ifTrue: [ SOBehaviorDescription meta ]
-		ifFalse: [
-			transaction 
-				behaviorDescriptionWithIndex: behaviorIndex
-				andVersion: behaviorVersion ].
+	| description |
+	description := self nextBehaviorDescription.
 	^ description objectClass classLayout soilBasicMaterialize: description with: self
 ]
 
@@ -74,6 +67,19 @@ SoilMaterializer >> nextAssociation: aClass [
 	^ association
 		key: self nextSoilObject;
 		value: self nextSoilObject
+]
+
+{ #category : #reading }
+SoilMaterializer >> nextBehaviorDescription [
+	| behaviorIndex behaviorVersion |
+	behaviorIndex := self nextLengthEncodedInteger.
+	behaviorVersion := self nextLengthEncodedInteger.
+	^ behaviorIndex isZero
+		ifTrue: [ SOBehaviorDescription meta ]
+		ifFalse: [
+			transaction
+				behaviorDescriptionWithIndex: behaviorIndex
+				andVersion: behaviorVersion ]
 ]
 
 { #category : #reading }

--- a/src/Soil-Serializer/SoilSerializer.class.st
+++ b/src/Soil-Serializer/SoilSerializer.class.st
@@ -21,11 +21,6 @@ SoilSerializer class >> serializeToBytes: anObject [
 
 ]
 
-{ #category : #public }
-SoilSerializer >> behaviorDescriptionFor: aClass [ 
-	^ transaction behaviorDescriptionFor: aClass
-]
-
 { #category : #initialization }
 SoilSerializer >> initialize [ 
 	super initialize.
@@ -46,6 +41,14 @@ SoilSerializer >> nextPutAssociation: anAssociation [
 	self nextPutByte: TypeCodeAssociation.
 	anAssociation key soilSerialize: self.
 	anAssociation value soilSerialize: self.
+]
+
+{ #category : #writing }
+SoilSerializer >> nextPutBehaviorDescription: description [
+	self
+		nextPutObjectType;
+		nextPutLengthEncodedInteger: (description objectId index);
+		nextPutLengthEncodedInteger: (description version)
 ]
 
 { #category : #writing }
@@ -210,6 +213,14 @@ SoilSerializer >> serialize: anObject [
 	clusterRoot soilSerialize: self.
 	stream flush.
 	^ stream contents
+]
+
+{ #category : #public }
+SoilSerializer >> serializeBehaviorDescriptionFor: anObject [
+	| description |
+	description := transaction behaviorDescriptionFor: anObject class.
+	self nextPutBehaviorDescription: description.
+	^ description
 ]
 
 { #category : #public }

--- a/src/Soil-Serializer/VariableLayout.extension.st
+++ b/src/Soil-Serializer/VariableLayout.extension.st
@@ -22,7 +22,7 @@ VariableLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer 
 VariableLayout >> soilBasicSerialize: anObject with: serializer [
 	| description basicSize|
 
-	description := self soilSerializeBehaviorDescription: anObject with: serializer.
+	description := serializer serializeBehaviorDescriptionFor: anObject.
 	basicSize := anObject basicSize.
 
 	serializer nextPutLengthEncodedInteger: basicSize.

--- a/src/Soil-Serializer/WeakLayout.extension.st
+++ b/src/Soil-Serializer/WeakLayout.extension.st
@@ -17,7 +17,7 @@ WeakLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 WeakLayout >> soilBasicSerialize: anObject with: serializer [
 	| description basicSize|
 
-	description := self soilSerializeBehaviorDescription: anObject with: serializer.
+	description := serializer serializeBehaviorDescriptionFor: anObject.
 	basicSize := anObject basicSize.
 
 	serializer nextPutLengthEncodedInteger: basicSize.

--- a/src/Soil-Serializer/WordLayout.extension.st
+++ b/src/Soil-Serializer/WordLayout.extension.st
@@ -15,7 +15,7 @@ WordLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 WordLayout >> soilBasicSerialize: anObject with: serializer [
 	| description basicSize |
 
-	description := self soilSerializeBehaviorDescription: anObject with: serializer.
+	description := serializer serializeBehaviorDescriptionFor: anObject.
 	basicSize := anObject basicSize.
 
 	serializer nextPutLengthEncodedInteger: basicSize.


### PR DESCRIPTION
This PR moves #soilSerializeBehaviorDescription:with: to be done instead by the serializer

on both the Serializer and Materializer, it implements and uses a low level nextBehaviorDescription / nextPutBehaviorDescription: method that does the reading and writing

(this is the second cleanup described in #138)