### PR TITLE
SoilObjectCodec: ivar objects, use different name in Serializer and Materializer

### DIFF
--- a/src/Soil-Serializer/SoilBasicMaterializer.class.st
+++ b/src/Soil-Serializer/SoilBasicMaterializer.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #SoilBasicMaterializer,
 	#superclass : #SoilObjectCodec,
+	#instVars : [
+		'objects'
+	],
 	#category : #'Soil-Serializer'
 }
 

--- a/src/Soil-Serializer/SoilBasicSerializer.class.st
+++ b/src/Soil-Serializer/SoilBasicSerializer.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : #SoilBasicSerializer,
 	#superclass : #SoilObjectCodec,
+	#instVars : [
+		'objectIdTable'
+	],
 	#category : #'Soil-Serializer'
 }
 
@@ -23,7 +26,7 @@ SoilBasicSerializer >> basicNextPutSymbol: aSymbol [
 { #category : #initialization }
 SoilBasicSerializer >> initialize [ 
 	super initialize.
-	objects := SoilObjectTable new
+	objectIdTable := SoilObjectTable new
 ]
 
 { #category : #'writing - basic' }

--- a/src/Soil-Serializer/SoilObjectCodec.class.st
+++ b/src/Soil-Serializer/SoilObjectCodec.class.st
@@ -4,7 +4,6 @@ Class {
 	#instVars : [
 		'externalObjectRegistry',
 		'stream',
-		'objects',
 		'transaction',
 		'soil'
 	],

--- a/src/Soil-Serializer/SoilSerializer.class.st
+++ b/src/Soil-Serializer/SoilSerializer.class.st
@@ -189,9 +189,9 @@ SoilSerializer >> registerObject: anObject ifAbsent: aBlock [
 	(anObject == clusterRoot) ifTrue: [
 		"later references could reference the cluster root so we put
 		it as first object to be able to have an internal reference to it"
-		objects add: anObject.
+		objectIdTable add: anObject.
 		^ aBlock value ].
-	index := objects identityIndexOf: anObject.
+	index := objectIdTable identityIndexOf: anObject.
 	(index > 0) ifTrue: [
 		self nextPutInternalReference: index.
 		^ self ].
@@ -207,7 +207,7 @@ SoilSerializer >> registerObject: anObject ifAbsent: aBlock [
 		ifTrue: [
 			self nextPutExternalReference: externalIndex ]
 		ifFalse: [
-			objects add: anObject.
+			objectIdTable add: anObject.
 			aBlock value ]
 ]
 


### PR DESCRIPTION
The ivar "objects" was defined in SoilObjectCodec, but then initialized with two different objects (OrderedCollection and SoilObjectTable) for the materializer.

This PR makes sure to use two different names.