### PR TITLE
Delegate object creation to the BehaviorDiscription

### DIFF
--- a/src/Soil-Serializer/ByteLayout.extension.st
+++ b/src/Soil-Serializer/ByteLayout.extension.st
@@ -3,9 +3,7 @@ Extension { #name : #ByteLayout }
 { #category : #'*Soil-Serializer' }
 ByteLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object basicSize |
-	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
-	aBehaviorDescription compatibilityCheck: object class classLayout.
-
+	object := aBehaviorDescription basicNew: (basicSize := materializer nextLengthEncodedInteger).
 	materializer registerObject: object.
 
 	materializer stream readInto: object startingAt: 1 count: basicSize.

--- a/src/Soil-Serializer/DoubleByteLayout.extension.st
+++ b/src/Soil-Serializer/DoubleByteLayout.extension.st
@@ -3,7 +3,7 @@ Extension { #name : #DoubleByteLayout }
 { #category : #'*Soil-Serializer' }
 DoubleByteLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object basicSize |
-	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
+	object := aBehaviorDescription basicNew: (basicSize := materializer nextLengthEncodedInteger).
 	materializer registerObject: object.
 
 	materializer stream readInto: object startingAt: 1 count: basicSize.

--- a/src/Soil-Serializer/DoubleWordLayout.extension.st
+++ b/src/Soil-Serializer/DoubleWordLayout.extension.st
@@ -3,8 +3,7 @@ Extension { #name : #DoubleWordLayout }
 { #category : #'*Soil-Serializer' }
 DoubleWordLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object basicSize |
-	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
-	aBehaviorDescription compatibilityCheck: object class classLayout.
+	object := aBehaviorDescription basicNew: (basicSize := materializer nextLengthEncodedInteger).
 	materializer registerObject: object.
 
 	1 to: basicSize do: [:i | object basicAt: i put: materializer nextLengthEncodedInteger].

--- a/src/Soil-Serializer/EphemeronLayout.extension.st
+++ b/src/Soil-Serializer/EphemeronLayout.extension.st
@@ -4,9 +4,7 @@ Extension { #name : #EphemeronLayout }
 EphemeronLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object basicSize |
 
-	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
-	aBehaviorDescription compatibilityCheck: object class classLayout.
-
+	object := aBehaviorDescription basicNew: (basicSize := materializer nextLengthEncodedInteger).
 	materializer registerObject: object.
 
 	self updateIvars: aBehaviorDescription with: materializer for: object.

--- a/src/Soil-Serializer/FixedLayout.extension.st
+++ b/src/Soil-Serializer/FixedLayout.extension.st
@@ -3,8 +3,7 @@ Extension { #name : #FixedLayout }
 { #category : #'*Soil-Serializer' }
 FixedLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object |
-	object := aBehaviorDescription objectClass basicNew.
-	aBehaviorDescription compatibilityCheck: object class classLayout.
+	object := aBehaviorDescription basicNew.
 	materializer registerObject: object.
 
 	self updateIvars: aBehaviorDescription with: materializer for: object.

--- a/src/Soil-Serializer/SOBehaviorDescription.class.st
+++ b/src/Soil-Serializer/SOBehaviorDescription.class.st
@@ -34,6 +34,16 @@ SOBehaviorDescription class >> soilTransientInstVars [
 	^ #( objectId ) 
 ]
 
+{ #category : #'object creation' }
+SOBehaviorDescription >> basicNew [
+	^ self compatibilityCheckObject: self objectClass basicNew
+]
+
+{ #category : #'object creation' }
+SOBehaviorDescription >> basicNew: size [
+	^ self compatibilityCheckObject: (self objectClass basicNew: size)
+]
+
 { #category : #accessing }
 SOBehaviorDescription >> beFirstVersion [
 	version := 1
@@ -59,6 +69,13 @@ SOBehaviorDescription >> compatibilityCheck: aClassLayout [
 	(aClassLayout isVariable and: [ aClassLayout isBits not and: [self isFixedLayout]]) ifTrue: [ ^true ].
 	"for now we raise errors for the others. We could instead create and empty object and log a warning"
 	SOLayoutMigrationError signal: 'Incompatible layout detected: trying to read a ', classLayout , ' current code uses ', aClassLayout class name asString
+]
+
+{ #category : #testing }
+SOBehaviorDescription >> compatibilityCheckObject: anObject [
+
+	self compatibilityCheck: anObject class classLayout.
+	^anObject
 ]
 
 { #category : #'as yet unclassified' }
@@ -122,6 +139,11 @@ SOBehaviorDescription >> matchesDescription: description [
 	(behaviorIdentifier = description behaviorIdentifier) ifFalse: [ ^ false ].
 	(instVarNames = description instVarNames) ifFalse: [ ^ false ].
 	^ true
+]
+
+{ #category : #'object creation' }
+SOBehaviorDescription >> newObjectWith: aSerializer [
+	^ self objectClass classLayout soilBasicMaterialize: self with: aSerializer
 ]
 
 { #category : #accessing }

--- a/src/Soil-Serializer/SoilMaterializer.class.st
+++ b/src/Soil-Serializer/SoilMaterializer.class.st
@@ -45,9 +45,8 @@ SoilMaterializer >> materializeFromBytes: aByteArray [
 
 { #category : #'instance creation' }
 SoilMaterializer >> newObject [
-	| description |
-	description := self nextBehaviorDescription.
-	^ description objectClass classLayout soilBasicMaterialize: description with: self
+
+	^ self nextBehaviorDescription newObjectWith: self
 ]
 
 { #category : #reading }

--- a/src/Soil-Serializer/VariableLayout.extension.st
+++ b/src/Soil-Serializer/VariableLayout.extension.st
@@ -8,9 +8,7 @@ VariableLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer 
 	basicSize := aBehaviorDescription isFixedLayout
 		ifTrue: [ 0 ]
 		ifFalse: [ materializer nextLengthEncodedInteger ].
-	object := aBehaviorDescription objectClass basicNew: basicSize.
-	aBehaviorDescription compatibilityCheck: object class classLayout.
-
+	object := aBehaviorDescription basicNew: basicSize.
 	materializer registerObject: object.
 
 	self updateIvars: aBehaviorDescription with: materializer for: object.

--- a/src/Soil-Serializer/WeakLayout.extension.st
+++ b/src/Soil-Serializer/WeakLayout.extension.st
@@ -4,8 +4,7 @@ Extension { #name : #WeakLayout }
 WeakLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object basicSize |
 
-	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
-	aBehaviorDescription compatibilityCheck: object class classLayout.
+	object := aBehaviorDescription basicNew: (basicSize := materializer nextLengthEncodedInteger).
 	materializer registerObject: object.
 
 	self updateIvars: aBehaviorDescription with: materializer for: object.

--- a/src/Soil-Serializer/WordLayout.extension.st
+++ b/src/Soil-Serializer/WordLayout.extension.st
@@ -3,8 +3,7 @@ Extension { #name : #WordLayout }
 { #category : #'*Soil-Serializer' }
 WordLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 	| object basicSize |
-	object := aBehaviorDescription objectClass basicNew: (basicSize := materializer nextLengthEncodedInteger).
-	aBehaviorDescription compatibilityCheck: object class classLayout.
+	object := aBehaviorDescription basicNew: (basicSize := materializer nextLengthEncodedInteger).
 	materializer registerObject: object.
 
 	1 to: basicSize do: [:i | object basicAt: i put: materializer nextLengthEncodedInteger].


### PR DESCRIPTION
Object creation should in the end be done by the BehaviorDiscription.

This way we can make subclasses where the class is not looked up in the current environment, for example to suppot anonymoys behaviors