### PR TITLE
 197-soilLoadedIn-vs-soilMaterialized 

### DIFF
--- a/src/Soil-Core-Tests/SOCleanCodeTest.class.st
+++ b/src/Soil-Core-Tests/SOCleanCodeTest.class.st
@@ -126,7 +126,7 @@ SOCleanCodeTest >> testNoUnsentMessages [
 
 	"To be fixed, see https://github.com/ApptiveGrid/Soil/issues/24"
 	knownviolations :=
-	 #('idOf:' 'soilLoadedIn:' 'inspectionObject' 'versionSize' 'makePersistent:').
+	 #('idOf:' 'inspectionObject' 'versionSize' 'makePersistent:').
 
 	found := found copyWithoutAll: knownviolations.
 


### PR DESCRIPTION
soilLoadedIn: is now send, this PR just cleans up testNoUnsentMessages to remove it from there

fixes #197