### PR TITLE
Avoid looping over bytes in #nextPutByteArray:

### DIFF
--- a/src/Soil-Serializer/SoilBasicMaterializer.class.st
+++ b/src/Soil-Serializer/SoilBasicMaterializer.class.st
@@ -25,14 +25,11 @@ SoilBasicMaterializer >> nextByte [
 
 { #category : #reading }
 SoilBasicMaterializer >> nextByteArray: aClass [ 
-	| byteArray |
-	byteArray := aClass new: self nextLengthEncodedInteger.
+	| byteArray size |
+	byteArray := aClass new: (size := self nextLengthEncodedInteger).
 	self registerObject: byteArray.
-	1 to: byteArray size do: [:i | 
-		byteArray 
-			at: i 
-			put: self nextByte ].
-	^byteArray
+	stream readInto: byteArray startingAt: 1 count: size.
+	^ byteArray
 ]
 
 { #category : #reading }

--- a/src/Soil-Serializer/SoilBasicSerializer.class.st
+++ b/src/Soil-Serializer/SoilBasicSerializer.class.st
@@ -35,9 +35,8 @@ SoilBasicSerializer >> nextPutByte: anInteger [
 SoilBasicSerializer >> nextPutByteArray: aByteArray [
 	self 
 		nextPutByte: TypeCodeByteArray; 
-		nextPutLengthEncodedInteger: aByteArray size.
-	1 to: aByteArray size do: [:i |
-		self nextPutByte: (aByteArray at: i)].
+		nextPutLengthEncodedInteger: aByteArray size;
+		nextPutBytesFrom: aByteArray
 ]
 
 { #category : #'writing - basic' }


### PR DESCRIPTION
we do not need to write bytes one-by-one in #nextPutByteArray:, we can just use #nextPutBytesFrom: