### PR TITLE
made sure that when a close key is found, the currentKey cursor is left  at a suitable place

### DIFF
--- a/src/Soil-Core/SoilSkipListIterator.class.st
+++ b/src/Soil-Core/SoilSkipListIterator.class.st
@@ -127,15 +127,17 @@ SoilSkipListIterator >> nextAssociation [
 
 { #category : #private }
 SoilSkipListIterator >> nextKeyCloseTo: key [
-	
+
 	| binKey |
 	binKey := (key asSkipListKeyOfSize: index keySize) asInteger.
-	self 
-		findPageFor: binKey
-		startingAt: index headerPage.
+	self findPageFor: binKey startingAt: index headerPage.
 	nextKey := currentPage keyOrClosestAfter: binKey.
-	nextKey ifNil: ["if there is no close key found, we position the cursor at the end, so that asking for the next association will return nil" 
-		currentKey := currentPage lastKey ]
+	nextKey
+		ifNil: [ "if there is no close key found, we position the cursor at the end, so that asking for the next association will return nil" 
+			currentKey := currentPage lastKey ]
+		ifNotNil: [ 
+			"if there is a close key found, we make sure the cursor get properly positioned"
+			currentKey := nextKey ]
 ]
 
 { #category : #printing }


### PR DESCRIPTION
made sure that when a close key is found, the currentKey cursor is left  at a suitable place