### PR TITLE
 321-SoilNewClusterVersionaddObjectreference-does-not-guard-for-duplicated-adds

### DIFF
--- a/src/Soil-Core/SoilNewClusterVersion.class.st
+++ b/src/Soil-Core/SoilNewClusterVersion.class.st
@@ -12,7 +12,7 @@ Class {
 { #category : #adding }
 SoilNewClusterVersion >> addObject: anObject reference: anObjectId [
 	externalObjects add: anObject.
-	references addLast: anObjectId
+	self addReference: anObjectId
 ]
 
 { #category : #converting }


### PR DESCRIPTION
use #addReference: to make sure we check for duplicates, fixes #321