### PR TITLE
adjusted #nextKeyCloseTo:

### DIFF
--- a/src/Soil-Core/SoilSkipListIterator.class.st
+++ b/src/Soil-Core/SoilSkipListIterator.class.st
@@ -133,7 +133,9 @@ SoilSkipListIterator >> nextKeyCloseTo: key [
 	self 
 		findPageFor: binKey
 		startingAt: index headerPage.
-	nextKey := currentPage keyOrClosestAfter: binKey
+	nextKey := currentPage keyOrClosestAfter: binKey.
+	nextKey ifNil: ["if there is no close key found, we position the cursor at the end, so that asking for the next association will return nil" 
+		currentKey := currentPage lastKey ]
 ]
 
 { #category : #printing }

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -188,9 +188,10 @@ SoilSkipListPage >> items [
 { #category : #accessing }
 SoilSkipListPage >> keyOrClosestAfter: key [ 
 	"find the closest key in this page. This returns the exact key if 
-	present or the key that comes after. This is useful if we enter the
+	present or the key that comes after. Else returns nil. This is useful if we enter the
 	list at an unknown point"
 	items ifEmpty: [ ^ nil ].
+	self lastKey < key ifTrue: [ ^ nil ].
 	^ items 
 		findBinaryIndex: [ :each | key - each key ] 
 		do: [ :e | e key] 


### PR DESCRIPTION
adjusted #nextKeyCloseTo: in the case of not matching elements. Make sure we leave the current position at the end of the list.

@noha I am not completly sure about the fix, but at least there would be something fishy here.
The context is to call #nextKeyCloseTo: on a key that is higher than all existing keys , and then call #nextAssociation
In such a case, the #nextKeyCloseTo: was still returning a key and leaving the nextKey, currentKey, currentPage in inconsistent state.
To me, if we traverse the list without any matching key, we should the leave the currentKey / currentPage at the end of the list. so that nextAssociation will return nil

