### PR TITLE
SoilIndexPage: move ivars and methods down

### DIFF
--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -1,10 +1,6 @@
 Class {
 	#name : #SoilBTreePage,
 	#superclass : #SoilIndexPage,
-	#instVars : [
-		'items',
-		'keySize'
-	],
 	#category : #'Soil-Core-Index-BTree'
 }
 
@@ -19,26 +15,6 @@ SoilBTreePage class >> pageCode [
 	^0
 ]
 
-{ #category : #adding }
-SoilBTreePage >> addItem: anAssociation [ 
-	items add: anAssociation.
-	dirty := true
-]
-
-{ #category : #accessing }
-SoilBTreePage >> associationAt: anInteger [ 
-	^ self
-		associationAt: anInteger 
-		ifAbsent: [ nil ]
-]
-
-{ #category : #accessing }
-SoilBTreePage >> associationAt: anInteger ifAbsent: aBlock [
-	^ items 
-		detect: [:each | each key = anInteger ] 
-		ifNone: [ aBlock value ]
-]
-
 { #category : #accessing }
 SoilBTreePage >> biggestKey [
 	^ items last key
@@ -49,11 +25,6 @@ SoilBTreePage >> find: aKey with: aBTree [
 	^ self subclassResponsibility
 ]
 
-{ #category : #accessing }
-SoilBTreePage >> firstItem [
-	^ items first
-]
-
 { #category : #testing }
 SoilBTreePage >> hasRoom [
 	^ self headerSize + ((items size + 1) * (self keySize + self valueSize)) <= self pageSize
@@ -62,13 +33,6 @@ SoilBTreePage >> hasRoom [
 { #category : #utilities }
 SoilBTreePage >> headerSize [
 	self subclassResponsibility
-]
-
-{ #category : #accessing }
-SoilBTreePage >> indexOfKey: anInteger [ 
-	items withIndexDo: [ :each :idx |
-		(each key = anInteger) ifTrue: [ ^ idx ] ].
-	^ 0
 ]
 
 { #category : #initialization }
@@ -83,11 +47,6 @@ SoilBTreePage >> insert: anItem into: aBtree [
 	^ self subclassResponsibility
 ]
 
-{ #category : #testing }
-SoilBTreePage >> isEmpty [
-	^ items isEmpty 
-]
-
 { #category : #'as yet unclassified' }
 SoilBTreePage >> itemAfter: key [ 
 	| i item |
@@ -96,58 +55,6 @@ SoilBTreePage >> itemAfter: key [
 	item := items at: i + 1.
 	(item key >= ((2 raisedTo: 64) - 1)) ifTrue: [ ^ nil ].
 	^ item
-]
-
-{ #category : #accessing }
-SoilBTreePage >> itemCapacity [
-	^ ((self pageSize - self headerSize) / (self keySize + self valueSize)) floor
-]
-
-{ #category : #accessing }
-SoilBTreePage >> itemRemoveAt: key [ 
-	^ self 
-		itemRemoveAt: key 
-		ifAbsent: [ KeyNotFound signalFor: key in: self ]
-]
-
-{ #category : #accessing }
-SoilBTreePage >> itemRemoveAt: anInteger ifAbsent: aBlock [
-	| item |
-	items 
-		findBinaryIndex: [ :each |  anInteger - each key ] 
-		do: [:ind | item := items removeAt: ind ]
-		ifNone: [ ^ aBlock value ].
-	dirty := true.
-	^ item
-]
-
-{ #category : #accessing }
-SoilBTreePage >> itemRemoveIndex: anInteger [
-	| item |
-	item := items at: anInteger.
-	items removeAt: anInteger.
-	dirty := true.
-	^ item
-]
-
-{ #category : #accessing }
-SoilBTreePage >> items [
-	^ items
-]
-
-{ #category : #accessing }
-SoilBTreePage >> keySize [
-	^ keySize
-]
-
-{ #category : #accessing }
-SoilBTreePage >> keySize: anInteger [ 
-	keySize := anInteger
-]
-
-{ #category : #accessing }
-SoilBTreePage >> numberOfItems [
-	^ items size
 ]
 
 { #category : #accessing }
@@ -164,16 +71,6 @@ SoilBTreePage >> readItemsFrom: aStream [
 		items add: (aStream next: self keySize) asInteger -> (aStream next: self valueSize) ]
 ]
 
-{ #category : #initialization }
-SoilBTreePage >> setItems: aCollection [ 
-	items := aCollection
-]
-
-{ #category : #accessing }
-SoilBTreePage >> smallestKey [
-	^ items first key
-]
-
 { #category : #private }
 SoilBTreePage >> split: newPage [
 	| middle |
@@ -185,20 +82,6 @@ SoilBTreePage >> split: newPage [
 	items removeLast: items size - middle.
 	
 	^ newPage
-]
-
-{ #category : #accessing }
-SoilBTreePage >> valueAt: anInteger [ 
-	^ self 
-		valueAt: anInteger 
-		ifAbsent: [ nil ]
-]
-
-{ #category : #accessing }
-SoilBTreePage >> valueAt: anInteger ifAbsent: aBlock [
-	^ (self 
-		associationAt: anInteger
-		ifAbsent: [ ^ aBlock value ]) value
 ]
 
 { #category : #writing }

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -89,6 +89,11 @@ SoilBasicBTree >> isEmpty [
 	^ self store headerPage hasItems not
 ]
 
+{ #category : #testing }
+SoilBasicBTree >> isRegistered [
+	^ self subclassResponsibility
+]
+
 { #category : #accessing }
 SoilBasicBTree >> keySize [
 	^ self headerPage keySize

--- a/src/Soil-Core/SoilClusterRecord.class.st
+++ b/src/Soil-Core/SoilClusterRecord.class.st
@@ -28,6 +28,16 @@ SoilClusterRecord >> addReference: reference [
 	references add: reference 
 ]
 
+{ #category : #'as yet unclassified' }
+SoilClusterRecord >> asNewClusterVersion [
+	^ self subclassResponsibility
+]
+
+{ #category : #'as yet unclassified' }
+SoilClusterRecord >> beChanged [
+	^ self subclassResponsibility
+]
+
 { #category : #accessing }
 SoilClusterRecord >> behaviorDescriptionAt: anInteger [ 
 	(anInteger = 0) ifTrue: [ ^ SoilBehaviorDescription meta ].
@@ -58,6 +68,11 @@ SoilClusterRecord >> bytes: anObject [
 { #category : #asserting }
 SoilClusterRecord >> committed [ 
 	committed := true
+]
+
+{ #category : #'as yet unclassified' }
+SoilClusterRecord >> hasChanged [
+	^ self subclassResponsibility
 ]
 
 { #category : #testing }
@@ -163,6 +178,11 @@ SoilClusterRecord >> serialize [
 	^ ByteArray streamContents: [ :stream |
 		self serializeOn: stream ]
 				
+]
+
+{ #category : #'as yet unclassified' }
+SoilClusterRecord >> shouldBeCommitted [
+	^ self subclassResponsibility
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilIndexPage.class.st
+++ b/src/Soil-Core/SoilIndexPage.class.st
@@ -4,7 +4,9 @@ Class {
 	#instVars : [
 		'index',
 		'dirty',
-		'pageSize'
+		'pageSize',
+		'items',
+		'keySize'
 	],
 	#classInstVars : [
 		'random'
@@ -34,6 +36,41 @@ SoilIndexPage class >> readPageFrom: aStream keySize: keySize valueSize: valueSi
 	^page readFrom: aStream.
 ]
 
+{ #category : #adding }
+SoilIndexPage >> addItem: anAssociation [ 
+	items add: anAssociation.
+	dirty := true
+]
+
+{ #category : #accessing }
+SoilIndexPage >> associationAt: anInteger [ 
+	^ self
+		associationAt: anInteger 
+		ifAbsent: [ nil ]
+]
+
+{ #category : #'as yet unclassified' }
+SoilIndexPage >> associationAt: anInteger ifAbsent: aBlock [
+	^ items 
+		detect: [:each | each key = anInteger ] 
+		ifNone: [ aBlock value ]
+]
+
+{ #category : #'as yet unclassified' }
+SoilIndexPage >> biggestKey [
+	^ self subclassResponsibility
+]
+
+{ #category : #'as yet unclassified' }
+SoilIndexPage >> firstItem [
+	^ items first
+]
+
+{ #category : #'as yet unclassified' }
+SoilIndexPage >> hasRoom [
+	^ self subclassResponsibility
+]
+
 { #category : #utilities }
 SoilIndexPage >> headerSize [ 
 	^ 1 "pageCode" 
@@ -49,6 +86,13 @@ SoilIndexPage >> index: anInteger [
 	index := anInteger
 ]
 
+{ #category : #accessing }
+SoilIndexPage >> indexOfKey: anInteger [ 
+	items withIndexDo: [ :each :idx |
+		(each key = anInteger) ifTrue: [ ^ idx ] ].
+	^ 0
+]
+
 { #category : #writing }
 SoilIndexPage >> indexSize [
 	^ 2
@@ -60,8 +104,55 @@ SoilIndexPage >> isDirty [
 ]
 
 { #category : #testing }
+SoilIndexPage >> isEmpty [
+	^ items isEmpty 
+]
+
+{ #category : #testing }
 SoilIndexPage >> isLastPage [
 	self shouldBeImplemented.
+]
+
+{ #category : #'as yet unclassified' }
+SoilIndexPage >> itemAfter: key [ 
+	^ self subclassResponsibility
+]
+
+{ #category : #'as yet unclassified' }
+SoilIndexPage >> itemCapacity [
+	^ ((self pageSize - self headerSize) / (self keySize + self valueSize)) floor
+]
+
+{ #category : #accessing }
+SoilIndexPage >> itemRemoveAt: key [ 
+	^ self 
+		itemRemoveAt: key 
+		ifAbsent: [ KeyNotFound signalFor: key in: self ]
+]
+
+{ #category : #accessing }
+SoilIndexPage >> itemRemoveAt: anInteger ifAbsent: aBlock [
+	| item |
+	items 
+		findBinaryIndex: [ :each |  anInteger - each key ] 
+		do: [:ind | item := items removeAt: ind ]
+		ifNone: [ ^ aBlock value ].
+	dirty := true.
+	^ item
+]
+
+{ #category : #accessing }
+SoilIndexPage >> itemRemoveIndex: anInteger [
+	| item |
+	item := items at: anInteger.
+	items removeAt: anInteger.
+	dirty := true.
+	^ item
+]
+
+{ #category : #accessing }
+SoilIndexPage >> items [
+	^ items
 ]
 
 { #category : #writing }
@@ -69,6 +160,22 @@ SoilIndexPage >> itemsSizeSize [
 	"as long as we target 65536 bytes as maximum page size a two-byte 
 	number of items is sufficient"
 	^ 2
+]
+
+{ #category : #accessing }
+SoilIndexPage >> keySize [
+	^ keySize
+]
+
+{ #category : #accessing }
+SoilIndexPage >> keySize: anInteger [ 
+	(anInteger = 0) ifTrue: [ Error signal: 'cannot use key size 0' ].
+	keySize := anInteger.
+]
+
+{ #category : #accessing }
+SoilIndexPage >> numberOfItems [
+	^ items size
 ]
 
 { #category : #accessing }
@@ -99,6 +206,30 @@ SoilIndexPage >> readIndexFrom: aStream [
 	we let the dummy read here for compatibility"
 	"index :=" (aStream next: self indexSize) asInteger.
 
+]
+
+{ #category : #accessing }
+SoilIndexPage >> setItems: aCollection [ 
+	items := aCollection
+]
+
+{ #category : #accessing }
+SoilIndexPage >> smallestKey [
+	^ items first key
+]
+
+{ #category : #'as yet unclassified' }
+SoilIndexPage >> valueAt: anInteger [ 
+	^ self 
+		valueAt: anInteger 
+		ifAbsent: [ nil ]
+]
+
+{ #category : #'as yet unclassified' }
+SoilIndexPage >> valueAt: key ifAbsent: aBlock [
+	^ (self 
+		associationAt: key
+		ifAbsent: [ ^ aBlock value ]) value
 ]
 
 { #category : #writing }

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -3,8 +3,6 @@ Class {
 	#superclass : #SoilIndexPage,
 	#instVars : [
 		'right',
-		'items',
-		'keySize',
 		'valueSize',
 		'lastTransaction'
 	],
@@ -28,36 +26,11 @@ SoilSkipListPage class >> pageCode [
 	^ 0 
 ]
 
-{ #category : #adding }
-SoilSkipListPage >> addItem: anAssociation [ 
-	items add: anAssociation.
-	dirty := true
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> associationAt: anInteger [ 
-	^ self 
-		associationAt: anInteger 
-		ifAbsent: [ nil ]
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> associationAt: key ifAbsent: aBlock [
-	^ items 
-		detect: [:each | each key = key ] 
-		ifNone: [ aBlock value ]
-]
-
 { #category : #'as yet unclassified' }
 SoilSkipListPage >> biggestKey [
 	^ self isLastPage 
 		ifTrue: [ (2 raisedTo: (keySize * 8)) - 1 ]
 		ifFalse: [ items last key ]
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> firstItem [
-	^ items first
 ]
 
 { #category : #testing }
@@ -78,15 +51,6 @@ SoilSkipListPage >> headerSize [
 	^ super headerSize + 8 "last transaction number"
 ]
 
-{ #category : #accessing }
-SoilSkipListPage >> indexOfKey: anInteger [ 
-	items withIndexDo: [ :each :idx |
-		(each key = anInteger) ifTrue: [ ^ idx ] ].
-	^ 0
-	
-		
-]
-
 { #category : #initialization }
 SoilSkipListPage >> initialize [ 
 	super initialize.
@@ -105,11 +69,6 @@ SoilSkipListPage >> initializeLevel: anInteger [
 		level := level + 1.
 		promote := self class random next > 0.5 ].
 	right := Array new: level withAll: 0. 
-]
-
-{ #category : #testing }
-SoilSkipListPage >> isEmpty [
-	^ items isEmpty 
 ]
 
 { #category : #testing }
@@ -148,43 +107,6 @@ SoilSkipListPage >> itemAt: key put: anObject [
 	^ removedItem
 ]
 
-{ #category : #'as yet unclassified' }
-SoilSkipListPage >> itemCapacity [
-	^ ((self pageSize - self headerSize) / (self keySize + self valueSize)) floor
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> itemRemoveAt: key [ 
-	^ self 
-		itemRemoveAt: key 
-		ifAbsent: [ KeyNotFound signalFor: key in: self ]
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> itemRemoveAt: anInteger ifAbsent: aBlock [
-	| item |
-	items 
-		findBinaryIndex: [ :each |  anInteger - each key ] 
-		do: [:ind | item := items removeAt: ind ]
-		ifNone: [ ^ aBlock value ].
-	dirty := true.
-	^ item
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> itemRemoveIndex: anInteger [
-	| item |
-	item := items at: anInteger.
-	items removeAt: anInteger.
-	dirty := true.
-	^ item
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> items [
-	^ items
-]
-
 { #category : #accessing }
 SoilSkipListPage >> keyOrClosestAfter: key [ 
 	"find the closest key in this page. This returns the exact key if 
@@ -197,17 +119,6 @@ SoilSkipListPage >> keyOrClosestAfter: key [
 		do: [ :e | e key] 
 		ifNone: [ :a :b | 
 			(items at: (b min: items size)) key ]
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> keySize [ 
-	^ keySize
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> keySize: anInteger [ 
-	(anInteger = 0) ifTrue: [ Error signal: 'cannot use key size 0' ].
-	keySize := anInteger.
 ]
 
 { #category : #accessing }
@@ -247,11 +158,6 @@ SoilSkipListPage >> level [
 { #category : #accessing }
 SoilSkipListPage >> level: anInteger [ 
 	right := Array new: anInteger withAll: 0
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> numberOfItems [
-	^ items size 
 ]
 
 { #category : #copying }
@@ -314,11 +220,6 @@ SoilSkipListPage >> rightSize [
 ]
 
 { #category : #accessing }
-SoilSkipListPage >> setItems: aCollection [ 
-	items := aCollection
-]
-
-{ #category : #accessing }
 SoilSkipListPage >> setRight: aCollection [ 
 	right := aCollection 
 ]
@@ -326,11 +227,6 @@ SoilSkipListPage >> setRight: aCollection [
 { #category : #private }
 SoilSkipListPage >> sizeInBytes [
 	^ self headerSize + (items size * (self keySize + self valueSize))
-]
-
-{ #category : #'as yet unclassified' }
-SoilSkipListPage >> smallestKey [
-	^ items first key
 ]
 
 { #category : #'as yet unclassified' }
@@ -343,20 +239,6 @@ SoilSkipListPage >> split: newPage [
 	items removeLast: items size - middle.
 	^ newPage
 	
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> valueAt: anInteger [ 
-	^ self 
-		valueAt: anInteger 
-		ifAbsent: [ nil ]
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> valueAt: key ifAbsent: aBlock [ 
-	^ (self 
-		associationAt: key
-		ifAbsent: [ ^ aBlock value ]) value
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- move ivars "items keySize" from SoilSkipListPage and SoilBTreePage to the superclass SoilIndexPage
- this allows us to move lots of duplicated methods there, too
- add some #subclassResponsibility methods