### PR TITLE
move SoilPagedIndexStore to the Index-Common

### DIFF
--- a/src/Soil-Core/SoilCopyOnWriteIndexStore.class.st
+++ b/src/Soil-Core/SoilCopyOnWriteIndexStore.class.st
@@ -4,10 +4,10 @@ Class {
 	#instVars : [
 		'wrappedStore'
 	],
-	#category : #'Soil-Core-Index-SkipList'
+	#category : #'Soil-Core-Index-Common'
 }
 
-{ #category : #accessing }
+{ #category : #flushing }
 SoilCopyOnWriteIndexStore >> flush [ 
 	^ wrappedStore flush
 ]

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -10,6 +10,12 @@ Class {
 	#category : #'Soil-Core-Index-Common'
 }
 
+{ #category : #testing }
+SoilIndexIterator class >> isAbstract [
+
+	^ self == SoilIndexIterator
+]
+
 { #category : #'instance creation' }
 SoilIndexIterator class >> on: aSoilIndex [
 	^ self new 

--- a/src/Soil-Core/SoilPagedFileIndexStore.class.st
+++ b/src/Soil-Core/SoilPagedFileIndexStore.class.st
@@ -5,7 +5,7 @@ Class {
 		'stream',
 		'streamSemaphore'
 	],
-	#category : #'Soil-Core-Index-SkipList'
+	#category : #'Soil-Core-Index-Common'
 }
 
 { #category : #converting }
@@ -14,7 +14,7 @@ SoilPagedFileIndexStore >> asCopyOnWriteStore [
 		wrappedStore: self
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #'open/close' }
 SoilPagedFileIndexStore >> close [ 
 	stream ifNotNil: [  
 		stream close.
@@ -27,12 +27,12 @@ SoilPagedFileIndexStore >> filePageSize [
 	^ 4096
 ]
 
-{ #category : #accessing }
+{ #category : #flushing }
 SoilPagedFileIndexStore >> flush [
 	self flushPages 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #flushing }
 SoilPagedFileIndexStore >> flushPages [
 	pagesMutex critical: [  
 		pages valuesDo: [ :page |
@@ -64,14 +64,14 @@ SoilPagedFileIndexStore >> initializeHeaderPage [
 		pages at: page index put: page	]
 ]
 
-{ #category : #'instance creation' }
+{ #category : #'open/close' }
 SoilPagedFileIndexStore >> open [
 	self 
 		openStream;
 		readHeaderPage 
 ]
 
-{ #category : #opening }
+{ #category : #'open/close' }
 SoilPagedFileIndexStore >> openStream [
 	stream := SoilLockableStream path: index path.
 ]
@@ -87,7 +87,7 @@ SoilPagedFileIndexStore >> pageFaultAt: anInteger [
 	^ page
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SoilPagedFileIndexStore >> pagesStart [
 	^ 4096
 ]
@@ -97,7 +97,7 @@ SoilPagedFileIndexStore >> positionOfPageIndex: anInteger [
 	^ ((anInteger - 1) * self filePageSize)
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #writing }
 SoilPagedFileIndexStore >> readHeaderPage [
 	| headerPage |
 	streamSemaphore critical: [  

--- a/src/Soil-Core/SoilPagedIndexStore.class.st
+++ b/src/Soil-Core/SoilPagedIndexStore.class.st
@@ -6,15 +6,20 @@ Class {
 		'index',
 		'pagesMutex'
 	],
-	#category : #'Soil-Core-Index-SkipList'
+	#category : #'Soil-Core-Index-Common'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
+SoilPagedIndexStore class >> isAbstract [
+	^ self == SoilPagedIndexStore
+]
+
+{ #category : #flushing }
 SoilPagedIndexStore >> flush [
 	^ self subclassResponsibility
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SoilPagedIndexStore >> headerPage [
 	^ self pageAt: 1
 ]
@@ -57,7 +62,7 @@ SoilPagedIndexStore >> newPage [
 	^ index newPage
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SoilPagedIndexStore >> nextPageIndex [
 	^ self headerPage nextPageIndex
 ]
@@ -78,7 +83,7 @@ SoilPagedIndexStore >> pageAt: anInteger put: aPage [
 			put: aPage ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SoilPagedIndexStore >> pageFaultAt: anInteger [ 
 	^ self subclassResponsibility
 ]


### PR DESCRIPTION
Just move some classes that are used by both BTree and Skiplist to common

-  tag as Abstract
-  categorize