### PR TITLE
193-SOTransaction-idMap-use-atifPresent 

### DIFF
--- a/src/Soil-Core/SOTransaction.class.st
+++ b/src/Soil-Core/SOTransaction.class.st
@@ -112,13 +112,7 @@ SOTransaction >> behaviorDescriptionFor: aClass [
 ]
 
 { #category : #'as yet unclassified' }
-SOTransaction >> behaviorDescriptionWithIndex: index andVersion: version [ 
-	
-	idMap 
-		detect: [ :each | each objectId = index ]
-		ifFound: [ :record | 
-			(record object version = version)
-				ifTrue: [ ^ record object ] ].
+SOTransaction >> behaviorDescriptionWithIndex: index andVersion: version [
 
 	^ self behaviorRegistry behaviorDescriptionWithIndex: index andVersion: version transaction: self
 ]
@@ -320,11 +314,9 @@ SOTransaction >> newPersistentClusterVersion [
 
 { #category : #accessing }
 SOTransaction >> newSerializer [
-	soil ifNil: [ self halt ].
 	^ soil newSerializer
 		transaction: self;
 		yourself
-
 ]
 
 { #category : #accessing }
@@ -340,8 +332,8 @@ SOTransaction >> objectRepository [
 { #category : #'as yet unclassified' }
 SOTransaction >> objectWithId: objectId [
 	idMap 
-		detect: [ :each | each objectId = objectId ]
-		ifFound: [ :record | ^ record object ].
+		at: objectId
+		ifPresent: [ :record | ^ record object ].
 
 	^ self materializationWithId: objectId
 ]

--- a/src/Soil-Core/SoilBehaviorRegistry.class.st
+++ b/src/Soil-Core/SoilBehaviorRegistry.class.st
@@ -22,8 +22,7 @@ SoilBehaviorRegistry >> behaviorDescriptionWithIndex: behaviorIndex andVersion: 
 
 	self loadHistoryForBehaviorWithIndex: behaviorIndex transaction: transaction.
 
-	versionsOfBehavior := versions at: behaviorIndex ifAbsent: [self halt].
-
+	versionsOfBehavior := versions at: behaviorIndex.
 	^versionsOfBehavior
 		detect: [ :behav | behav version >= version ]
 		ifNone: [(SOObjectNotFound new segment: 0; index: behaviorIndex) signal]


### PR DESCRIPTION
We can query the idMap by identity

- The behaviorDescriptionWithIndex: does not need to read this cache as we cache the versions in the behaviorRegistry
- #objectWithId: can  use #at:ifPresent: to avoid lineary scan

remove two "self halt" that are not needed anymore

fixes #193