### PR TITLE
index management without indexed object/holder 

### DIFF
--- a/src/Soil-Core-Tests/SoilJournalTest.class.st
+++ b/src/Soil-Core-Tests/SoilJournalTest.class.st
@@ -49,12 +49,12 @@ SoilJournalTest >> testNewRootSkipList [
 		at: #foo put: #bar).
 	tx checkpoint.
 	journal := tx journal.
-	self assert: journal size equals: 9.
+	self assert: journal size equals: 10.
 	self assert: (journal anyEntrySatisfy:[:each | each objectId notNil and: [ each objectId isSameObjectId: (SoilObjectId segment: 1 index: 1) ]]).
 	self assert: (journal anyEntrySatisfy: [:each | each class = SoilNewKeyEntry ]).
-	self assert: (journal entryAt: 6) class equals: SoilNewBehaviorEntry.
-	self assert: (journal entryAt: 7) class equals: SoilUpdateSegmentIndexEntry.
-	self assert: (journal entryAt: 8) class equals: SoilUpdateDatabaseVersion.
+	self assert: (journal entryAt: 7) class equals: SoilNewBehaviorEntry.
+	self assert: (journal entryAt: 8) class equals: SoilUpdateSegmentIndexEntry.
+	self assert: (journal entryAt: 9) class equals: SoilUpdateDatabaseVersion.
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -256,6 +256,15 @@ Soil >> renameClassNamed: oldName to: newName [
 	transaction commit
 ]
 
+{ #category : #'as yet unclassified' }
+Soil >> replayJournal: aSoilJournal [ 
+	| tx |
+	tx := self newTransaction.
+	aSoilJournal allTransactionJournals do: [ :j |
+		j commitIn: tx ].
+	tx commit
+]
+
 { #category : #accessing }
 Soil >> settings [
 

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -260,7 +260,7 @@ Soil >> renameClassNamed: oldName to: newName [
 Soil >> replayJournal: aSoilJournal [ 
 	| tx |
 	tx := self newTransaction.
-	aSoilJournal allTransactionJournals do: [ :j |
+	aSoilJournal allTransactionJournals reverse do: [ :j |
 		j commitIn: tx ].
 	tx commit
 ]

--- a/src/Soil-Core/SoilClusterRecord.class.st
+++ b/src/Soil-Core/SoilClusterRecord.class.st
@@ -65,6 +65,13 @@ SoilClusterRecord >> hasPreviousVersion [
 	^ previousVersionPosition > 0 
 ]
 
+{ #category : #accessing }
+SoilClusterRecord >> indexAt: indexId [ 
+	"resolve the index in the segment of the cluster root"
+	^ (transaction segmentAt: objectId segment)
+		indexAt: indexId
+]
+
 { #category : #initialization }
 SoilClusterRecord >> initialize [ 
 	super initialize.

--- a/src/Soil-Core/SoilIndexManager.class.st
+++ b/src/Soil-Core/SoilIndexManager.class.st
@@ -25,13 +25,13 @@ SoilIndexManager >> acceptSoil: aSoilVisitor [
 ]
 
 { #category : #accessing }
-SoilIndexManager >> at: anIndexedObject ifAbsent: aBlock [ 
+SoilIndexManager >> at: indexId ifAbsent: aBlock [ 
 	^ semaphore critical: [  
 		indexes 
-			at: anIndexedObject id 
+			at: indexId 
 			ifAbsentPut: [ 
 				self 
-					loadIndexWithId: anIndexedObject 
+					loadIndexWithId: indexId 
 					ifNone: [ aBlock value ] ] ]
 		
 ]
@@ -55,11 +55,14 @@ SoilIndexManager >> initializeFilesystem [
 ]
 
 { #category : #'as yet unclassified' }
-SoilIndexManager >> loadIndexWithId: anIndexedObject ifNone: aBlock [
+SoilIndexManager >> loadIndexWithId: indexId ifNone: aBlock [
 	| path |
-	path := self path / anIndexedObject id , #index.
+	path := self path / indexId , #index.
 	^ path exists
-		ifTrue: [ anIndexedObject loadFrom: path ]
+		ifTrue: [ 
+			(self class indexClassFromFile: path) new 
+				path: path;
+				open ]
 		ifFalse: [ aBlock value ]
 ]
 
@@ -71,6 +74,18 @@ SoilIndexManager >> open [
 { #category : #accessing }
 SoilIndexManager >> path [ 
 	^ segment path / #indexes
+]
+
+{ #category : #'as yet unclassified' }
+SoilIndexManager >> registerIndex: aSoilIndex at: indexId [
+	| registeredIndex |
+	registeredIndex :=  aSoilIndex thePersistentInstance
+		path: self path / indexId , #index;
+		initializeFilesystem.
+	^ semaphore critical: [  
+		indexes 
+			at: indexId
+			put: registeredIndex ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Soil-Core/SoilIndexManager.class.st
+++ b/src/Soil-Core/SoilIndexManager.class.st
@@ -36,6 +36,14 @@ SoilIndexManager >> at: indexId ifAbsent: aBlock [
 		
 ]
 
+{ #category : #'as yet unclassified' }
+SoilIndexManager >> at: indexId put: aSoilIndex [
+	^ semaphore critical: [  
+		indexes 
+			at: indexId
+			put: aSoilIndex thePersistentInstance ]
+]
+
 { #category : #'initialize-release' }
 SoilIndexManager >> close [
 	semaphore critical: [  
@@ -76,28 +84,9 @@ SoilIndexManager >> path [
 	^ segment path / #indexes
 ]
 
-{ #category : #'as yet unclassified' }
-SoilIndexManager >> registerIndex: aSoilIndex at: indexId [
-	| registeredIndex |
-	registeredIndex :=  aSoilIndex thePersistentInstance
-		path: self path / indexId , #index;
-		initializeFilesystem.
-	^ semaphore critical: [  
-		indexes 
-			at: indexId
-			put: registeredIndex ]
-]
-
-{ #category : #'as yet unclassified' }
-SoilIndexManager >> registerIndexedObject: aSoilIndexObject [ 
-	| registeredIndex |
-	registeredIndex :=  aSoilIndexObject index thePersistentInstance
-		path: self path / aSoilIndexObject id, #index;
-		initializeFilesystem.
-	^ semaphore critical: [  
-		indexes 
-			at: aSoilIndexObject id
-			put: registeredIndex ]
+{ #category : #accessing }
+SoilIndexManager >> pathFor: indexId [ 
+	^ self path / indexId , #index
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilIndexNotFound.class.st
+++ b/src/Soil-Core/SoilIndexNotFound.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #SoilIndexNotFound,
+	#superclass : #Error,
+	#category : #'Soil-Core-Model'
+}

--- a/src/Soil-Core/SoilNewCheckpointEntry.class.st
+++ b/src/Soil-Core/SoilNewCheckpointEntry.class.st
@@ -17,6 +17,10 @@ SoilNewCheckpointEntry >> address [
 	^ ''
 ]
 
+{ #category : #committing }
+SoilNewCheckpointEntry >> commitIn: aTransaction [ 
+]
+
 { #category : #accessing }
 SoilNewCheckpointEntry >> container [
 	^ #soil
@@ -33,7 +37,7 @@ SoilNewCheckpointEntry >> readFrom: aStream [
 	| size |
 	super readFrom: aStream.
 	size := aStream next.
-	checkpointedAt := DateAndTime epoch + ((aStream next: size) asInteger / 1000) milliSeconds  
+	checkpointedAt := (DateAndTime epoch + ((aStream next: size) asInteger / 1000) milliSeconds) asLocal
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilNewIndexEntry.class.st
+++ b/src/Soil-Core/SoilNewIndexEntry.class.st
@@ -1,0 +1,36 @@
+Class {
+	#name : #SoilNewIndexEntry,
+	#superclass : #SoilJournalEntry,
+	#instVars : [
+		'id',
+		'segment',
+		'keySize',
+		'valueSize'
+	],
+	#category : #'Soil-Core-Journal'
+}
+
+{ #category : #'accessing - defaults' }
+SoilNewIndexEntry class >> journalTypeCode [
+	^ 10
+]
+
+{ #category : #accessing }
+SoilNewIndexEntry >> indexId: aString [ 
+	id := aString
+]
+
+{ #category : #accessing }
+SoilNewIndexEntry >> keySize: anInteger [ 
+	keySize := anInteger
+]
+
+{ #category : #accessing }
+SoilNewIndexEntry >> segment: anInteger [ 
+	segment := anInteger
+]
+
+{ #category : #accessing }
+SoilNewIndexEntry >> valueSize: anInteger [ 
+	valueSize := anInteger 
+]

--- a/src/Soil-Core/SoilNewKeyEntry.class.st
+++ b/src/Soil-Core/SoilNewKeyEntry.class.st
@@ -2,6 +2,7 @@ Class {
 	#name : #SoilNewKeyEntry,
 	#superclass : #SoilJournalEntry,
 	#instVars : [
+		'segment',
 		'indexId',
 		'key',
 		'value',
@@ -23,9 +24,7 @@ SoilNewKeyEntry >> address [
 { #category : #'as yet unclassified' }
 SoilNewKeyEntry >> commitIn: transaction [ 
 	| index |
-	index := (transaction indexes associations 
-		detect: [ :each | each key id = indexId ]
-		ifNone: [ Error signal: 'shouldnt happen' ]) value.
+	index := transaction indexAt: indexId segment: 1.
 	index newIterator 
 		at: key put: value;
 		updateCurrentTransaction: transaction writeVersion 
@@ -80,6 +79,11 @@ SoilNewKeyEntry >> readFrom: aStream [
 	indexId := (aStream next: indexIdSize) asString.
 	key := (aStream next: (aStream next: 2) asInteger) asInteger.
 	value := (aStream next: (aStream next: 2) asInteger) asSoilObjectId .
+]
+
+{ #category : #accessing }
+SoilNewKeyEntry >> segment: anInteger [ 
+	segment := anInteger
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilNewKeyEntry.class.st
+++ b/src/Soil-Core/SoilNewKeyEntry.class.st
@@ -24,7 +24,7 @@ SoilNewKeyEntry >> address [
 { #category : #'as yet unclassified' }
 SoilNewKeyEntry >> commitIn: transaction [ 
 	| index |
-	index := transaction indexAt: indexId segment: 1.
+	index := transaction indexAt: indexId segment: segment.
 	index newIterator 
 		at: key put: value;
 		updateCurrentTransaction: transaction writeVersion 

--- a/src/Soil-Core/SoilNewSkipListIndexEntry.class.st
+++ b/src/Soil-Core/SoilNewSkipListIndexEntry.class.st
@@ -1,0 +1,27 @@
+Class {
+	#name : #SoilNewSkipListIndexEntry,
+	#superclass : #SoilNewIndexEntry,
+	#instVars : [
+		'maxLevel'
+	],
+	#category : #'Soil-Core-Journal'
+}
+
+{ #category : #committing }
+SoilNewSkipListIndexEntry >> commitIn: aSoilTransaction [ 
+	| index |
+	index := SoilSkipList new.
+	(aSoilTransaction objectRepository segmentAt: segment)
+		registerIndex: index at: id.
+	index 
+		initializeHeaderPage;
+		maxLevel: maxLevel;
+		keySize: keySize;
+		valueSize: valueSize;
+		flush.
+]
+
+{ #category : #accessing }
+SoilNewSkipListIndexEntry >> maxLevel: anInteger [ 
+	maxLevel := anInteger
+]

--- a/src/Soil-Core/SoilNewSkipListIndexEntry.class.st
+++ b/src/Soil-Core/SoilNewSkipListIndexEntry.class.st
@@ -8,17 +8,19 @@ Class {
 }
 
 { #category : #committing }
-SoilNewSkipListIndexEntry >> commitIn: aSoilTransaction [ 
-	| index |
-	index := SoilSkipList new.
-	(aSoilTransaction segmentAt: segment)
-		registerIndex: index at: id.
-	index 
+SoilNewSkipListIndexEntry >> commitIn: aSoilTransaction [
+
+	| index indexManager |
+	indexManager := (aSoilTransaction segmentAt: segment) indexManager.
+	index := SoilSkipList new
+		path: (indexManager pathFor: id);
+		initializeFilesystem;
 		initializeHeaderPage;
 		maxLevel: maxLevel;
 		keySize: keySize;
 		valueSize: valueSize;
 		flush.
+	indexManager at: id put: index
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilNewSkipListIndexEntry.class.st
+++ b/src/Soil-Core/SoilNewSkipListIndexEntry.class.st
@@ -11,7 +11,7 @@ Class {
 SoilNewSkipListIndexEntry >> commitIn: aSoilTransaction [ 
 	| index |
 	index := SoilSkipList new.
-	(aSoilTransaction objectRepository segmentAt: segment)
+	(aSoilTransaction segmentAt: segment)
 		registerIndex: index at: id.
 	index 
 		initializeHeaderPage;

--- a/src/Soil-Core/SoilNewTransactionEntry.class.st
+++ b/src/Soil-Core/SoilNewTransactionEntry.class.st
@@ -41,7 +41,7 @@ SoilNewTransactionEntry >> readFrom: aStream [
 	| size |
 	super readFrom: aStream.
 	size := aStream next.
-	createdAt := DateAndTime epoch + ((aStream next: size) asInteger / 1000) milliSeconds  
+	createdAt := (DateAndTime epoch + ((aStream next: size) asInteger / 1000) milliSeconds) asLocal
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilObjectId.class.st
+++ b/src/Soil-Core/SoilObjectId.class.st
@@ -133,9 +133,7 @@ SoilObjectId >> printOn: aStream [
 
 { #category : #accessing }
 SoilObjectId >> segment [
-	self flag: #todo.
-	"There should ne no default segment. This is a shortcut"
-	^ segment ifNil: [ 1 ]
+	^ segment
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilObjectSegment.class.st
+++ b/src/Soil-Core/SoilObjectSegment.class.st
@@ -101,6 +101,11 @@ SoilObjectSegment >> id: anObject [
 ]
 
 { #category : #accessing }
+SoilObjectSegment >> indexAt: aString [ 
+	^ self indexManager at: aString ifAbsent: [ Error signal: 'index not found' ]
+]
+
+{ #category : #accessing }
 SoilObjectSegment >> indexAt: anIndexedObject ifAbsent: aBlock [
 	^ self indexManager 
 		at: anIndexedObject 
@@ -202,6 +207,11 @@ SoilObjectSegment >> path [
 { #category : #printing }
 SoilObjectSegment >> printOn: aStream [ 
 	aStream << 'segment #' << id asString 
+]
+
+{ #category : #'as yet unclassified' }
+SoilObjectSegment >> registerIndex: aSoilIndex at: indexId [
+	^ self indexManager registerIndex: aSoilIndex at: indexId
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Soil-Core/SoilObjectSegment.class.st
+++ b/src/Soil-Core/SoilObjectSegment.class.st
@@ -114,6 +114,12 @@ SoilObjectSegment >> indexAt: indexId ifAbsent: aBlock [
 		ifAbsent: aBlock
 ]
 
+{ #category : #'as yet unclassified' }
+SoilObjectSegment >> indexAt: indexId put: aSoilIndex [
+
+	^ self indexManager at: indexId put: aSoilIndex
+]
+
 { #category : #accessing }
 SoilObjectSegment >> indexFile [
 	^ indexFile ifNil: [
@@ -209,11 +215,6 @@ SoilObjectSegment >> path [
 { #category : #printing }
 SoilObjectSegment >> printOn: aStream [ 
 	aStream << 'segment #' << id asString 
-]
-
-{ #category : #'as yet unclassified' }
-SoilObjectSegment >> registerIndex: aSoilIndex at: indexId [
-	^ self indexManager registerIndex: aSoilIndex at: indexId
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilObjectSegment.class.st
+++ b/src/Soil-Core/SoilObjectSegment.class.st
@@ -101,14 +101,16 @@ SoilObjectSegment >> id: anObject [
 ]
 
 { #category : #accessing }
-SoilObjectSegment >> indexAt: aString [ 
-	^ self indexManager at: aString ifAbsent: [ Error signal: 'index not found' ]
+SoilObjectSegment >> indexAt: indexId [ 
+	^ self indexManager 
+		at: indexId 
+		ifAbsent: [ SoilIndexNotFound signal: 'index not found' ] 
 ]
 
 { #category : #accessing }
-SoilObjectSegment >> indexAt: anIndexedObject ifAbsent: aBlock [
+SoilObjectSegment >> indexAt: indexId ifAbsent: aBlock [
 	^ self indexManager 
-		at: anIndexedObject 
+		at: indexId 
 		ifAbsent: aBlock
 ]
 
@@ -212,11 +214,6 @@ SoilObjectSegment >> printOn: aStream [
 { #category : #'as yet unclassified' }
 SoilObjectSegment >> registerIndex: aSoilIndex at: indexId [
 	^ self indexManager registerIndex: aSoilIndex at: indexId
-]
-
-{ #category : #'as yet unclassified' }
-SoilObjectSegment >> registerIndexedObject: aSoilSkipListDictionary [ 
-	^ self indexManager registerIndexedObject: aSoilSkipListDictionary 
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilRemoveKeyEntry.class.st
+++ b/src/Soil-Core/SoilRemoveKeyEntry.class.st
@@ -23,9 +23,7 @@ SoilRemoveKeyEntry >> address [
 { #category : #'as yet unclassified' }
 SoilRemoveKeyEntry >> commitIn: transaction [ 
 	| index |
-	index := (transaction indexes associations 
-		detect: [ :each | each key id = indexId ]
-		ifNone: [ Error signal: 'shouldnt happen' ]) value.
+	index := transaction indexAt: indexId segment: 1.
 	self flag: #todo.
 	"ifAbsent: should not be used here"
 	index newIterator 

--- a/src/Soil-Core/SoilRemoveKeyEntry.class.st
+++ b/src/Soil-Core/SoilRemoveKeyEntry.class.st
@@ -4,7 +4,8 @@ Class {
 	#instVars : [
 		'indexId',
 		'key',
-		'oldValue'
+		'oldValue',
+		'segment'
 	],
 	#category : #'Soil-Core-Journal'
 }
@@ -77,6 +78,11 @@ SoilRemoveKeyEntry >> readFrom: aStream [
 	indexId := (aStream next: indexIdSize) asString.
 	key := (aStream next: (aStream next: 2) asInteger) asInteger.
 	oldValue := (aStream next: (aStream next: 2) asInteger) asSoilObjectId .
+]
+
+{ #category : #accessing }
+SoilRemoveKeyEntry >> segment: anInteger [ 
+	segment := anInteger 
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilSkipListDictionary.class.st
+++ b/src/Soil-Core/SoilSkipListDictionary.class.st
@@ -177,8 +177,7 @@ SoilSkipListDictionary >> id [
 
 { #category : #accessing }
 SoilSkipListDictionary >> index [
-	^ index ifNil: [ 
-		index := self lookupIndex asCopyOnWrite  ]
+	^ index
 ]
 
 { #category : #initialization }
@@ -265,13 +264,6 @@ SoilSkipListDictionary >> loadFrom: aFileReference [
 	^ SoilSkipList new 
 		path: aFileReference;
 		open
-]
-
-{ #category : #'as yet unclassified' }
-SoilSkipListDictionary >> lookupIndex [
-	^ transaction 
-		indexAt: self
-		ifAbsent: [ self newIndexInstance ]
 ]
 
 { #category : #accessing }
@@ -406,6 +398,14 @@ SoilSkipListDictionary >> soilLoadedIn: aTransaction [
 	newValues := Dictionary new.
 	removedValues := Dictionary new.
 	oldValues := Dictionary new
+]
+
+{ #category : #'as yet unclassified' }
+SoilSkipListDictionary >> soilMaterialized: aMaterializer [
+	"connect the global index at materialization time when we
+	know the cluster root which defines the location of the index.
+	Store a copy-on-write version so all changes are per transaction"
+	index := (aMaterializer indexAt: id) asCopyOnWrite
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilSkipListDictionary.class.st
+++ b/src/Soil-Core/SoilSkipListDictionary.class.st
@@ -207,11 +207,21 @@ SoilSkipListDictionary >> isRegistered [
 
 { #category : #'as yet unclassified' }
 SoilSkipListDictionary >> journalEntries [
-	| entries |
+	| entries segment |
 	entries := OrderedCollection new.
+	segment := (transaction objectIdOf: self) segment.
+	self isRegistered ifFalse: [
+		entries add: (SoilNewSkipListIndexEntry new 
+			transactionId: transaction writeVersion;
+			segment: segment;
+			indexId: id;
+			maxLevel: index maxLevel;
+			keySize: index keySize;
+			valueSize: index valueSize) ].
 	newValues keysAndValuesDo: [ :key :value |
 		entries add: (SoilNewKeyEntry new 
 			transactionId: transaction writeVersion;
+			segment: segment;
 			indexId: id;
 			key: key;
 			value: value;
@@ -219,6 +229,7 @@ SoilSkipListDictionary >> journalEntries [
 	removedValues keysAndValuesDo: [ :key :value |
 		entries add: (SoilRemoveKeyEntry new 
 			transactionId: transaction writeVersion;
+			segment: segment;
 			indexId: id;
 			key: key; 
 			oldValue: value) ].
@@ -371,8 +382,6 @@ SoilSkipListDictionary >> soilBasicSerialize: aSerializer [
 		self prepareNewValues ].
 	super soilBasicSerialize: aSerializer.
 	aSerializer registerIndexId: id.
-	self isRegistered ifFalse: [  
-		index := (aSerializer registerIndexedObject: self) asCopyOnWrite  ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Soil-Core/SoilTransaction.class.st
+++ b/src/Soil-Core/SoilTransaction.class.st
@@ -214,7 +214,7 @@ SoilTransaction >> checkpoint [
 		self buildJournal
 			write;
 			commitIn: self;
-			checkpoint: self;
+			checkpoint: self; 
 			close.
 		indexes values do: #flush.
 		soil behaviorRegistry flush ]
@@ -258,20 +258,20 @@ SoilTransaction >> hasModifications [
 	^ self dirtyObjects notEmpty
 ]
 
-{ #category : #'as yet unclassified' }
-SoilTransaction >> idOf: anObject [ 
-	| id |
-	id := objectMap at: anObject.
-	(id index = 0) ifTrue: [ Error signal: 'index of object id is not initialized' ].
-	^ id
-]
-
 { #category : #accessing }
 SoilTransaction >> indexAt: anObject ifAbsent: aBlock [ 
 	^ indexes
 		at: anObject
 		ifAbsentPut: [ 
 			self lookupIndex: anObject ifNone: aBlock ]
+]
+
+{ #category : #accessing }
+SoilTransaction >> indexAt: aString segment: anInteger [ 
+	^ indexes 
+		at: aString 
+		ifAbsentPut: [ 
+			(self segmentAt: anInteger) indexAt: aString  ]
 ]
 
 { #category : #accessing }
@@ -370,7 +370,7 @@ SoilTransaction >> lookupIndex: anObject ifNone: aBlock [
 	| objectId segment |
 	objectId := (objectMap at: anObject) objectId.
 	segment := self objectRepository segmentAt: objectId segment.
-	^ segment indexAt: anObject ifAbsent: aBlock
+	^ segment indexAt: anObject id ifAbsent: aBlock
 ]
 
 { #category : #public }
@@ -464,6 +464,12 @@ SoilTransaction >> objectId: objectId ifVisible: visibleBlock ifHidden: hiddenBl
 	^ (self isVisibleObjectId: objectId)
 		ifTrue: [ visibleBlock cull: objectId ]
 		ifFalse: [ hiddenBlock cull: objectId ] 
+]
+
+{ #category : #'as yet unclassified' }
+SoilTransaction >> objectIdOf: anObject [ 
+	^ (objectMap at: anObject) objectId.
+	
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilTransaction.class.st
+++ b/src/Soil-Core/SoilTransaction.class.st
@@ -259,19 +259,11 @@ SoilTransaction >> hasModifications [
 ]
 
 { #category : #accessing }
-SoilTransaction >> indexAt: anObject ifAbsent: aBlock [ 
-	^ indexes
-		at: anObject
-		ifAbsentPut: [ 
-			self lookupIndex: anObject ifNone: aBlock ]
-]
-
-{ #category : #accessing }
-SoilTransaction >> indexAt: aString segment: anInteger [ 
+SoilTransaction >> indexAt: indexId segment: segmentIndex [ 
 	^ indexes 
-		at: aString 
+		at: indexId 
 		ifAbsentPut: [ 
-			(self segmentAt: anInteger) indexAt: aString  ]
+			(self segmentAt: segmentIndex) indexAt: indexId  ]
 ]
 
 { #category : #accessing }
@@ -363,14 +355,6 @@ SoilTransaction >> journalEntriesFor: key inIndex: aSoilIndex startingAt: anInte
 { #category : #'as yet unclassified' }
 SoilTransaction >> lockObjectId: aSOObjectId [ 
 	^ self objectRepository lockObjectId: aSOObjectId for: self
-]
-
-{ #category : #'as yet unclassified' }
-SoilTransaction >> lookupIndex: anObject ifNone: aBlock [
-	| objectId segment |
-	objectId := (objectMap at: anObject) objectId.
-	segment := self objectRepository segmentAt: objectId segment.
-	^ segment indexAt: anObject id ifAbsent: aBlock
 ]
 
 { #category : #public }
@@ -551,17 +535,6 @@ SoilTransaction >> records [
 { #category : #accessing }
 SoilTransaction >> recordsToCommit [
 	^ recordsToCommit
-]
-
-{ #category : #'as yet unclassified' }
-SoilTransaction >> registerIndexedObject: anObject forRoot: aClusterRoot [
-	| objectId segment |
-	indexes at: anObject ifPresent: [ Error signal: 'shouldnt happen' ].
-	objectId := (objectMap at: aClusterRoot) objectId.
-	segment := self objectRepository segmentAt: objectId segment.
-	^ indexes 
-		at: anObject 
-		put: (segment registerIndexedObject: anObject)
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Soil-Serializer/SoilMaterializer.class.st
+++ b/src/Soil-Serializer/SoilMaterializer.class.st
@@ -33,6 +33,11 @@ SoilMaterializer >> behaviorVersionsUpTo: aDescription [
 	^ transaction behaviorVersionsUpTo: aDescription 
 ]
 
+{ #category : #accessing }
+SoilMaterializer >> indexAt: indexId [ 
+	^ externalObjectRegistry indexAt: indexId
+]
+
 { #category : #public }
 SoilMaterializer >> materialize [
 	^ self nextSoilObject

--- a/src/Soil-Serializer/SoilSerializer.class.st
+++ b/src/Soil-Serializer/SoilSerializer.class.st
@@ -181,15 +181,6 @@ SoilSerializer >> registerIndexId: aString [
 ]
 
 { #category : #registry }
-SoilSerializer >> registerIndexedObject: anObject [ 
-	"indexes are registered in the segment of the cluster root. So we pass
-	the cluster root in order to figure the segment"
-	^ transaction 
-		registerIndexedObject: anObject 
-		forRoot: clusterRoot 
-]
-
-{ #category : #registry }
 SoilSerializer >> registerObject: anObject ifAbsent: aBlock [
 	| index externalIndex |
 	objectIdTable ifEmpty: [


### PR DESCRIPTION
index creation and lookup is now done by segment/index id so it can be used in the journal