### PR TITLE
SoilPersistentDictionary #keys, more tests for SoilSkipListDictionaryTest and SoilPersistentDictionaryTest

### DIFF
--- a/src/Soil-Core-Tests/SoilPersistentDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilPersistentDictionaryTest.class.st
@@ -84,6 +84,21 @@ SoilPersistentDictionaryTest >> testCommitAndRead [
 ]
 
 { #category : #tests }
+SoilPersistentDictionaryTest >> testKeys [
+
+	| dict transaction |
+	transaction := soil newTransaction.
+	dict := SoilPersistentDictionary new.
+	transaction makeRoot: dict.
+	dict at: #test put: 'string'.
+	dict at: #test2 put: 'string2'.
+	transaction commit.
+		
+	self assert: (dict keys includes: 'test').
+	self assert: (dict keys includes: 'test2')
+]
+
+{ #category : #tests }
 SoilPersistentDictionaryTest >> testNewPersistentDictionary [
 
 	| dict |
@@ -110,4 +125,19 @@ SoilPersistentDictionaryTest >> testRemoveKey [
 	
 
 
+]
+
+{ #category : #tests }
+SoilPersistentDictionaryTest >> testValues [
+
+	| dict transaction |
+	transaction := soil newTransaction.
+	dict := SoilPersistentDictionary new.
+	transaction makeRoot: dict.
+	dict at: #test put: 'string'.
+	dict at: #test2 put: 'string2'.
+	transaction commit.
+		
+	self assert: (dict values includes: 'string').
+	self assert: (dict values includes: 'string2')
 ]

--- a/src/Soil-Core-Tests/SoilSkipListDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListDictionaryTest.class.st
@@ -150,3 +150,70 @@ SoilSkipListDictionaryTest >> testAddToNewList [
 		raise: Error.
 	self assert: (dict at: #foo) equals: #bar
 ]
+
+{ #category : #tests }
+SoilSkipListDictionaryTest >> testFirst [
+	| dict |
+	dict := SoilSkipListDictionary new
+		keySize: 10;
+		maxLevel: 8;
+		yourself.
+	dict at: #foo put: #bar.
+	dict at: #foo2 put: #bar2.
+
+	self assert: dict first equals: #bar.
+	self assert: (dict first: 1) first equals: #bar.
+]
+
+{ #category : #tests }
+SoilSkipListDictionaryTest >> testLast [
+	| dict |
+	dict := SoilSkipListDictionary new
+		keySize: 10;
+		maxLevel: 8;
+		yourself.
+	dict at: #foo put: #bar.
+	dict at: #foo2 put: #bar2.
+
+	self assert: dict last equals: #bar2
+]
+
+{ #category : #tests }
+SoilSkipListDictionaryTest >> testSecond [
+	| dict |
+	dict := SoilSkipListDictionary new
+		keySize: 10;
+		maxLevel: 8;
+		yourself.
+	dict at: #foo put: #bar.
+	dict at: #foo2 put: #bar2.
+
+	self assert: dict second equals: #bar2
+]
+
+{ #category : #tests }
+SoilSkipListDictionaryTest >> testSize [
+	| dict |
+	dict := SoilSkipListDictionary new
+		keySize: 10;
+		maxLevel: 8;
+		yourself.
+	dict at: #foo put: #bar.
+	dict at: #foo2 put: #bar2.
+
+	self assert: dict size equals: 2
+]
+
+{ #category : #tests }
+SoilSkipListDictionaryTest >> testValues [
+	| dict |
+	dict := SoilSkipListDictionary new
+		keySize: 10;
+		maxLevel: 8;
+		yourself.
+	dict at: #foo put: #bar.
+	dict at: #foo2 put: #bar2.
+
+	self assert: (dict values includes: 'bar').
+	self assert: (dict values includes: 'bar2')
+]

--- a/src/Soil-Serializer/SoilPersistentDictionary.class.st
+++ b/src/Soil-Serializer/SoilPersistentDictionary.class.st
@@ -32,7 +32,7 @@ SoilPersistentDictionary >> add: anAssociation [
 	^return
 ]
 
-{ #category : #accessing }
+{ #category : #forwarded }
 SoilPersistentDictionary >> anyOne [ 
 	^ dict anyOne
 ]
@@ -97,6 +97,11 @@ SoilPersistentDictionary >> isEmpty [
 ]
 
 { #category : #forwarded }
+SoilPersistentDictionary >> keys [
+	^ dict keys
+]
+
+{ #category : #forwarded }
 SoilPersistentDictionary >> keysAndValuesDo: aBlock [
 	^ dict keysAndValuesDo: aBlock
 ]
@@ -139,7 +144,7 @@ SoilPersistentDictionary >> soilLoadedIn: aSOTransaction [
 	transaction := aSOTransaction 
 ]
 
-{ #category : #accessing }
+{ #category : #forwarded }
 SoilPersistentDictionary >> values [
 	^ dict values
 ]


### PR DESCRIPTION
- implement the missing #keys in SoilPersistentDictionary
- add more tests in SoilSkipListDictionaryTest
- two more tests on SoilPersistentDictionaryTest