### PR TITLE
319-SoilSkipListIteratoratifAbsent-should-use-currentKey-to-find-page

### DIFF
--- a/src/Soil-Core/SoilSkipListIterator.class.st
+++ b/src/Soil-Core/SoilSkipListIterator.class.st
@@ -8,10 +8,10 @@ Class {
 }
 
 { #category : #private }
-SoilSkipListIterator >> at: key ifAbsent: aBlock [
-	currentKey := (key asSkipListKeyOfSize: index keySize) asInteger.
+SoilSkipListIterator >> at: aKeyObject ifAbsent: aBlock [
+	currentKey := (aKeyObject asSkipListKeyOfSize: index keySize) asInteger.
 	self 
-		findPageFor: key 
+		findPageFor: currentKey 
 		startingAt: index headerPage.
 	^ currentPage 
 		valueAt: currentKey


### PR DESCRIPTION
fixes #319: make sure to use the keyObject after conversion with asSkipListKeyOfSize: