### PR TITLE
in SoilSerializer>>#registerObject:ifAbsent:, check for not-identical

### DIFF
--- a/src/Soil-Serializer/SoilSerializer.class.st
+++ b/src/Soil-Serializer/SoilSerializer.class.st
@@ -193,7 +193,7 @@ SoilSerializer >> registerObject: anObject ifAbsent: aBlock [
 			internal. This might be too dangerous later and might
 			be removed"
 			0 ].
-	(anObject ~= clusterRoot and: [ externalIndex > 0 ])
+	(anObject ~~ clusterRoot and: [ externalIndex > 0 ])
 		ifTrue: [
 			self nextPutExternalReference: externalIndex ]
 		ifFalse: [


### PR DESCRIPTION
in SoilSerializer>>#registerObject:ifAbsent: we use #~=, but that checks for not-equal, we have to check for "not identical  object" using #~~