### PR TITLE
 BTree: do not have valueSize in Index, never store keySize/valueSize other then header page, fix loading SkipList

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreePageTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreePageTest.class.st
@@ -37,7 +37,7 @@ SoilBTreePageTest >> testWriteAndRead [
 	bytes := ByteArray streamContents: [ :stream |
 		page writeOn: stream ].
 	self deny: page isDirty.
-	readPage := SoilBTreePage readPageFrom: bytes readStream keySize: 8.
+	readPage := SoilBTreePage readPageFrom: bytes readStream keySize: 8 valueSize: 8.
 	self assert: readPage next equals: page next.
 	self assert: readPage valueSize equals: page valueSize.
 	self assert: readPage keySize equals: page keySize.
@@ -56,7 +56,7 @@ SoilBTreePageTest >> testWriteAndReadIndex [
 	bytes := ByteArray streamContents: [ :stream |
 		page writeOn: stream ].
 	self deny: page isDirty.
-	readPage := SoilBTreePage readPageFrom: bytes readStream.
+	readPage := SoilBTreePage readPageFrom: bytes readStream keySize: 8 valueSize: 8.
 	self assert: readPage index equals: 1.
 	self deny: readPage isDirty
 ]
@@ -73,7 +73,7 @@ SoilBTreePageTest >> testWriteAndReadPageCode [
 	bytes := ByteArray streamContents: [ :stream |
 		page writeOn: stream ].
 	self deny: page isDirty.
-	readPage := SoilBTreePage readPageFrom: bytes readStream keySize: 8.
+	readPage := SoilBTreePage readPageFrom: bytes readStream keySize: 8 valueSize: 8.
 	self assert: readPage next equals: page next.
 	self assert: readPage valueSize equals: page valueSize.
 	self assert: readPage keySize equals: page keySize.

--- a/src/Soil-Core-Tests/SoilBTreePageTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreePageTest.class.st
@@ -37,7 +37,7 @@ SoilBTreePageTest >> testWriteAndRead [
 	bytes := ByteArray streamContents: [ :stream |
 		page writeOn: stream ].
 	self deny: page isDirty.
-	readPage := SoilBTreePage readPageFrom: bytes readStream.
+	readPage := SoilBTreePage readPageFrom: bytes readStream keySize: 8.
 	self assert: readPage next equals: page next.
 	self assert: readPage valueSize equals: page valueSize.
 	self assert: readPage keySize equals: page keySize.
@@ -73,7 +73,7 @@ SoilBTreePageTest >> testWriteAndReadPageCode [
 	bytes := ByteArray streamContents: [ :stream |
 		page writeOn: stream ].
 	self deny: page isDirty.
-	readPage := SoilBTreePage readPageFrom: bytes readStream.
+	readPage := SoilBTreePage readPageFrom: bytes readStream keySize: 8.
 	self assert: readPage next equals: page next.
 	self assert: readPage valueSize equals: page valueSize.
 	self assert: readPage keySize equals: page keySize.

--- a/src/Soil-Core-Tests/SoilBTreePageTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreePageTest.class.st
@@ -21,8 +21,7 @@ SoilBTreePageTest >> testCreationIndex [
 	page := SoilBTreeIndexPage new 
 		index: 1;
 		pageSize: 4096;
-		keySize: 16;
-		valueSize: 8.
+		keySize: 16.
 	self assert: page hasRoom
 ]
 
@@ -52,7 +51,6 @@ SoilBTreePageTest >> testWriteAndReadIndex [
 	| page bytes readPage |
 	page := SoilBTreeIndexPage new 
 		index: 1;
-		valueSize: 8;
 		keySize: 8.
 	self assert: page isDirty.
 	bytes := ByteArray streamContents: [ :stream |

--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -363,18 +363,18 @@ SoilBTreeTest >> testSplitRootIndexPage [
 	[btree rootPage hasRoom] whileTrue: [
 		btree at: n put: #[ 1 2 3 4 5 6 7 8 ].
 		n:= n+1. ].
-	self assert: btree pages size equals: 256.
+	self assert: btree pages size equals: 410.
 	
 	"if we lots of more pages, the root index has to be split"
 	1 to: capacity do: [ :i | btree at:  i + n put: #[ 1 2 3 4 5 6 7 8 ]].
 	
-	self assert: btree pages size equals: 259.
+	self assert: btree pages size equals: 413.
 	indexPages := btree pages values select: [ :each | each isKindOf: SoilBTreeIndexPage ].
 	"we now have indeed three index pages"
 	self assert: indexPages size equals: 3.
-	self assert: btree rootPage equals: indexPages second.
+	self assert: btree rootPage equals: indexPages third.
 	"the root page now points to the new index page"
-	self assert: (btree rootPage items anySatisfy: [ :item | item value asInteger = indexPages third index ]).
+	self assert: (btree rootPage items anySatisfy: [ :item | item value asInteger = indexPages first index ]).
 	"and we can find the key added last"
 	self assert: (btree at: capacity + n ) equals:  #[ 1 2 3 4 5 6 7 8 ]
 ]
@@ -388,7 +388,7 @@ SoilBTreeTest >> testSplitRootIndexPageReload [
 	[btree rootPage hasRoom] whileTrue: [
 		btree at: n put: #[ 1 2 3 4 5 6 7 8 ].
 		n:= n+1. ].
-	self assert: btree pages size equals: 256.
+	self assert: btree pages size equals: 410.
 	
 	"if we lots of more pages, the root index has to be split"
 	1 to: capacity do: [ :i | btree at:  i + n put: #[ 1 2 3 4 5 6 7 8 ]].

--- a/src/Soil-Core-Tests/SoilSkipListPageTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListPageTest.class.st
@@ -27,7 +27,7 @@ SoilSkipListPageTest >> testWriteAndRead [
 	bytes := ByteArray streamContents: [ :stream |
 		page writeOn: stream ].
 	self deny: page isDirty.
-	readPage := SoilSkipListPage readPageFrom: bytes readStream.
+	readPage := SoilSkipListPage readPageFrom: bytes readStream keySize: 8 valueSize: 8.
 	self assert: readPage index equals: 1.
 	self assert: readPage level equals: 8.
 	self deny: readPage isDirty 
@@ -44,7 +44,7 @@ SoilSkipListPageTest >> testWriteAndReadRightArray [
 	bytes := ByteArray streamContents: [ :stream |
 		page writeOn: stream ].
 	self deny: page isDirty.
-	readPage := SoilSkipListPage readPageFrom: bytes readStream.
+	readPage := SoilSkipListPage readPageFrom: bytes readStream keySize: 8 valueSize: 8. 
 	self assert: readPage index equals: 1.
 	self assert: readPage level equals: 8.
 	self assert: readPage right equals: #( 1 2 3 4 5 6 7 8).

--- a/src/Soil-Core-Tests/SoilSkipListTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListTest.class.st
@@ -44,6 +44,32 @@ SoilSkipListTest >> testAddFirstOverflow [
 ]
 
 { #category : #tests }
+SoilSkipListTest >> testAddFirstOverflowReload [
+	
+	| page capacity |
+	capacity := skipList firstPage itemCapacity.
+	1 to: capacity do: [ :n | 
+		skipList at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+	self assert: skipList pages size equals: 1.
+	skipList at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: skipList pages size equals: 2.
+	page := skipList pageAt: 2.
+	self assert: page numberOfItems equals: 128.
+	self assert: page items first key equals: 129.
+	self assert: page items last key asByteArray equals: #[ 1 0 ].
+	
+	"write it and then read it back with a new SoilSkipList"
+	skipList writePages.
+	skipList close.
+	skipList := SoilSkipList new 
+		path: 'sunit-skiplist';
+		initializeFilesystem;
+		open.
+	"we should be able to do a lookup"
+	self assert: ((skipList at: capacity) asByteArrayOfSize: 8) equals: #[ 1 2 3 4 5 6 7 8 ].
+]
+
+{ #category : #tests }
 SoilSkipListTest >> testAddInBetween [
 	
 	| page capacity |

--- a/src/Soil-Core/SoilBTree.class.st
+++ b/src/Soil-Core/SoilBTree.class.st
@@ -91,6 +91,7 @@ SoilBTree >> keySize [
 { #category : #accessing }
 SoilBTree >> keySize: anInteger [
 	self headerPage keySize: anInteger.
+	"we have to set the keySize of the rootPage, too, as the page gets created before the keySize is known"
 	self rootPage keySize: anInteger
 ]
 
@@ -194,7 +195,7 @@ SoilBTree >> path: aStringOrFileReference [
 
 { #category : #'instance creation' }
 SoilBTree >> readPageFrom: aStream [
-	^ SoilBTreePage readPageFrom: aStream
+	^ SoilBTreePage readPageFrom: aStream keySize: self keySize
 ]
 
 { #category : #removing }

--- a/src/Soil-Core/SoilBTree.class.st
+++ b/src/Soil-Core/SoilBTree.class.st
@@ -117,7 +117,6 @@ SoilBTree >> newHeaderPage [
 SoilBTree >> newIndexPage [
 	^ SoilBTreeIndexPage new 
 		keySize: self keySize;
-		valueSize: self valueSize;
 		pageSize: self pageSize;
 		yourself
 ]
@@ -152,7 +151,6 @@ SoilBTree >> newPage [
 SoilBTree >> newRootPage [
 	^ SoilBTreeRootPage new
 		index: 2;
-		valueSize: self valueSize;
 		keySize: self keySize;
 		pageSize: self pageSize
 ]
@@ -261,8 +259,7 @@ SoilBTree >> valueSize [
 
 { #category : #accessing }
 SoilBTree >> valueSize: anInteger [
-	self headerPage valueSize: anInteger.
-	self rootPage valueSize: anInteger
+	self headerPage valueSize: anInteger
 ]
 
 { #category : #writing }

--- a/src/Soil-Core/SoilBTree.class.st
+++ b/src/Soil-Core/SoilBTree.class.st
@@ -195,7 +195,7 @@ SoilBTree >> path: aStringOrFileReference [
 
 { #category : #'instance creation' }
 SoilBTree >> readPageFrom: aStream [
-	^ SoilBTreePage readPageFrom: aStream keySize: self keySize
+	^ SoilBTreePage readPageFrom: aStream keySize: self keySize valueSize: self valueSize
 ]
 
 { #category : #removing }

--- a/src/Soil-Core/SoilBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilBTreeDataPage.class.st
@@ -89,17 +89,15 @@ SoilBTreeDataPage >> nextPageIn: btree [
 	^btree pageAt: next
 ]
 
-{ #category : #'instance creation' }
+{ #category : #'reading-writing' }
 SoilBTreeDataPage >> readFrom: aStream [ 
 	super readFrom: aStream.
-	self readNextFrom: aStream.
-	keySize := (aStream next: 2) asInteger.
-	valueSize := (aStream next: 2) asInteger.
-
-	self readItemsFrom: aStream
+	self 
+		readNextFrom: aStream;
+		readItemsFrom: aStream
 ]
 
-{ #category : #'instance creation' }
+{ #category : #'reading-writing' }
 SoilBTreeDataPage >> readNextFrom: aStream [
 	
 	next := (aStream next: self pointerSize) asInteger.
@@ -115,14 +113,16 @@ SoilBTreeDataPage >> valueSize: anInteger [
 	valueSize := anInteger 
 ]
 
-{ #category : #writing }
+{ #category : #'reading-writing' }
+SoilBTreeDataPage >> writeNextOn: aStream [
+	aStream
+		nextPutAll: (next asByteArrayOfSize: self pointerSize)
+]
+
+{ #category : #'reading-writing' }
 SoilBTreeDataPage >> writeOn: aStream [ 
 	super writeOn: aStream.
-	aStream
-		nextPutAll: (next asByteArrayOfSize: self pointerSize);
-		nextPutAll: (keySize asByteArrayOfSize: 2);
-		nextPutAll: (valueSize asByteArrayOfSize: 2).
-		
 	self 
+		writeNextOn: aStream;
 		writeItemsOn: aStream
 ]

--- a/src/Soil-Core/SoilBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilBTreeDataPage.class.st
@@ -2,7 +2,8 @@ Class {
 	#name : #SoilBTreeDataPage,
 	#superclass : #SoilBTreePage,
 	#instVars : [
-		'next'
+		'next',
+		'valueSize'
 	],
 	#category : #'Soil-Core-Index-BTree'
 }
@@ -88,11 +89,6 @@ SoilBTreeDataPage >> nextPageIn: btree [
 	^btree pageAt: next
 ]
 
-{ #category : #accessing }
-SoilBTreeDataPage >> pointerSize [
-	^ 2
-]
-
 { #category : #'instance creation' }
 SoilBTreeDataPage >> readFrom: aStream [ 
 	super readFrom: aStream.
@@ -107,6 +103,16 @@ SoilBTreeDataPage >> readFrom: aStream [
 SoilBTreeDataPage >> readNextFrom: aStream [
 	
 	next := (aStream next: self pointerSize) asInteger.
+]
+
+{ #category : #accessing }
+SoilBTreeDataPage >> valueSize [ 
+	^ valueSize
+]
+
+{ #category : #accessing }
+SoilBTreeDataPage >> valueSize: anInteger [ 
+	valueSize := anInteger 
 ]
 
 { #category : #writing }

--- a/src/Soil-Core/SoilBTreeIndexPage.class.st
+++ b/src/Soil-Core/SoilBTreeIndexPage.class.st
@@ -76,7 +76,7 @@ SoilBTreeIndexPage >> readItemsFrom: aStream [
 
 { #category : #accessing }
 SoilBTreeIndexPage >> valueSize: anInteger [
-	"ignore, not used"
+	"ignore, not used, the index pages store the pageID as the value, size is static defined in #pointerSize"
 ]
 
 { #category : #'reading-writing' }
@@ -93,6 +93,5 @@ SoilBTreeIndexPage >> writeItemsOn: aStream [
 { #category : #'reading-writing' }
 SoilBTreeIndexPage >> writeOn: aStream [ 
 	super writeOn: aStream.
-	self 
-		writeItemsOn: aStream
+	self writeItemsOn: aStream
 ]

--- a/src/Soil-Core/SoilBTreeIndexPage.class.st
+++ b/src/Soil-Core/SoilBTreeIndexPage.class.st
@@ -58,15 +58,13 @@ SoilBTreeIndexPage >> printOn: aStream [
 	aStream << 'index page : #' << index asString
 ]
 
-{ #category : #reading }
+{ #category : #'reading-writing' }
 SoilBTreeIndexPage >> readFrom: aStream [ 
 	super readFrom: aStream.
-	keySize := (aStream next: 2) asInteger.
-
 	self readItemsFrom: aStream
 ]
 
-{ #category : #writing }
+{ #category : #'reading-writing' }
 SoilBTreeIndexPage >> readItemsFrom: aStream [ 
 	| numberOfItems |
 	
@@ -76,7 +74,7 @@ SoilBTreeIndexPage >> readItemsFrom: aStream [
 		items add: (aStream next: self keySize) asInteger -> (aStream next: self pointerSize) asInteger ]
 ]
 
-{ #category : #writing }
+{ #category : #'reading-writing' }
 SoilBTreeIndexPage >> writeItemsOn: aStream [ 
 
 	aStream
@@ -87,11 +85,9 @@ SoilBTreeIndexPage >> writeItemsOn: aStream [
 			nextPutAll: (assoc value asByteArrayOfSize: self pointerSize)]
 ]
 
-{ #category : #writing }
+{ #category : #'reading-writing' }
 SoilBTreeIndexPage >> writeOn: aStream [ 
 	super writeOn: aStream.
-	aStream
-		nextPutAll: (keySize asByteArrayOfSize: 2).
 	self 
 		writeItemsOn: aStream
 ]

--- a/src/Soil-Core/SoilBTreeIndexPage.class.st
+++ b/src/Soil-Core/SoilBTreeIndexPage.class.st
@@ -25,6 +25,11 @@ SoilBTreeIndexPage >> findPageFor: aKey with: aBTree [
 	^nil
 ]
 
+{ #category : #testing }
+SoilBTreeIndexPage >> hasRoom [
+	^ self headerSize + ((items size + 1) * (self keySize + self pointerSize)) <= self pageSize
+]
+
 { #category : #utilities }
 SoilBTreeIndexPage >> headerSize [
 	^ self indexSize
@@ -57,7 +62,6 @@ SoilBTreeIndexPage >> printOn: aStream [
 SoilBTreeIndexPage >> readFrom: aStream [ 
 	super readFrom: aStream.
 	keySize := (aStream next: 2) asInteger.
-	valueSize := (aStream next: 2) asInteger.
 
 	self readItemsFrom: aStream
 ]
@@ -69,7 +73,7 @@ SoilBTreeIndexPage >> readItemsFrom: aStream [
 	numberOfItems := (aStream next: self itemsSizeSize) asInteger.
 	items := SortedCollection new: numberOfItems.
 	numberOfItems timesRepeat: [ 
-		items add: (aStream next: self keySize) asInteger -> (aStream next: 2) asInteger ]
+		items add: (aStream next: self keySize) asInteger -> (aStream next: self pointerSize) asInteger ]
 ]
 
 { #category : #writing }
@@ -80,15 +84,14 @@ SoilBTreeIndexPage >> writeItemsOn: aStream [
 	items do: [ :assoc |
 		aStream 
 			nextPutAll: (assoc key asByteArrayOfSize: self keySize);
-			nextPutAll: (assoc value asByteArrayOfSize: 2)]
+			nextPutAll: (assoc value asByteArrayOfSize: self pointerSize)]
 ]
 
 { #category : #writing }
 SoilBTreeIndexPage >> writeOn: aStream [ 
 	super writeOn: aStream.
 	aStream
-		nextPutAll: (keySize asByteArrayOfSize: 2);
-		nextPutAll: (valueSize asByteArrayOfSize: 2).
+		nextPutAll: (keySize asByteArrayOfSize: 2).
 	self 
 		writeItemsOn: aStream
 ]

--- a/src/Soil-Core/SoilBTreeIndexPage.class.st
+++ b/src/Soil-Core/SoilBTreeIndexPage.class.st
@@ -74,6 +74,11 @@ SoilBTreeIndexPage >> readItemsFrom: aStream [
 		items add: (aStream next: self keySize) asInteger -> (aStream next: self pointerSize) asInteger ]
 ]
 
+{ #category : #accessing }
+SoilBTreeIndexPage >> valueSize: anInteger [
+	"ignore, not used"
+]
+
 { #category : #'reading-writing' }
 SoilBTreeIndexPage >> writeItemsOn: aStream [ 
 

--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -14,6 +14,16 @@ SoilBTreePage class >> pageCode [
 	^0
 ]
 
+{ #category : #'as yet unclassified' }
+SoilBTreePage class >> readPageFrom: aStream keySize: anInteger [
+	| pageCode pageClass page |
+	pageCode := aStream next asInteger.
+	pageClass := self allSubclasses detect: [ :class | class pageCode = pageCode ].
+	page := pageClass new.
+	page keySize: anInteger.
+	^page readFrom: aStream.
+]
+
 { #category : #adding }
 SoilBTreePage >> addItem: anAssociation [ 
 	items add: anAssociation.

--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -14,17 +14,6 @@ SoilBTreePage class >> pageCode [
 	^0
 ]
 
-{ #category : #'instance creation' }
-SoilBTreePage class >> readPageFrom: aStream keySize: anInteger [
-	| pageCode pageClass page |
-	pageCode := aStream next asInteger.
-	pageClass := self allSubclasses detect: [ :class | class pageCode = pageCode ].
-	page := pageClass new.
-	page keySize: anInteger.
-	page valueSize: anInteger.
-	^page readFrom: aStream.
-]
-
 { #category : #adding }
 SoilBTreePage >> addItem: anAssociation [ 
 	items add: anAssociation.

--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -3,8 +3,7 @@ Class {
 	#superclass : #SoilSkipListPage,
 	#instVars : [
 		'items',
-		'keySize',
-		'valueSize'
+		'keySize'
 	],
 	#category : #'Soil-Core-Index-BTree'
 }
@@ -31,6 +30,11 @@ SoilBTreePage >> associationAt: anInteger [
 { #category : #accessing }
 SoilBTreePage >> biggestKey [
 	^ items last key
+]
+
+{ #category : #'as yet unclassified' }
+SoilBTreePage >> find: aKey with: aBTree [ 
+	^ self subclassResponsibility
 ]
 
 { #category : #accessing }
@@ -60,6 +64,11 @@ SoilBTreePage >> initialize [
 	super initialize.
 	items := SortedCollection new.
 	dirty := true
+]
+
+{ #category : #'as yet unclassified' }
+SoilBTreePage >> insert: anItem into: aBtree [ 
+	^ self subclassResponsibility
 ]
 
 { #category : #testing }
@@ -134,6 +143,11 @@ SoilBTreePage >> numberOfItems [
 	^ items size
 ]
 
+{ #category : #accessing }
+SoilBTreePage >> pointerSize [
+	^ 2
+]
+
 { #category : #reading }
 SoilBTreePage >> readItemsFrom: aStream [ 
 	| numberOfItems |
@@ -169,16 +183,6 @@ SoilBTreePage >> split: newPage [
 { #category : #accessing }
 SoilBTreePage >> valueAt: anInteger [ 
 	^ (self associationAt: anInteger) value
-]
-
-{ #category : #accessing }
-SoilBTreePage >> valueSize [ 
-	^ valueSize
-]
-
-{ #category : #accessing }
-SoilBTreePage >> valueSize: anInteger [ 
-	valueSize := anInteger 
 ]
 
 { #category : #writing }

--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -14,13 +14,14 @@ SoilBTreePage class >> pageCode [
 	^0
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SoilBTreePage class >> readPageFrom: aStream keySize: anInteger [
 	| pageCode pageClass page |
 	pageCode := aStream next asInteger.
 	pageClass := self allSubclasses detect: [ :class | class pageCode = pageCode ].
 	page := pageClass new.
 	page keySize: anInteger.
+	page valueSize: anInteger.
 	^page readFrom: aStream.
 ]
 

--- a/src/Soil-Core/SoilSkipList.class.st
+++ b/src/Soil-Core/SoilSkipList.class.st
@@ -102,7 +102,7 @@ SoilSkipList >> path: aStringOrFileReference [
 
 { #category : #'instance creation' }
 SoilSkipList >> readPageFrom: aStream [
-	^ SoilSkipListPage readPageFrom: aStream
+	^ SoilSkipListPage readPageFrom: aStream keySize: self keySize valueSize: self valueSize
 ]
 
 { #category : #converting }

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -24,11 +24,14 @@ SoilSkipListPage class >> random [
 ]
 
 { #category : #'instance creation' }
-SoilSkipListPage class >> readPageFrom: aStream [
-	| pageCode pageClass |
+SoilSkipListPage class >> readPageFrom: aStream keySize: keySize valueSize: valueSize [
+	| pageCode pageClass page |
 	pageCode := aStream next asInteger.
 	pageClass := self allSubclasses detect: [ :class | class pageCode = pageCode ].
-	^pageClass new readFrom: aStream.
+	page := pageClass new.
+	page keySize: keySize.
+	page valueSize: valueSize.
+	^page readFrom: aStream.
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
The Index Pages of the B+tree have items of the form key->page Index, as such they do not care about valueSize