### PR TITLE
move #lastPage to the SoilSkipListIterator

### DIFF
--- a/src/Soil-Core-Tests/SoilSkipListTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListTest.class.st
@@ -198,6 +198,19 @@ SoilSkipListTest >> testIteratorFirst [
 ]
 
 { #category : #tests }
+SoilSkipListTest >> testLast [
+	
+	| capacity |
+	capacity := skipList firstPage itemCapacity * 2.
+
+	1 to: capacity - 1 do: [ :n |
+		skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	skipList at: capacity put: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: skipList pages size equals: 3.
+	self assert: skipList last equals: #[ 8 7 6 5 4 3 2 1 ]
+]
+
+{ #category : #tests }
 SoilSkipListTest >> testMorePages [
 	1 to: 512 do: [ :n |
 		skipList at: (n asString asSkipListKeyOfSize: 8) put: #[ 1 2 3 4 5 6 7 8 ] ].

--- a/src/Soil-Core/SoilBasicSkipList.class.st
+++ b/src/Soil-Core/SoilBasicSkipList.class.st
@@ -116,7 +116,7 @@ SoilBasicSkipList >> keySize: anInteger [
 
 { #category : #accessing }
 SoilBasicSkipList >> last [
-	^ self newIterator lastAssociation value
+	^ self newIterator last
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilBasicSkipList.class.st
+++ b/src/Soil-Core/SoilBasicSkipList.class.st
@@ -116,7 +116,7 @@ SoilBasicSkipList >> keySize: anInteger [
 
 { #category : #accessing }
 SoilBasicSkipList >> last [
-	^ self newIterator lastPage lastItem value
+	^ self newIterator lastAssociation value
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilBasicSkipList.class.st
+++ b/src/Soil-Core/SoilBasicSkipList.class.st
@@ -116,7 +116,7 @@ SoilBasicSkipList >> keySize: anInteger [
 
 { #category : #accessing }
 SoilBasicSkipList >> last [
-	^ self store lastPage lastItem
+	^ self newIterator lastPage lastItem value
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilPagedIndexStore.class.st
+++ b/src/Soil-Core/SoilPagedIndexStore.class.st
@@ -47,18 +47,6 @@ SoilPagedIndexStore >> isCopyOnWrite [
 	^ false
 ]
 
-{ #category : #accessing }
-SoilPagedIndexStore >> lastPage [
-	| maxLevel page pageNumber |
-	^ pagesMutex critical: [  
-		maxLevel := self index maxLevel.
-		page := self headerPage.
-		[ (pageNumber := page rightAt: maxLevel) isZero ] whileFalse: [ 
-			page := self pageAt: pageNumber ].
-		page ]
-	
-]
-
 { #category : #acessing }
 SoilPagedIndexStore >> lastPageIndex [
 	^ self headerPage lastPageIndex

--- a/src/Soil-Core/SoilSkipListIterator.class.st
+++ b/src/Soil-Core/SoilSkipListIterator.class.st
@@ -55,7 +55,7 @@ SoilSkipListIterator >> findPageFor: key startingAt: page [
 
 { #category : #accessing }
 SoilSkipListIterator >> first [
-	^ self firstAssociation ifNotNil: [ :assoc | assoc value ]
+	^ self firstAssociation value
 ]
 
 { #category : #accessing }
@@ -68,8 +68,16 @@ SoilSkipListIterator >> firstAssociation [
 ]
 
 { #category : #accessing }
-SoilSkipListIterator >> lastAssociation [ 
-	^  self lastPage lastItem
+SoilSkipListIterator >> last [
+	^ self lastAssociation value
+]
+
+{ #category : #accessing }
+SoilSkipListIterator >> lastAssociation [
+	| item |
+	item := self lastPage lastItem. "sets currentPage"
+	currentKey := item key.
+	^ item
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilSkipListIterator.class.st
+++ b/src/Soil-Core/SoilSkipListIterator.class.st
@@ -69,10 +69,7 @@ SoilSkipListIterator >> firstAssociation [
 
 { #category : #accessing }
 SoilSkipListIterator >> lastAssociation [ 
-	| item |
-	currentPage := skipList store lastPage.
-	item := currentPage lastItem.
-	^ item
+	^  self lastPage lastItem
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilSkipListIterator.class.st
+++ b/src/Soil-Core/SoilSkipListIterator.class.st
@@ -76,6 +76,17 @@ SoilSkipListIterator >> lastAssociation [
 ]
 
 { #category : #accessing }
+SoilSkipListIterator >> lastPage [
+	| maxLevel pageNumber |
+	maxLevel := "self index maxLevel."1.
+	"there is a bug with right being 0 for pages other then the last"
+	currentPage := skipList headerPage.
+	[ (pageNumber := currentPage rightAt: maxLevel) isZero ] whileFalse: [ 
+		currentPage := self pageAt: pageNumber ].
+	^currentPage
+]
+
+{ #category : #accessing }
 SoilSkipListIterator >> levelAt: anInteger [ 
 	^ levels at: anInteger 
 ]


### PR DESCRIPTION
this uses a workaround and follows "right at: 1", not #maxLevel, see #283