### PR TITLE
Unify encoding/decoding WideSymbols/WideStrings

### DIFF
--- a/src/Soil-Serializer/SoilBasicMaterializer.class.st
+++ b/src/Soil-Serializer/SoilBasicMaterializer.class.st
@@ -145,8 +145,7 @@ SoilBasicMaterializer >> nextTime [
 { #category : #reading }
 SoilBasicMaterializer >> nextWideString [
 	| buf length wideString |
-	length := self nextLengthEncodedInteger.
-	buf := ByteArray new: length.
+	buf := ByteArray new: (length := self nextLengthEncodedInteger).
 	stream readInto: buf startingAt: 1 count: length.
 	wideString := self class decodeBytes: buf. 
 	self registerObject: wideString. 
@@ -158,5 +157,5 @@ SoilBasicMaterializer >> nextWideSymbol [
 	| buf len |
 	buf := ByteArray new: (len := self nextLengthEncodedInteger).
 	stream readInto: buf startingAt: 1 count: len.
-	^ buf utf8Decoded asSymbol
+	^ (self class decodeBytes: buf) asSymbol
 ]

--- a/src/Soil-Serializer/SoilBasicSerializer.class.st
+++ b/src/Soil-Serializer/SoilBasicSerializer.class.st
@@ -172,9 +172,9 @@ SoilBasicSerializer >> nextPutWideString: aWideString [
 { #category : #writing }
 SoilBasicSerializer >> nextPutWideSymbol: aSymbol [
 	| buf |
-	buf := aSymbol asString utf8Encoded.
+	buf := self class encodeString: aSymbol.
 	self
 		nextPutByte: TypeCodeWideSymbol;
-		nextPutLengthEncodedInteger:  buf size;
+		nextPutLengthEncodedInteger: buf size;
 		nextPutBytesFrom: buf
 ]


### PR DESCRIPTION
unify how WideString and WideSymbol are encoded  (use the encoder defined for both)