### PR TITLE
311-SoilNewObjectEntrywriteOn-limits-the-size-of-objects

### DIFF
--- a/src/Soil-Core/SoilNewObjectEntry.class.st
+++ b/src/Soil-Core/SoilNewObjectEntry.class.st
@@ -73,7 +73,7 @@ SoilNewObjectEntry >> readFrom: aStream [
 	| bytesSize |
 	super readFrom: aStream.
 	objectId := SoilObjectId readFrom: aStream.
-	bytesSize := (aStream next: 2) asInteger.
+	bytesSize := (aStream next: 8) asInteger.
 	bytes := aStream next: bytesSize.
 ]
 
@@ -98,7 +98,7 @@ SoilNewObjectEntry >> value [
 SoilNewObjectEntry >> writeOn: aStream [ 
 	super writeOn: aStream.
 	objectId writeOn: aStream.
-	aStream nextPutAll: (bytes size asByteArrayOfSize: 2).
+	aStream nextPutAll: (bytes size asByteArrayOfSize: 8).
 	aStream 
 		nextPutAll: bytes
 	

--- a/src/Soil-Core/SoilNewObjectVersionEntry.class.st
+++ b/src/Soil-Core/SoilNewObjectVersionEntry.class.st
@@ -22,14 +22,14 @@ SoilNewObjectVersionEntry >> oldBytes: aCollection [
 SoilNewObjectVersionEntry >> readFrom: aStream [ 
 	| oldBytesSize |
 	super readFrom: aStream.
-	oldBytesSize := (aStream next: 2) asInteger.
+	oldBytesSize := (aStream next: 8) asInteger.
 	oldBytes := aStream next: oldBytesSize
 ]
 
 { #category : #writing }
 SoilNewObjectVersionEntry >> writeOn: aStream [ 
 	super writeOn: aStream.
-	aStream nextPutAll: (oldBytes size asByteArrayOfSize: 2).
+	aStream nextPutAll: (oldBytes size asByteArrayOfSize: 8).
 	aStream nextPutAll: oldBytes.
 	
 ]


### PR DESCRIPTION
fixes #311 by using full 64bit for the size. 

We should later check if we an not make length encoding easy usable with all streams and use it here (we do use length encoding to store the bytes in the serializer already).