### PR TITLE
fix tests for serializing compiledMethods for pharo12

### DIFF
--- a/src/Soil-Serializer-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilSerializationTest.class.st
@@ -69,7 +69,7 @@ SoilSerializationTest >> testSerializationByteLayout [
 SoilSerializationTest >> testSerializationCleanBlockClosure [
 	<compilerOptions: #(+ optionCleanBlockClosure)>
 	| object serialized  materialized |
-	(SystemVersion current major == 11) ifFalse: [ self skip ].
+	(SystemVersion current major >= 11) ifFalse: [ self skip ].
 	object := [1+2].
 	
 	serialized := self serializeToBytes: object.
@@ -83,8 +83,8 @@ SoilSerializationTest >> testSerializationCleanBlockClosure [
 SoilSerializationTest >> testSerializationCompiledMethodLayout [
 
 	| object serialized materialized |
-	(SystemVersion current major == 11) ifFalse: [ self skip ].
 	"We use CompiledMethod as an exampe of a class with a CompiledMethodLayout"
+	(SystemVersion current major >= 11) ifFalse: [ self skip ].
 	object := (OrderedCollection >> #do:) copy.
 
 	self
@@ -104,7 +104,7 @@ SoilSerializationTest >> testSerializationCompiledMethodLayout [
 { #category : #'tests-layouts' }
 SoilSerializationTest >> testSerializationCompiledMethodLayoutCompiledBlock [
 	| object serialized materialized |
-	(SystemVersion current major == 11) ifFalse: [ self skip ].
+	(SystemVersion current major >= 11) ifFalse: [ self skip ].
  	"This tests CompiledBlock. we use a clean block for now"
  	object := [1+2 "clean block"] compiledBlock.
 
@@ -121,9 +121,8 @@ SoilSerializationTest >> testSerializationCompiledMethodLayoutCompiledBlock [
 
 { #category : #'test-blocks' }
 SoilSerializationTest >> testSerializationConstantBlockClosure [
-	<compilerOptions: #(+ optionConstantBlockClosure)>
 	| object serialized  materialized |
-	(SystemVersion current major == 11) ifFalse: [ self skip ].
+	(SystemVersion current major >= 11) ifFalse: [ self skip ].
 	object := [1].
 	
 	serialized := self serializeToBytes: object.

--- a/src/Soil-Serializer/SoilMaterializer.class.st
+++ b/src/Soil-Serializer/SoilMaterializer.class.st
@@ -118,7 +118,7 @@ SoilMaterializer >> nextCompiledBlock: aClass [
 { #category : #reading }
 SoilMaterializer >> nextCompiledMethod: aClass [
 
- 	| header bytecodesPlusTrailerSize compiledMethod |
+ 	| header bytecodesPlusTrailerSize compiledMethod trailerSize |
 
  	header :=  self nextSoilObject.
  	bytecodesPlusTrailerSize := self nextLengthEncodedInteger.
@@ -135,8 +135,12 @@ SoilMaterializer >> nextCompiledMethod: aClass [
  				compiledMethod literalAt: i  put: self nextSoilObject ].			
 
  	"then the bytecodes, we ignore the trailer for now"
+	trailerSize := 
+	(SystemVersion current major = 12)
+		ifFalse: [  compiledMethod trailer size ] 
+		ifTrue: [  CompiledMethod trailerSize ].
  	compiledMethod initialPC 
- 		to: compiledMethod size - compiledMethod trailer size
+ 		to: compiledMethod size - trailerSize
  		do: [ :index |
  			compiledMethod
  				at: index


### PR DESCRIPTION
- run tests on Pharo12
- remove optionConstantBlockClosure as the test is only run on Pharo11 and newer where it is the default
- fix trailerSize for Pharo12