### PR TITLE
unify how the objects ivar is initialized in the SoilObjectCodec Hierarchy

### DIFF
--- a/src/Soil-Serializer/SoilMaterializer.class.st
+++ b/src/Soil-Serializer/SoilMaterializer.class.st
@@ -215,7 +215,6 @@ SoilMaterializer >> nextSoilObject [
 
 { #category : #registry }
 SoilMaterializer >> registerObject: anObject [
-	objects ifNil: [ objects := OrderedCollection new ].
 	objects add: anObject 
 ]
 

--- a/src/Soil-Serializer/SoilObjectCodec.class.st
+++ b/src/Soil-Serializer/SoilObjectCodec.class.st
@@ -44,6 +44,12 @@ SoilObjectCodec >> externalObjectRegistry: anObject [
 	externalObjectRegistry := anObject
 ]
 
+{ #category : #initialization }
+SoilObjectCodec >> initialize [ 
+	super initialize.
+	objects := OrderedCollection new
+]
+
 { #category : #accessing }
 SoilObjectCodec >> soil [
 

--- a/src/Soil-Serializer/SoilSerializer.class.st
+++ b/src/Soil-Serializer/SoilSerializer.class.st
@@ -21,12 +21,6 @@ SoilSerializer class >> serializeToBytes: anObject [
 
 ]
 
-{ #category : #initialization }
-SoilSerializer >> initialize [ 
-	super initialize.
-	objects := OrderedCollection new
-]
-
 { #category : #writing }
 SoilSerializer >> nextPutArray: anArray [ 
 	self 


### PR DESCRIPTION
This PR unified how the objects ivar is initialized in the SoilObjectCodec hierarchy:

 it was lazy in one and at creation for the other. We can set it on creation ones for both.

- move #initialize up to SoilObjectCodec
- remvove nil check in #registerObject: (which is called for every object, so it should be fast)