### PR TITLE
106-Migration-test-migration-with-multiple-intermediate-versions 

### DIFF
--- a/src/Soil-Core-Tests/SoilMigrationTest.class.st
+++ b/src/Soil-Core-Tests/SoilMigrationTest.class.st
@@ -212,6 +212,54 @@ SoilMigrationTest >> testMaterializingObjectWithChangedShape [
 ]
 
 { #category : #tests }
+SoilMigrationTest >> testMaterializingObjectWithIVarRemovedAndAddedBack [
+
+	| tx tx2 root materializedRoot object |
+
+	"this test checks that removing an ivar and adding it back later means this is a new ivar,
+	this makes sure iterating over behavior description history works, see
+	 PointerLayout>>#updateIvars:with:for:"
+	root := Dictionary new.
+	object := migrationClass new.
+	object
+		instVarNamed: #one put: 1;
+		instVarNamed: #two put: 2.
+	tx := soil newTransaction.
+	root at: #version1 put: object.
+	tx root: root.
+	tx commit.
+
+	"now we change the class and store an object with the changed shape"
+
+	migrationClass
+		removeSlot: (migrationClass slotNamed: #two).
+
+	object := migrationClass new.
+	object
+		instVarNamed: #one put: 'one'.
+	root
+		at: #version2 put: object.
+
+	tx := soil newTransaction.
+	tx root: root.
+	tx commit.
+
+	migrationClass := (SOBaseTestObject << #SOMigrationObject
+		layout: FixedLayout;
+		slots: { #one .#two . #three };
+		package: self class package name) install.
+
+	"load back, the object at #varsion1 loads the stored two ivars"
+	tx2 := soil newTransaction.
+	materializedRoot := tx2 root.
+	self assert: ((materializedRoot at: #version1) instVarNamed: #one ) equals: 1.
+	self assert: ((materializedRoot at: #version2) instVarNamed: #one ) equals: 'one'.
+	"the ivar for both is nil"
+	self assert: ((materializedRoot at: #version1) instVarNamed: #two ) equals: nil.
+	self assert: ((materializedRoot at: #version2) instVarNamed: #two ) equals: nil
+]
+
+{ #category : #tests }
 SoilMigrationTest >> testMaterializingObjectWithIvarRemoved [
 	"We can load an object that was saved with two ivars even if the current class has just one"
 	| tx tx2 materializedRoot object |
@@ -282,6 +330,43 @@ SoilMigrationTest >> testMaterializingObjectWithIvarRemovedThenCommit [
 	materializedRoot := tx2 root.
 	self assert: materializedRoot class instVarNames size equals: 1.
 	self assert: (materializedRoot instVarNamed: #one) equals: 1
+]
+
+{ #category : #tests }
+SoilMigrationTest >> testMaterializingObjectWithMultipleChangesinHistory [
+	| tx tx2 root materializedRoot object |
+
+	"this test checks that we can read object where we change multiple times the class"
+	root := Dictionary new.
+	object := migrationClass new.
+	object
+		instVarNamed: #one put: 1;
+		instVarNamed: #two put: 2.
+	tx := soil newTransaction.
+	root at: #version1 put: object.
+	tx root: root.
+	tx commit.
+
+	"now we change the class and store an object with the changed shape"
+
+	migrationClass
+		removeSlot: (migrationClass slotNamed: #two).
+
+	object := migrationClass new.
+	object
+		instVarNamed: #one put: 'one'.
+	root
+		at: #version2 put: object.
+
+	tx := soil newTransaction.
+	tx root: root.
+	tx commit.
+
+	"load back, the object at #varsion1 loads the stored two ivars"
+	tx2 := soil newTransaction.
+	materializedRoot := tx2 root.
+	self assert: ((materializedRoot at: #version1) instVarNamed: #one ) equals: 1.
+	self assert: ((materializedRoot at: #version2) instVarNamed: #one ) equals: 'one'
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -158,7 +158,6 @@ Soil >> renameClassNamed: oldName to: newName [
 
 	"modify existing description and increment version"
 	behaviorDescription initializeFromBehavior: (Smalltalk at: newName).
-	behaviorDescription incrementVersion.
 
 	self behaviorRegistry
 		nameAt: newName

--- a/src/Soil-Core/SoilBehaviorRegistry.class.st
+++ b/src/Soil-Core/SoilBehaviorRegistry.class.st
@@ -23,9 +23,8 @@ SoilBehaviorRegistry >> behaviorDescriptionWithIndex: behaviorIndex andVersion: 
 	self loadHistoryForBehaviorWithIndex: behaviorIndex transaction: transaction.
 
 	versionsOfBehavior := versions at: behaviorIndex ifAbsent: [self halt].
-
 	^versionsOfBehavior
-		detect: [ :behav | behav version >= version ]
+		detect: [ :behav | behav version = version ]
 		ifNone: [(SOObjectNotFound new segment: 0; index: behaviorIndex) signal]
 ]
 


### PR DESCRIPTION
This PR adds two tests:

1) testMaterializingObjectWithMultipleChangesinHistory Just a test that loads back intances of different class versions in the same root, of course this works

2) testMaterializingObjectIVarRemovedAndAddedBack takes that test and adds back the removed ivar before loading This tests PointerLayout>>#updateIvars:with:for: and fixes problems:

- we can not check for >= in SoilBehaviorRegistry>>#behaviorDescriptionWithIndex:andVersion:transaction:,  as we need to get all the old versions
- this was there only for Soil>>#renameClassNamed:to:, remove the version number increase there (I think this is conceptionally better, too: version number models structure change, rename keeps the structure)

fixes #106