### PR TITLE
B+Tree: test for non-root index split, more tests, fixes

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -46,6 +46,31 @@ SoilBTreeTest >> testAddFirstOverflow [
 ]
 
 { #category : #tests }
+SoilBTreeTest >> testAddRandom [
+	| numEntries entries |
+	"just some random addind and checking that we can find it. tree is configured to create lots of pages"
+	btree := SoilBTree new 
+		path: 'sunit-btree';
+		destroy;
+		initializeFilesystem;
+		initializeHeaderPage;
+		keySize: 512;
+		valueSize: 512.
+	
+	numEntries := 20.
+	entries := Set new: numEntries.
+	
+	
+	numEntries timesRepeat: [ | toAdd |
+		toAdd := (numEntries*20) atRandom.
+		entries add: toAdd.
+		btree at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+	
+	"can we find all the keys we added?"
+	entries do: [:each | self assert: (btree at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+]
+
+{ #category : #tests }
 SoilBTreeTest >> testAddSecondOverflow [
 
 	| page capacity |
@@ -238,6 +263,61 @@ SoilBTreeTest >> testSize [
 ]
 
 { #category : #tests }
+SoilBTreeTest >> testSplitIndexPage [
+	| entries |
+	"this test leads to a split of a non-root index page"
+	btree := SoilBTree new 
+		path: 'sunit-btree';
+		destroy;
+		initializeFilesystem;
+		initializeHeaderPage;
+		keySize: 512;
+		valueSize: 512.
+	
+	entries :=  #(104 247 56 281 61 286 66 337 308 1 400 272 347 335 45 62 207 7 123 140).
+	
+	
+	entries do: [:toAdd |
+		btree at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+	
+	"can we find all the keys we added?"
+	entries do: [:each | self assert: (btree at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+]
+
+{ #category : #tests }
+SoilBTreeTest >> testSplitIndexPageReleoad [
+	| entries |
+	"this test leads to a split of a non-root index page"
+	btree := SoilBTree new 
+		path: 'sunit-btree';
+		destroy;
+		initializeFilesystem;
+		initializeHeaderPage;
+		keySize: 512 ;
+		valueSize: 512.
+	
+	entries :=  #(104 247 56 281 61 286 66 337 308 1 400 272 347 335 45 62 207 7 123 140).
+	
+	
+	entries do: [:toAdd |
+		btree at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+	
+	"can we find all the keys we added?"
+	entries do: [:each | self assert: (btree at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	
+	"write and reload"
+	btree writePages.
+	btree close.
+	btree := SoilBTree new 
+		path: 'sunit-btree';
+		initializeFilesystem;
+		open. 
+	
+	"can we find all the keys we added?"
+	entries do: [:each | self assert: (btree at: each ) equals: (#[ 1 2 3 4 5 6 7 8 ] asByteArrayOfSize: 512)].
+]
+
+{ #category : #tests }
 SoilBTreeTest >> testSplitRootIndexPage [ 
 	"we add until the root Index is full and has to be split"
 	| capacity n indexPages |
@@ -260,4 +340,29 @@ SoilBTreeTest >> testSplitRootIndexPage [
 	self assert: (btree rootPage items anySatisfy: [ :item | item value asInteger = indexPages third index ]).
 	"and we can find the key added last"
 	self assert: (btree at: capacity + n ) equals:  #[ 1 2 3 4 5 6 7 8 ]
+]
+
+{ #category : #tests }
+SoilBTreeTest >> testSplitRootIndexPageReload [
+	"we add until the root Index is full and has to be split"
+	| capacity n |
+	n := 1.
+	capacity := btree headerPage itemCapacity.
+	[btree rootPage hasRoom] whileTrue: [
+		btree at: n put: #[ 1 2 3 4 5 6 7 8 ].
+		n:= n+1. ].
+	self assert: btree pages size equals: 256.
+	
+	"if we lots of more pages, the root index has to be split"
+	1 to: capacity do: [ :i | btree at:  i + n put: #[ 1 2 3 4 5 6 7 8 ]].
+
+	btree writePages.
+	btree close.
+	btree := SoilBTree new 
+		path: 'sunit-btree';
+		initializeFilesystem;
+		open. 
+	
+	"and we can find the key added last"
+	self assert: (btree at: capacity + n ) equals:  #[ 1 2 3 4 5 6 7 8 ].
 ]

--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -260,7 +260,9 @@ SoilBTreeTest >> testRemoveKey [
 	
 	self assert: (btree at: 1) equals: #[ 1 2 3 4 5 6 7 8 ].
 	self assert: (btree at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self should: [ btree at: 20  ] raise: KeyNotFound
+	self should: [ btree at: 20  ] raise: KeyNotFound.
+	btree at: 20 put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (btree at: 20) equals: #[ 1 2 3 4 5 6 7 8 ].
 ]
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -250,6 +250,20 @@ SoilBTreeTest >> testPageAddFirstAndLoad [
 ]
 
 { #category : #tests }
+SoilBTreeTest >> testRemoveKey [
+
+	| capacity |
+	capacity := btree headerPage itemCapacity.
+	1 to: capacity do: [ :n | btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	
+	btree removeKey: 20.
+	
+	self assert: (btree at: 1) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (btree at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self should: [ btree at: 20  ] raise: KeyNotFound
+]
+
+{ #category : #tests }
 SoilBTreeTest >> testSize [
 	
 	| capacity |

--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -177,6 +177,13 @@ SoilBTreeTest >> testCreation [
 ]
 
 { #category : #tests }
+SoilBTreeTest >> testIsEmpty [
+	self assert: btree isEmpty.
+	btree at: 1 put: #[1 2].
+	self deny: btree isEmpty
+]
+
+{ #category : #tests }
 SoilBTreeTest >> testIteratorFirst [
 	
 	| capacity first |

--- a/src/Soil-Core-Tests/SoilSkipListTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListTest.class.st
@@ -154,6 +154,11 @@ SoilSkipListTest >> testFindKeyReverse [
 ]
 
 { #category : #tests }
+SoilSkipListTest >> testIsEmpty [
+	self assert: skipList isEmpty
+]
+
+{ #category : #tests }
 SoilSkipListTest >> testIteratorDo [
 	
 	| capacity col |
@@ -228,6 +233,22 @@ SoilSkipListTest >> testPageAddFirst [
 	page := skipList firstPage.
 	self assert: page numberOfItems equals: 1.
 	self assert: page items first key equals: (#foo asSkipListKeyOfSize: 8) asInteger
+]
+
+{ #category : #tests }
+SoilSkipListTest >> testRemoveKey [
+
+	| capacity |
+	capacity := skipList headerPage itemCapacity.
+	1 to: capacity do: [ :n | skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	
+	skipList removeKey: 20.
+	
+	self assert: (skipList at: 1) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (skipList at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self should: [ skipList at: 20  ] raise: KeyNotFound.
+	skipList at: 20 put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (skipList at: 20) equals: #[ 1 2 3 4 5 6 7 8 ].
 ]
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilSkipListTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListTest.class.st
@@ -155,7 +155,9 @@ SoilSkipListTest >> testFindKeyReverse [
 
 { #category : #tests }
 SoilSkipListTest >> testIsEmpty [
-	self assert: skipList isEmpty
+	self assert: skipList isEmpty.
+	skipList at: 1 put: #[1 2].
+	self deny: skipList isEmpty
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/SoilBTree.class.st
+++ b/src/Soil-Core/SoilBTree.class.st
@@ -61,6 +61,11 @@ SoilBTree >> initializeHeaderPage [
 	self store initializeHeaderPage
 ]
 
+{ #category : #testing }
+SoilBTree >> isEmpty [
+	^ self store headerPage hasItems not
+]
+
 { #category : #accessing }
 SoilBTree >> keySize [
 	^ self headerPage keySize

--- a/src/Soil-Core/SoilBTree.class.st
+++ b/src/Soil-Core/SoilBTree.class.st
@@ -177,6 +177,25 @@ SoilBTree >> readPageFrom: aStream [
 	^ SoilBTreePage readPageFrom: aStream
 ]
 
+{ #category : #removing }
+SoilBTree >> removeKey: key [ 
+	^ self
+		removeKey: key 
+		ifAbsent: [ KeyNotFound signal: key ]
+]
+
+{ #category : #removing }
+SoilBTree >> removeKey: aString ifAbsent: aBlock [
+	| page index key |
+	key := (aString asSkipListKeyOfSize: self keySize) asInteger.
+	page := self newIterator 
+		find: key;
+		page.
+	^ ((index := page indexOfKey: key) > 0) 
+		ifTrue: [ (page itemRemoveIndex: index) value ]
+		ifFalse: [ aBlock value ]
+]
+
 { #category : #accessing }
 SoilBTree >> rootPage [
 	^ self store pageAt: 2

--- a/src/Soil-Core/SoilBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilBTreeDataPage.class.st
@@ -25,6 +25,11 @@ SoilBTreeDataPage >> find: aKey with: aBTree [
 
 ]
 
+{ #category : #testing }
+SoilBTreeDataPage >> hasItems [
+	^ items notEmpty
+]
+
 { #category : #utilities }
 SoilBTreeDataPage >> headerSize [
 	^ self indexSize + self pointerSize

--- a/src/Soil-Core/SoilBTreeHeaderPage.class.st
+++ b/src/Soil-Core/SoilBTreeHeaderPage.class.st
@@ -25,6 +25,11 @@ SoilBTreeHeaderPage >> nextPageIndex [
 	^ lastPageIndex 
 ]
 
+{ #category : #printing }
+SoilBTreeHeaderPage >> printOn: aStream [ 
+	aStream << 'header page : #' << index asString
+]
+
 { #category : #writing }
 SoilBTreeHeaderPage >> readFrom: aStream [ 
 	dirty := false.

--- a/src/Soil-Core/SoilBTreeIndexPage.class.st
+++ b/src/Soil-Core/SoilBTreeIndexPage.class.st
@@ -21,7 +21,7 @@ SoilBTreeIndexPage >> findPageFor: aKey with: aBTree [
 	items
 		reverseDo: [ :each |
 			each key <= aKey 
-				ifTrue: [ ^ aBTree pageAt: each value asInteger ] ].
+				ifTrue: [ ^ aBTree pageAt: each value ] ].
 	^nil
 ]
 
@@ -32,19 +32,25 @@ SoilBTreeIndexPage >> headerSize [
 
 { #category : #accessing }
 SoilBTreeIndexPage >> insert: anItem into: aBtree [
-	| indexPage newPage indexItem |
+	| indexPage newPage indexItem newIndexPage  |
 	indexPage := self findPageFor: anItem key with: aBtree.
 	indexPage ifNil: [ ^nil ]. "nothing to do"
 	newPage := indexPage insert: anItem into: aBtree.
 	newPage ifNil: [ ^nil ]. "nothing to do"
 	
-	indexItem := newPage smallestKey -> (newPage index asByteArrayOfSize: 2).
+	indexItem := newPage smallestKey -> newPage index.
 	"if the insert resulted in a split, we have to update the index, which might habe to split, too"
 	self hasRoom ifTrue: [ self addItem: indexItem . ^ nil ].
-	newPage := aBtree splitIndexPage: self.
+	newIndexPage := aBtree splitIndexPage: self.				
+	((newIndexPage smallestKey <= anItem key) 
+		ifTrue: [ newIndexPage ] 
+		ifFalse: [ self ]) addItem: indexItem.
+	^newIndexPage
+]
 
-	self addItem: indexItem.
-	^newPage
+{ #category : #printing }
+SoilBTreeIndexPage >> printOn: aStream [ 
+	aStream << 'index page : #' << index asString
 ]
 
 { #category : #reading }
@@ -60,16 +66,15 @@ SoilBTreeIndexPage >> readFrom: aStream [
 SoilBTreeIndexPage >> readItemsFrom: aStream [ 
 	| numberOfItems |
 	
-	self flag: #fixme. "duplicated code from superclass, should not be needed if valueSize is correct"
 	numberOfItems := (aStream next: self itemsSizeSize) asInteger.
 	items := SortedCollection new: numberOfItems.
 	numberOfItems timesRepeat: [ 
-		items add: (aStream next: self keySize) asInteger -> (aStream next: 2) ]
+		items add: (aStream next: self keySize) asInteger -> (aStream next: 2) asInteger ]
 ]
 
 { #category : #writing }
 SoilBTreeIndexPage >> writeItemsOn: aStream [ 
-	self flag: #fixme. "duplicated code from superclass, should not be needed if valueSize is correct"
+
 	aStream
 		nextPutAll: (items size asByteArrayOfSize: self itemsSizeSize).
 	items do: [ :assoc |

--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -103,6 +103,15 @@ SoilBTreePage >> itemRemoveAt: anInteger ifAbsent: aBlock [
 ]
 
 { #category : #accessing }
+SoilBTreePage >> itemRemoveIndex: anInteger [
+	| item |
+	item := items at: anInteger.
+	items removeAt: anInteger.
+	dirty := true.
+	^ item
+]
+
+{ #category : #accessing }
 SoilBTreePage >> items [
 	^ items
 ]

--- a/src/Soil-Core/SoilBTreeRootPage.class.st
+++ b/src/Soil-Core/SoilBTreeRootPage.class.st
@@ -12,27 +12,38 @@ SoilBTreeRootPage class >> pageCode [
 { #category : #initialization }
 SoilBTreeRootPage >> initialize [
 	super initialize.
-	self addItem: 0 -> (1 asByteArrayOfSize: 2) "headPage id"
+	self addItem: 0 -> 1 "headPage id"
 ]
 
 { #category : #accessing }
 SoilBTreeRootPage >> insert: anItem into: aBtree [
-	| indexPage newPage indexItem newPage2 |
+	| indexPage newPage indexItem newIndexPage1 newIndexPage2 |
 		
 	indexPage := self findPageFor: anItem key with: aBtree.
 	indexPage ifNil: [ ^nil ]. "nothing to do"
 	newPage := indexPage insert: anItem into: aBtree.
 	newPage ifNil: [ ^nil ]. "nothing to do"
 	
-	indexItem := newPage smallestKey -> (newPage index asByteArrayOfSize: 2).
+	indexItem := newPage smallestKey -> newPage index.
 	"if the insert resulted in a split, we have to update the index, which might habe to split, too"
 	self hasRoom ifTrue: [ self addItem: indexItem . ^ nil ].
-	newPage := aBtree splitIndexPage: self.
+	newIndexPage1 := aBtree splitIndexPage: self.
 	"we are the root index page, thus we have to create another index page and move items there"
-	newPage2 := aBtree newIndexPageFromRoot: self.
+	newIndexPage2 := aBtree newIndexPageFromRoot: self.
 	
-	"here now add entries for newPage2 and newPage to self"
-	self addItem: indexItem.
-	self addItem: newPage2 smallestKey -> (newPage2 index asByteArrayOfSize: 2).
+	"here now add entries for newIndexPage1 and newIndexPage2 to self"
+	self addItem: newIndexPage1 smallestKey -> newIndexPage1 index.
+	self addItem: newIndexPage2 smallestKey -> newIndexPage2 index.
+	
+	"and add the indexItem to one of the two"
+	((newIndexPage1 smallestKey <= anItem key) 
+		ifTrue: [ newIndexPage1 ] 
+		ifFalse: [ newIndexPage2 ]) addItem: indexItem.
+
 	^nil
+]
+
+{ #category : #printing }
+SoilBTreeRootPage >> printOn: aStream [ 
+	aStream << 'root index page : #' << index asString
 ]

--- a/src/Soil-Core/SoilSkipListDataPage.class.st
+++ b/src/Soil-Core/SoilSkipListDataPage.class.st
@@ -42,9 +42,7 @@ SoilSkipListDataPage >> firstItem [
 
 { #category : #testing }
 SoilSkipListDataPage >> hasItems [
-	self flag: #todo.
-	"need to filter lowest and highest key and check for zero"
-	^ items size > 2
+	^ items notEmpty
 ]
 
 { #category : #testing }


### PR DESCRIPTION
- add a test where a non-root index page is split
- add more reload tests
- fix insertion 
- improve printOn: for Btree pages
- do not use ByteArrays but integers as values in the index (this is the page number)

fixes #268