### PR TITLE
order mismatch in skip list

### DIFF
--- a/src/Soil-Core/Integer.extension.st
+++ b/src/Soil-Core/Integer.extension.st
@@ -2,7 +2,29 @@ Extension { #name : #Integer }
 
 { #category : #'*Soil-Core' }
 Integer >> asSkipListKeyOfSize: keySize [ 
-	^ self asByteArrayOfSize: keySize 
+
+	"Has been copied from omnibase so that new keys gets added at the right position in regards to the ominibase keys. 
+	We should decide if it is something we want or we want to migrate all to a new format.
+	Answer BCD encoded byte array for indexing integers in B-tree."
+
+	| bytes b i n |
+	bytes := ByteArray new: keySize.
+	n := self abs.
+	i := keySize.
+	[i = 1] whileFalse: 
+			[b := n \\ 10.
+			n := n // 10.
+			b := n \\ 10 * 16 bitOr: b.
+			n := n // 10.
+			bytes at: i put: b.
+			i := i - 1].
+	b := n \\ 10.
+	self < 0 ifTrue: [b := b bitOr: 32].
+	bytes at: 1 put: b.
+	n < 10 
+		ifFalse: 
+			[self error: 'B-tree dictionary key size is too short to convert receiver into byte array'].
+	^bytes
 ]
 
 { #category : #'*soil-core' }


### PR DESCRIPTION
@noha So that would be the inner issue.
Here I changed the skiplist key computed from integer values so that it fits what was doing omnibase.
this looks pretty complex in regards the original implementation and i am not sure about the purpose of this code. 
however i am not sure how we could convert back the existing omnibase keys