### PR TITLE
146-Refactor-behavior-registry-to-load-and-hold-all-versions-of-a-behavior 

### DIFF
--- a/src/Soil-Core-Tests/SoilMigrationTest.class.st
+++ b/src/Soil-Core-Tests/SoilMigrationTest.class.st
@@ -265,12 +265,19 @@ SoilMigrationTest >> testMaterializingObjectWithIvarRemovedThenCommit [
 	tx commit.
 	migrationClass
 		removeSlot: (migrationClass slotNamed: #two).
+	
+	"load it"	
+	tx2 := soil newTransaction.
+	materializedRoot := tx2 root.
+	self assert: materializedRoot class instVarNames size equals: 1.
+	self assert: (materializedRoot instVarNamed: #one) equals: 1.
 
 	"lets try to commit with the class changed"
 	tx := soil newTransaction.
-	tx root: object.
+	tx root: materializedRoot.
 	tx commit.
 
+	"load again"
 	tx2 := soil newTransaction.
 	materializedRoot := tx2 root.
 	self assert: materializedRoot class instVarNames size equals: 1.

--- a/src/Soil-Core/SOObjectRepository.class.st
+++ b/src/Soil-Core/SOObjectRepository.class.st
@@ -126,11 +126,6 @@ SOObjectRepository >> lockObjectId: aSOObjectId for: lockContext [
 ]
 
 { #category : #accessing }
-SOObjectRepository >> metaAt: index [ 
-	^ self metaSegment at: index
-]
-
-{ #category : #accessing }
 SOObjectRepository >> metaSegment [
 	^ metaSegment 
 ]

--- a/src/Soil-Core/SOObjectRepository.class.st
+++ b/src/Soil-Core/SOObjectRepository.class.st
@@ -48,7 +48,7 @@ SOObjectRepository >> addNewSegment: aSegment [
 SOObjectRepository >> allVersionsOf: aSOObjectId [ 
 	| segment |
 	segment := self segmentAt: aSOObjectId segment.
-	^ segment allVersionsOf: aSOObjectId  
+	^ segment allVersionsAt: aSOObjectId index
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SOObjectSegment.class.st
+++ b/src/Soil-Core/SOObjectSegment.class.st
@@ -22,9 +22,9 @@ SOObjectSegment >> addNewRaw: aByteArray [
 ]
 
 { #category : #'as yet unclassified' }
-SOObjectSegment >> allVersionsOf: aSOObjectId [ 
+SOObjectSegment >> allVersionsAt: index [ 
 	| obj versions |
-	obj := self at: aSOObjectId index.
+	obj := self at: index.
 	versions := OrderedCollection new.
 	versions add: obj.
 	[ obj previousVersionPosition isZero ] whileFalse: [ 

--- a/src/Soil-Core/SOTransaction.class.st
+++ b/src/Soil-Core/SOTransaction.class.st
@@ -112,14 +112,15 @@ SOTransaction >> behaviorDescriptionFor: aClass [
 ]
 
 { #category : #'as yet unclassified' }
-SOTransaction >> behaviorDescriptionWithIndex: index andVersion: version [
-	| description |
-	(index = 2) ifTrue: [ ^ SOBehaviorDescription meta ].
-	description := self behaviorWithIndex: index ifNone: [ 
-		(SOObjectNotFound segment: 0 index: index) signal ].
-	(description version = version)
-		ifTrue: [ ^ description ].
-	^ self behaviorWithIndex: index andVersion: version ifNone: [ self halt ]
+SOTransaction >> behaviorDescriptionWithIndex: index andVersion: version [ 
+	
+	idMap 
+		detect: [ :each | each objectId = index ]
+		ifFound: [ :record | 
+			(record object version = version)
+				ifTrue: [ ^ record object ] ].
+
+	^ self behaviorRegistry behaviorDescriptionWithIndex: index andVersion: version transaction: self
 ]
 
 { #category : #accessing }
@@ -133,40 +134,6 @@ SOTransaction >> behaviorVersionsUpTo: aSOBehaviorDescription [
 		behaviorVersionsUpTo: aSOBehaviorDescription
 		transaction: self .
 	
-]
-
-{ #category : #'as yet unclassified' }
-SOTransaction >> behaviorWithIndex: objectId andVersion: version ifNone: aBlock [
-	| list |
-	idMap 
-		detect: [ :each | each objectId = objectId ]
-		ifFound: [ :record | 
-			(record object version = version)
-				ifTrue: [ ^ record object ] ].
-
-	self flag: #todo.
-	"this is slow because it fetches always all versions"
-	list := self objectRepository allVersionsOf: (SOObjectId segment: 0 index: objectId).
-	"we search until we find a newer version or the exact version requested"
-	list do: [ :rec |
-		rec
-			transaction: self;
-			materializeObject.
-		(rec object version >= version) ifTrue: [ ^ rec object ]  ].
-	Error signal.
-]
-
-{ #category : #'as yet unclassified' }
-SOTransaction >> behaviorWithIndex: objectId ifNone: aBlock [
-	idMap 
-		detect: [ :each | each objectId = objectId ]
-		ifFound: [ :record | 
-			^ record object ].
-
-	^ (self objectRepository metaAt: objectId)
-		transaction: self;
-		materializeObject;
-		object
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilBehaviorRegistry.class.st
+++ b/src/Soil-Core/SoilBehaviorRegistry.class.st
@@ -20,7 +20,7 @@ SoilBehaviorRegistry >> addSpecialObjects [
 SoilBehaviorRegistry >> behaviorDescriptionWithIndex: behaviorIndex andVersion: version transaction: transaction [
 	| versionsOfBehavior |
 
-	self loadHistoryForBehaviorWithId: (SOObjectId segment: 0 index: behaviorIndex) transaction: transaction.
+	self loadHistoryForBehaviorWithIndex: behaviorIndex transaction: transaction.
 
 	versionsOfBehavior := versions at: behaviorIndex ifAbsent: [self halt].
 
@@ -35,7 +35,7 @@ SoilBehaviorRegistry >> behaviorVersionsUpTo: aSOBehaviorDescription transaction
 	objectId := self 
 		nameAt: aSOBehaviorDescription behaviorIdentifier 
 		ifAbsent: [ self halt ].
-	self loadHistoryForBehaviorWithId: objectId transaction: transaction.
+	self loadHistoryForBehaviorWithIndex: objectId index transaction: transaction.
 	chain := versions at: objectId index.
 	chain first isCurrent ifFalse: [ 
 		chain addFirst: ((SOBehaviorDescription for: aSOBehaviorDescription objectClass) version: (aSOBehaviorDescription version + 1))].
@@ -65,13 +65,13 @@ SoilBehaviorRegistry >> initializeFilesystem [
 ]
 
 { #category : #'as yet unclassified' }
-SoilBehaviorRegistry >> loadHistoryForBehaviorWithId: objectId transaction: transaction [
+SoilBehaviorRegistry >> loadHistoryForBehaviorWithIndex: objectIndex transaction: transaction [
 	|  records chain |
 
 	"check if we loaded the history already"
-	(versions includesKey: objectId index ) ifTrue: [ ^ self ].
+	(versions includesKey: objectIndex ) ifTrue: [ ^ self ].
 
-	records := transaction objectRepository allVersionsOf: objectId.
+	records := transaction objectRepository metaSegment allVersionsAt: objectIndex.
 	chain := records collect: [ :record |
 		record
 			transaction: transaction;
@@ -79,7 +79,7 @@ SoilBehaviorRegistry >> loadHistoryForBehaviorWithId: objectId transaction: tran
 			object  ].
 
 	versions
-		at: objectId index
+		at: objectIndex
 		put: chain
 ]
 

--- a/src/Soil-Core/SoilBehaviorRegistry.class.st
+++ b/src/Soil-Core/SoilBehaviorRegistry.class.st
@@ -17,23 +17,28 @@ SoilBehaviorRegistry >> addSpecialObjects [
 ]
 
 { #category : #'as yet unclassified' }
+SoilBehaviorRegistry >> behaviorDescriptionWithIndex: behaviorIndex andVersion: version transaction: transaction [
+	| versionsOfBehavior |
+
+	self loadHistoryForBehaviorWithId: (SOObjectId segment: 0 index: behaviorIndex) transaction: transaction.
+
+	versionsOfBehavior := versions at: behaviorIndex ifAbsent: [self halt].
+
+	^versionsOfBehavior
+		detect: [ :behav | behav version >= version ]
+		ifNone: [(SOObjectNotFound new segment: 0; index: behaviorIndex) signal]
+]
+
+{ #category : #'as yet unclassified' }
 SoilBehaviorRegistry >> behaviorVersionsUpTo: aSOBehaviorDescription transaction: transaction [
-	| objectId records chain offset |
+	| objectId chain offset |
 	objectId := self 
 		nameAt: aSOBehaviorDescription behaviorIdentifier 
 		ifAbsent: [ self halt ].
-	records := soil objectRepository 
-		allVersionsOf: objectId.
-	chain := records collect: [ :record |
-		record 
-			transaction: transaction;
-			materializeObject;
-			object  ].
+	self loadHistoryForBehaviorWithId: objectId transaction: transaction.
+	chain := versions at: objectId index.
 	chain first isCurrent ifFalse: [ 
-		chain addFirst: (SOBehaviorDescription for: aSOBehaviorDescription objectClass) ].
-	versions 
-		at: aSOBehaviorDescription behaviorIdentifier 
-		put: chain.
+		chain addFirst: ((SOBehaviorDescription for: aSOBehaviorDescription objectClass) version: (aSOBehaviorDescription version + 1))].
 	offset := chain detectIndex: [ :each | each matchesDescription: aSOBehaviorDescription ].
 	^ chain copyFrom: 1 to: offset
 ]
@@ -44,9 +49,12 @@ SoilBehaviorRegistry >> index [
 ]
 
 { #category : #initialization }
-SoilBehaviorRegistry >> initialize [ 
+SoilBehaviorRegistry >> initialize [
+
 	super initialize.
 	versions := Dictionary new
+		            at: 2
+		            put: (OrderedCollection with: SOBehaviorDescription meta); yourself
 ]
 
 { #category : #initialization }
@@ -54,6 +62,25 @@ SoilBehaviorRegistry >> initializeFilesystem [
 	self open.
 	index initializeList.
 	self addSpecialObjects
+]
+
+{ #category : #'as yet unclassified' }
+SoilBehaviorRegistry >> loadHistoryForBehaviorWithId: objectId transaction: transaction [
+	|  records chain |
+
+	"check if we loaded the history already"
+	(versions includesKey: objectId index ) ifTrue: [ ^ self ].
+
+	records := transaction objectRepository allVersionsOf: objectId.
+	chain := records collect: [ :record |
+		record
+			transaction: transaction;
+			materializeObject;
+			object  ].
+
+	versions
+		at: objectId index
+		put: chain
 ]
 
 { #category : #accessing }

--- a/src/Soil-Serializer/SoilMaterializer.class.st
+++ b/src/Soil-Serializer/SoilMaterializer.class.st
@@ -74,12 +74,9 @@ SoilMaterializer >> nextBehaviorDescription [
 	| behaviorIndex behaviorVersion |
 	behaviorIndex := self nextLengthEncodedInteger.
 	behaviorVersion := self nextLengthEncodedInteger.
-	^ behaviorIndex isZero
-		ifTrue: [ SOBehaviorDescription meta ]
-		ifFalse: [
-			transaction
+	^ transaction
 				behaviorDescriptionWithIndex: behaviorIndex
-				andVersion: behaviorVersion ]
+				andVersion: behaviorVersion
 ]
 
 { #category : #reading }


### PR DESCRIPTION
use the "versions" ivar of the behaviorRegistry to cache versions index -> chain of behavior history

- unify behaviorVersionsUpTo:  and behaviorDescriptionWithIndex: andVersion: to first fill the cache and use it
- remove #isZero check in #nextBehaviorDescription