### PR TITLE
#first for BTree and more tests BTree/SkipList

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -177,6 +177,20 @@ SoilBTreeTest >> testCreation [
 ]
 
 { #category : #tests }
+SoilBTreeTest >> testFirst [
+	
+	| capacity |
+	capacity := btree headerPage itemCapacity * 2.
+
+	2 to: capacity do: [ :n |
+		btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	btree at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: btree pages size equals: 4.
+	self assert: btree first equals: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: (btree first: 2) second equals: #[ 1 2 3 4 5 6 7 8 ].
+]
+
+{ #category : #tests }
 SoilBTreeTest >> testIsEmpty [
 	self assert: btree isEmpty.
 	btree at: 1 put: #[1 2].

--- a/src/Soil-Core-Tests/SoilSkipListDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListDictionaryTest.class.st
@@ -166,6 +166,19 @@ SoilSkipListDictionaryTest >> testFirst [
 ]
 
 { #category : #tests }
+SoilSkipListDictionaryTest >> testIsEmpty [
+	| dict |
+	dict := SoilSkipListDictionary new
+		keySize: 10;
+		maxLevel: 8;
+		yourself.
+		
+	self assert: dict isEmpty.
+	dict at: #foo put: #bar.
+	self deny: dict isEmpty
+]
+
+{ #category : #tests }
 SoilSkipListDictionaryTest >> testLast [
 	| dict |
 	dict := SoilSkipListDictionary new

--- a/src/Soil-Core-Tests/SoilSkipListTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListTest.class.st
@@ -135,6 +135,22 @@ SoilSkipListTest >> testCreation [
 ]
 
 { #category : #tests }
+SoilSkipListTest >> testDo [
+	
+	| capacity col |
+	capacity := skipList firstPage itemCapacity.
+	skipList at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
+	2 to: capacity do: [ :n |
+		skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	skipList at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: skipList pages size equals: 2.
+	col := OrderedCollection new.
+	skipList do: [ :item | col add: item ].
+	self assert: col first equals: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: col size equals: capacity + 1
+]
+
+{ #category : #tests }
 SoilSkipListTest >> testFindKey [
 	| value |
 	1 to: 200 do: [ :n |
@@ -154,26 +170,24 @@ SoilSkipListTest >> testFindKeyReverse [
 ]
 
 { #category : #tests }
+SoilSkipListTest >> testFirst [
+	
+	| capacity |
+	capacity := skipList firstPage itemCapacity * 2.
+
+	2 to: capacity do: [ :n |
+		skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	skipList at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: skipList pages size equals: 3.
+	self assert: skipList first equals: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: (skipList first: 2) second equals: #[ 1 2 3 4 5 6 7 8 ].
+]
+
+{ #category : #tests }
 SoilSkipListTest >> testIsEmpty [
 	self assert: skipList isEmpty.
 	skipList at: 1 put: #[1 2].
 	self deny: skipList isEmpty
-]
-
-{ #category : #tests }
-SoilSkipListTest >> testIteratorDo [
-	
-	| capacity col |
-	capacity := skipList firstPage itemCapacity.
-	skipList at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
-	2 to: capacity do: [ :n |
-		skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	skipList at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: skipList pages size equals: 2.
-	col := OrderedCollection new.
-	skipList newIterator do: [ :item | col add: item ].
-	self assert: col first equals: #[ 8 7 6 5 4 3 2 1 ].
-	self assert: col size equals: capacity + 1
 ]
 
 { #category : #tests }
@@ -189,19 +203,6 @@ SoilSkipListTest >> testIteratorFindAndNext [
 		find: 222;
 		next.
 	self assert: value equals: (223 asByteArrayOfSize: 8)
-]
-
-{ #category : #tests }
-SoilSkipListTest >> testIteratorFirst [
-	
-	| capacity first |
-	capacity := skipList firstPage itemCapacity * 2.
-	skipList at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
-	2 to: capacity do: [ :n |
-		skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	self assert: skipList pages size equals: 3.
-	first := skipList newIterator first.
-	self assert: first equals: #[ 8 7 6 5 4 3 2 1 ]
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/SoilBTree.class.st
+++ b/src/Soil-Core/SoilBTree.class.st
@@ -47,6 +47,23 @@ SoilBTree >> find: aString [
 ]
 
 { #category : #accessing }
+SoilBTree >> first [
+	^ self newIterator first
+]
+
+{ #category : #accessing }
+SoilBTree >> first: anInteger [ 
+	| iterator col |
+	iterator := self newIterator.
+	col := OrderedCollection new.
+	anInteger timesRepeat: [ 
+		(iterator next)
+			ifNotNil: [ :value | col add: value ]
+			ifNil: [ ^ col ]].
+	^ col
+]
+
+{ #category : #accessing }
 SoilBTree >> headerPage [
 	^ self store headerPage
 ]

--- a/src/Soil-Core/SoilBasicSkipList.class.st
+++ b/src/Soil-Core/SoilBasicSkipList.class.st
@@ -67,6 +67,11 @@ SoilBasicSkipList >> find: aString [
 ]
 
 { #category : #accessing }
+SoilBasicSkipList >> first [
+	^ self newIterator first
+]
+
+{ #category : #accessing }
 SoilBasicSkipList >> first: anInteger [ 
 	| iterator col |
 	iterator := self newIterator.
@@ -76,11 +81,6 @@ SoilBasicSkipList >> first: anInteger [
 			ifNotNil: [ :value | col add: value ]
 			ifNil: [ ^ col ]].
 	^ col
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> firstItem [
-	^ self headerPage firstItem
 ]
 
 { #category : #accessing }
@@ -98,7 +98,7 @@ SoilBasicSkipList >> isEmpty [
 	^ self store headerPage hasItems not
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SoilBasicSkipList >> isRegistered [
 	^ self subclassResponsibility
 ]
@@ -200,6 +200,11 @@ SoilBasicSkipList >> store [
 SoilBasicSkipList >> store: anObject [
 	anObject index: self.
 	store := anObject
+]
+
+{ #category : #'as yet unclassified' }
+SoilBasicSkipList >> thePersistentInstance [
+	^ self subclassResponsibility
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilPagedIndexStore.class.st
+++ b/src/Soil-Core/SoilPagedIndexStore.class.st
@@ -47,7 +47,7 @@ SoilPagedIndexStore >> isCopyOnWrite [
 	^ false
 ]
 
-{ #category : #acessing }
+{ #category : #accessing }
 SoilPagedIndexStore >> lastPageIndex [
 	^ self headerPage lastPageIndex
 ]
@@ -55,11 +55,6 @@ SoilPagedIndexStore >> lastPageIndex [
 { #category : #'instance creation' }
 SoilPagedIndexStore >> newPage [
 	^ index newPage
-]
-
-{ #category : #accessing }
-SoilPagedIndexStore >> nextIndex [
-	^ pages size + 1
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Soil-Core/SoilSkipListDataPage.class.st
+++ b/src/Soil-Core/SoilSkipListDataPage.class.st
@@ -11,7 +11,8 @@ Class {
 }
 
 { #category : #testing }
-SoilSkipListDataPage class >> isAbstract [ 
+SoilSkipListDataPage class >> isAbstract [
+	<ignoreForCoverage>
 	^ self == SoilSkipListDataPage 
 ]
 

--- a/src/Soil-Core/SoilSkipListDictionary.class.st
+++ b/src/Soil-Core/SoilSkipListDictionary.class.st
@@ -74,7 +74,7 @@ SoilSkipListDictionary >> do: aBlock [
 { #category : #accessing }
 SoilSkipListDictionary >> first [
 	^ transaction 
-		ifNotNil: [ self proxyFromByteArray: self index firstItem value ]
+		ifNotNil: [ self proxyFromByteArray: self index first ]
 		ifNil: [ newValues associations first value ]
 ]
 


### PR DESCRIPTION
- implement #first and first: for BTree / tests
- implement #first for Skiplist, remove #firstItem (it is on the iterator)
- some recategorizations
- test #isEmpty for SoilSkipListDictionaryTest
- SoilSkipListTest: test do and #first on th SkipList, which uses the iterator, not the iterator

- remove unused #nextIndex