### PR TITLE
 Serializer-nextPutBytesFrom 

### DIFF
--- a/src/Soil-Serializer/ByteLayout.extension.st
+++ b/src/Soil-Serializer/ByteLayout.extension.st
@@ -16,7 +16,7 @@ ByteLayout >> soilBasicSerialize: anObject with: serializer [
 	description := serializer serializeBehaviorDescriptionFor: anObject.
 	basicSize := anObject basicSize.
 
-	serializer nextPutLengthEncodedInteger: basicSize.
-	1 to: basicSize do: [:i |
-		serializer nextPutByte: (anObject at: i)]
+	serializer 
+		nextPutLengthEncodedInteger: basicSize;
+		nextPutBytesFrom: anObject
 ]

--- a/src/Soil-Serializer/SoilBasicSerializer.class.st
+++ b/src/Soil-Serializer/SoilBasicSerializer.class.st
@@ -9,18 +9,16 @@ Class {
 
 { #category : #'writing - basic' }
 SoilBasicSerializer >> basicNextPutString: aString [ 
-	| buf |
-	buf := aString asByteArray.
 	self
-		nextPutLengthEncodedInteger: buf size;
-		nextPutBytesFrom: buf
+		nextPutLengthEncodedInteger: aString size;
+		nextPutBytesFrom: aString
 ]
 
 { #category : #writing }
 SoilBasicSerializer >> basicNextPutSymbol: aSymbol [ 
 	self
 		nextPutLengthEncodedInteger: aSymbol size;
-		nextPutBytesFrom: aSymbol asByteArray
+		nextPutBytesFrom: aSymbol
 ]
 
 { #category : #initialization }
@@ -44,7 +42,7 @@ SoilBasicSerializer >> nextPutByteArray: aByteArray [
 
 { #category : #'writing - basic' }
 SoilBasicSerializer >> nextPutBytesFrom: aByteArray [
-	stream nextPutAll: aByteArray 
+	stream nextBytesPutAll: aByteArray 
 
 ]
 


### PR DESCRIPTION
use #nextBytesPutAll: when serializing bytes, this way we
- can change string and symbol writing to not use a buffer
- ByteLayout can use it instead of doing the loop itself