### PR TITLE
analyze fixed fields

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreePageTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreePageTest.class.st
@@ -42,7 +42,6 @@ SoilBTreePageTest >> testWriteAndRead [
 	self assert: readPage valueSize equals: page valueSize.
 	self assert: readPage keySize equals: page keySize.
 	
-	self assert: readPage index equals: 1.
 	self deny: readPage isDirty 
 ]
 
@@ -57,7 +56,6 @@ SoilBTreePageTest >> testWriteAndReadIndex [
 		page writeOn: stream ].
 	self deny: page isDirty.
 	readPage := SoilBTreePage readPageFrom: bytes readStream keySize: 8 valueSize: 8.
-	self assert: readPage index equals: 1.
 	self deny: readPage isDirty
 ]
 
@@ -78,6 +76,5 @@ SoilBTreePageTest >> testWriteAndReadPageCode [
 	self assert: readPage valueSize equals: page valueSize.
 	self assert: readPage keySize equals: page keySize.
 	
-	self assert: readPage index equals: 1.
 	self deny: readPage isDirty 
 ]

--- a/src/Soil-Core-Tests/SoilSkipListPageTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListPageTest.class.st
@@ -64,7 +64,6 @@ SoilSkipListPageTest >> testDataPageWriteAndRead [
 		page writeOn: stream ].
 	self deny: page isDirty.
 	readPage := SoilIndexPage readPageFrom: bytes readStream keySize: 8 valueSize: 8.
-	self assert: readPage index equals: 1.
 	self assert: readPage level equals: 8.
 	self deny: readPage isDirty 
 ]
@@ -81,7 +80,6 @@ SoilSkipListPageTest >> testDataPageWriteAndReadRightArray [
 		page writeOn: stream ].
 	self deny: page isDirty.
 	readPage := SoilIndexPage readPageFrom: bytes readStream keySize: 8 valueSize: 8. 
-	self assert: readPage index equals: 1.
 	self assert: readPage level equals: 8.
 	self assert: readPage right equals: #( 1 2 3 4 5 6 7 8).
 	self deny: readPage isDirty 
@@ -142,7 +140,6 @@ SoilSkipListPageTest >> testHeaderPageWriteAndRead [
 		page writeOn: stream ].
 	self deny: page isDirty.
 	readPage := SoilIndexPage readPageFrom: bytes readStream keySize: 8 valueSize: 8.
-	self assert: readPage index equals: 1.
 	self assert: readPage level equals: 8.
 	self assert: readPage keySize equals: 16.
 	self assert: readPage valueSize equals: 8.

--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -135,11 +135,6 @@ SoilBTreePage >> items [
 	^ items
 ]
 
-{ #category : #writing }
-SoilBTreePage >> itemsSizeSize [
-	^ 2
-]
-
 { #category : #accessing }
 SoilBTreePage >> keySize [
 	^ keySize

--- a/src/Soil-Core/SoilIndexPage.class.st
+++ b/src/Soil-Core/SoilIndexPage.class.st
@@ -88,7 +88,10 @@ SoilIndexPage >> readFrom: aStream [
 
 { #category : #writing }
 SoilIndexPage >> readIndexFrom: aStream [ 
-	index := (aStream next: self indexSize) asInteger.
+	self flag: #todo.
+	"index should be determined at read time depending on the stream.
+	we let the dummy read here for compatibility"
+	"index :=" (aStream next: self indexSize) asInteger.
 
 ]
 
@@ -96,7 +99,10 @@ SoilIndexPage >> readIndexFrom: aStream [
 SoilIndexPage >> writeHeaderOn: aStream [ 
 	aStream
 		nextPut: self class pageCode;
-		nextPutAll: (index asByteArrayOfSize: self indexSize)
+		flag: #todo;
+		"we write 0 as index because the code should not rely on
+		the persisted value as it will go away"
+		nextPutAll: (0 asByteArrayOfSize: self indexSize)
 ]
 
 { #category : #writing }

--- a/src/Soil-Core/SoilIndexPage.class.st
+++ b/src/Soil-Core/SoilIndexPage.class.st
@@ -64,6 +64,13 @@ SoilIndexPage >> isLastPage [
 	self shouldBeImplemented.
 ]
 
+{ #category : #writing }
+SoilIndexPage >> itemsSizeSize [
+	"as long as we target 65536 bytes as maximum page size a two-byte 
+	number of items is sufficient"
+	^ 2
+]
+
 { #category : #accessing }
 SoilIndexPage >> pageSize [
 	^ pageSize

--- a/src/Soil-Core/SoilNewBehaviorEntry.class.st
+++ b/src/Soil-Core/SoilNewBehaviorEntry.class.st
@@ -71,7 +71,7 @@ SoilNewBehaviorEntry >> readFrom: aStream [
 	| size |
 	super readFrom: aStream.
 	objectId := SoilObjectId readFrom: aStream.
-	size := (aStream next: 2) asInteger.
+	size := aStream nextLengthEncodedInteger.
 	identifier := (aStream next: size) asString
 ]
 
@@ -84,6 +84,6 @@ SoilNewBehaviorEntry >> value [
 SoilNewBehaviorEntry >> writeOn: aStream [ 
 	super writeOn: aStream.
 	objectId writeOn: aStream.
-	aStream nextPutAll: (identifier size asByteArrayOfSize: 2).
+	aStream nextPutLengthEncodedInteger:  identifier size.
 	aStream nextPutAll: identifier asByteArray
 ]

--- a/src/Soil-Core/SoilNewCheckpointEntry.class.st
+++ b/src/Soil-Core/SoilNewCheckpointEntry.class.st
@@ -34,10 +34,8 @@ SoilNewCheckpointEntry >> initialize [
 
 { #category : #'instance creation' }
 SoilNewCheckpointEntry >> readFrom: aStream [ 
-	| size |
 	super readFrom: aStream.
-	size := aStream next.
-	checkpointedAt := (DateAndTime epoch + ((aStream next: size) asInteger / 1000) milliSeconds) asLocal
+	checkpointedAt := (DateAndTime epoch + ((aStream nextLengthEncodedInteger) asInteger / 1000) milliSeconds) asLocal
 ]
 
 { #category : #accessing }
@@ -50,9 +48,7 @@ SoilNewCheckpointEntry >> writeOn: aStream [
 	| timestamp |
 	super writeOn: aStream.
 	
-	timestamp := (checkpointedAt asSeconds * 1000000 + (checkpointedAt nanoSecond // 1000)) asByteArray.
+	timestamp := checkpointedAt asSeconds * 1000000 + (checkpointedAt nanoSecond // 1000).
 	
-	aStream
-		nextPut: timestamp size; 
-		nextPutAll: timestamp
+	aStream nextPutLengthEncodedInteger:  timestamp
 ]

--- a/src/Soil-Core/SoilNewKeyEntry.class.st
+++ b/src/Soil-Core/SoilNewKeyEntry.class.st
@@ -77,8 +77,8 @@ SoilNewKeyEntry >> readFrom: aStream [
 	super readFrom: aStream.
 	indexIdSize := aStream next.
 	indexId := (aStream next: indexIdSize) asString.
-	key := (aStream next: (aStream next: 2) asInteger) asInteger.
-	value := (aStream next: (aStream next: 2) asInteger) asSoilObjectId .
+	key := (aStream next: aStream nextLengthEncodedInteger) asInteger.
+	value := (aStream next: (aStream nextLengthEncodedInteger) asInteger) asSoilObjectId .
 ]
 
 { #category : #accessing }
@@ -102,8 +102,8 @@ SoilNewKeyEntry >> writeOn: aStream [
 	aStream 
 		nextPut: indexId size; 
 		nextPutAll: indexId asByteArray;
-		nextPutAll: (key asByteArray size asByteArrayOfSize: 2);
-		nextPutAll: key asByteArray ;
-		nextPutAll: (value asByteArray size asByteArrayOfSize: 2);
+		nextPutLengthEncodedInteger: key asByteArray size;
+		nextPutAll: key asByteArray;
+		nextPutLengthEncodedInteger: value asByteArray size;
 		nextPutAll: value asByteArray
 ]

--- a/src/Soil-Core/SoilNewObjectEntry.class.st
+++ b/src/Soil-Core/SoilNewObjectEntry.class.st
@@ -73,7 +73,7 @@ SoilNewObjectEntry >> readFrom: aStream [
 	| bytesSize |
 	super readFrom: aStream.
 	objectId := SoilObjectId readFrom: aStream.
-	bytesSize := (aStream next: 8) asInteger.
+	bytesSize := aStream nextLengthEncodedInteger.
 	bytes := aStream next: bytesSize.
 ]
 
@@ -98,8 +98,8 @@ SoilNewObjectEntry >> value [
 SoilNewObjectEntry >> writeOn: aStream [ 
 	super writeOn: aStream.
 	objectId writeOn: aStream.
-	aStream nextPutAll: (bytes size asByteArrayOfSize: 8).
 	aStream 
+		nextPutLengthEncodedInteger: bytes size;
 		nextPutAll: bytes
 	
 ]

--- a/src/Soil-Core/SoilNewObjectVersionEntry.class.st
+++ b/src/Soil-Core/SoilNewObjectVersionEntry.class.st
@@ -22,14 +22,14 @@ SoilNewObjectVersionEntry >> oldBytes: aCollection [
 SoilNewObjectVersionEntry >> readFrom: aStream [ 
 	| oldBytesSize |
 	super readFrom: aStream.
-	oldBytesSize := (aStream next: 8) asInteger.
+	oldBytesSize := aStream nextLengthEncodedInteger.
 	oldBytes := aStream next: oldBytesSize
 ]
 
 { #category : #writing }
 SoilNewObjectVersionEntry >> writeOn: aStream [ 
 	super writeOn: aStream.
-	aStream nextPutAll: (oldBytes size asByteArrayOfSize: 8).
+	aStream nextPutLengthEncodedInteger: oldBytes size.
 	aStream nextPutAll: oldBytes.
 	
 ]

--- a/src/Soil-Core/SoilNewTransactionEntry.class.st
+++ b/src/Soil-Core/SoilNewTransactionEntry.class.st
@@ -38,10 +38,8 @@ SoilNewTransactionEntry >> objectId [
 
 { #category : #'instance creation' }
 SoilNewTransactionEntry >> readFrom: aStream [ 
-	| size |
 	super readFrom: aStream.
-	size := aStream next.
-	createdAt := (DateAndTime epoch + ((aStream next: size) asInteger / 1000) milliSeconds) asLocal
+	createdAt := (DateAndTime epoch + ((aStream nextLengthEncodedInteger) / 1000) milliSeconds) asLocal
 ]
 
 { #category : #accessing }
@@ -54,8 +52,6 @@ SoilNewTransactionEntry >> writeOn: aStream [
 	| timestamp |
 	super writeOn: aStream.
 	
-	timestamp := (createdAt asSeconds * 1000000 + (createdAt nanoSecond // 1000)) asByteArray..
-	aStream
-		nextPut: timestamp size; 
-		nextPutAll: timestamp
+	timestamp := createdAt asSeconds * 1000000 + (createdAt nanoSecond // 1000).
+	aStream nextPutLengthEncodedInteger: timestamp
 ]

--- a/src/Soil-Core/SoilPagedFileIndexStore.class.st
+++ b/src/Soil-Core/SoilPagedFileIndexStore.class.st
@@ -81,7 +81,7 @@ SoilPagedFileIndexStore >> pageFaultAt: anInteger [
 	| page |
 	streamSemaphore critical: [  
 		stream position: (self positionOfPageIndex: anInteger).
-		page := index readPageFrom: stream ].
+		page := (index readPageFrom: stream) index: anInteger ].
 	pagesMutex critical: [  
 		pages at: anInteger put: page ].
 	^ page

--- a/src/Soil-Core/SoilRemoveKeyEntry.class.st
+++ b/src/Soil-Core/SoilRemoveKeyEntry.class.st
@@ -74,8 +74,8 @@ SoilRemoveKeyEntry >> readFrom: aStream [
 	super readFrom: aStream.
 	indexIdSize := aStream next.
 	indexId := (aStream next: indexIdSize) asString.
-	key := (aStream next: (aStream next: 2) asInteger) asInteger.
-	oldValue := (aStream next: (aStream next: 2) asInteger) asSoilObjectId .
+	key := (aStream next: aStream nextLengthEncodedInteger) asInteger.
+	oldValue := (aStream next: aStream nextLengthEncodedInteger) asSoilObjectId .
 ]
 
 { #category : #accessing }
@@ -94,9 +94,9 @@ SoilRemoveKeyEntry >> writeOn: aStream [
 	aStream 
 		nextPut: indexId size; 
 		nextPutAll: indexId asByteArray;
-		nextPutAll: (key asByteArray size asByteArrayOfSize: 2);
-		nextPutAll: key asByteArray ;
-		nextPutAll: (oldValue asByteArray size asByteArrayOfSize: 2);
+		nextPutLengthEncodedInteger: key asByteArray size;
+		nextPutAll: key asByteArray;
+		nextPutLengthEncodedInteger: oldValue asByteArray size;
 		nextPutAll: oldValue asByteArray
 		
 ]

--- a/src/Soil-Core/SoilSkipListHeaderPage.class.st
+++ b/src/Soil-Core/SoilSkipListHeaderPage.class.st
@@ -90,6 +90,8 @@ SoilSkipListHeaderPage >> writeHeaderOn: aStream [
 		nextPutAll: (keySize asByteArrayOfSize: 2);
 		nextPutAll: (valueSize asByteArrayOfSize: 2);
 		nextPutAll: (maxLevel asByteArrayOfSize: 2);
+		flag: #todo;
+		"lastPageIndex must be 4 bytes"
 		nextPutAll: (lastPageIndex asByteArrayOfSize: 2).
 	self 
 		writeLevelsOn: aStream

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -185,11 +185,6 @@ SoilSkipListPage >> items [
 	^ items
 ]
 
-{ #category : #writing }
-SoilSkipListPage >> itemsSizeSize [
-	^ 2
-]
-
 { #category : #accessing }
 SoilSkipListPage >> keyOrClosestAfter: key [ 
 	"find the closest key in this page. This returns the exact key if 
@@ -310,6 +305,8 @@ SoilSkipListPage >> rightAt: anInteger put: anObject [
 
 { #category : #writing }
 SoilSkipListPage >> rightSize [
+	"this fixes the maximum number of pages to 32 bits which should be enough. This
+	17TB when using a page size of 4k"
 	^ 4
 ]
 

--- a/src/Soil-Core/SoilUpdateDatabaseVersion.class.st
+++ b/src/Soil-Core/SoilUpdateDatabaseVersion.class.st
@@ -59,8 +59,8 @@ SoilUpdateDatabaseVersion >> printOn: aStream [
 { #category : #'instance creation' }
 SoilUpdateDatabaseVersion >> readFrom: aStream [ 
 	super readFrom: aStream.
-	version := (aStream next: 8) asInteger.
-	previousVersion := (aStream next: 8) asInteger
+	version := aStream nextLengthEncodedInteger.
+	previousVersion := aStream nextLengthEncodedInteger
 ]
 
 { #category : #accessing }
@@ -76,6 +76,6 @@ SoilUpdateDatabaseVersion >> version: anInteger [
 { #category : #writing }
 SoilUpdateDatabaseVersion >> writeOn: aStream [ 
 	super writeOn: aStream.
-	aStream nextPutAll: (version asByteArrayOfSize: 8).
-	aStream nextPutAll: (previousVersion asByteArrayOfSize: 8).
+	aStream nextPutLengthEncodedInteger: version.
+	aStream nextPutLengthEncodedInteger: previousVersion.
 ]

--- a/src/Soil-Core/SoilUpdateSegmentIndexEntry.class.st
+++ b/src/Soil-Core/SoilUpdateSegmentIndexEntry.class.st
@@ -57,8 +57,8 @@ SoilUpdateSegmentIndexEntry >> printOn: aStream [
 { #category : #'instance creation' }
 SoilUpdateSegmentIndexEntry >> readFrom: aStream [ 
 	super readFrom: aStream.
-	segmentId := (aStream next: (aStream next: 2) asInteger) asInteger.
-	index := (aStream next: 8 asInteger) asInteger.
+	segmentId := aStream nextLengthEncodedInteger.
+	index := aStream nextLengthEncodedInteger 
 ]
 
 { #category : #accessing }
@@ -75,7 +75,6 @@ SoilUpdateSegmentIndexEntry >> value [
 SoilUpdateSegmentIndexEntry >> writeOn: aStream [ 
 	super writeOn: aStream.
 	aStream 
-		nextPutAll: (segmentId asByteArray size asByteArrayOfSize: 2);
-		nextPutAll: segmentId asByteArray;
-		nextPutAll: (index asByteArrayOfSize: 8)
+		nextPutLengthEncodedInteger: segmentId;
+		nextPutLengthEncodedInteger: index
 ]

--- a/src/Soil-File/ZnBufferedReadStream.extension.st
+++ b/src/Soil-File/ZnBufferedReadStream.extension.st
@@ -1,0 +1,9 @@
+Extension { #name : #ZnBufferedReadStream }
+
+{ #category : #'*Soil-File' }
+ZnBufferedReadStream >> nextLengthEncodedInteger [
+	| value |
+	value := self next.
+	(value < 128) ifTrue: [ ^ value ].
+	^ (self nextLengthEncodedInteger bitShift: 7) bitOr: (value bitAnd: 127)
+]

--- a/src/Soil-File/ZnBufferedWriteStream.extension.st
+++ b/src/Soil-File/ZnBufferedWriteStream.extension.st
@@ -1,0 +1,11 @@
+Extension { #name : #ZnBufferedWriteStream }
+
+{ #category : #'*Soil-File' }
+ZnBufferedWriteStream >> nextPutLengthEncodedInteger: anInteger [ 
+	"store length of integer encoded in a way that the presence of a
+	most significant bit indicates that the next byte is part of
+	the value"
+	anInteger < 128 ifTrue: [ ^ self nextPut: anInteger ].
+	self nextPut: ((anInteger bitAnd: 127) bitOr: 128).
+	self nextPutLengthEncodedInteger: (anInteger bitShift: -7)
+]


### PR DESCRIPTION
- Remove index as a page field. It is not needed as postions/index are determined by the location in the stream. And as it is fixed to two bytes it is error-prone. The field is still written for compatibility
- Changed lots of fixed fields into length encoded 
- added length encoded reading/writing to zinc streams
- commented on fixed sizes usage