### PR TITLE
do not automatically allocate indexes

### DIFF
--- a/src/Soil-Core/SoilNewClusterVersion.class.st
+++ b/src/Soil-Core/SoilNewClusterVersion.class.st
@@ -176,7 +176,7 @@ SoilNewClusterVersion >> serializeOn: stream [
 	references do: [ :ref |
 		"do not write zero index, try to allocate a new index before"
 		(ref index = 0) ifTrue: [ 
-			transaction allocateObjectId: ref ].
+			SoilObjectIdNotInitialized signal: 'index should not be zero' ].
 		ref writeOn: stream ].
 	"indexes"
 	serializer nextPutLengthEncodedInteger: indexIds size.

--- a/src/Soil-Core/SoilObjectId.class.st
+++ b/src/Soil-Core/SoilObjectId.class.st
@@ -100,12 +100,6 @@ SoilObjectId >> initialize [
 	segment := 1
 ]
 
-{ #category : #initialization }
-SoilObjectId >> initializeIndex: objectRepository [ 
-	(index = 0) ifFalse: [ ^ self ].
-	index := (objectRepository segmentAt: segment) allocateNextIndex 
-]
-
 { #category : #testing }
 SoilObjectId >> isInitialized [
 	^ index > 0

--- a/src/Soil-Core/SoilObjectIdNotInitialized.class.st
+++ b/src/Soil-Core/SoilObjectIdNotInitialized.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #SoilObjectIdNotInitialized,
+	#superclass : #SoilError,
+	#category : #'Soil-Core-Error'
+}

--- a/src/Soil-Core/SoilTransaction.class.st
+++ b/src/Soil-Core/SoilTransaction.class.st
@@ -52,11 +52,6 @@ SoilTransaction >> addClusterObject: anObject [
 
 ]
 
-{ #category : #'as yet unclassified' }
-SoilTransaction >> allocateObjectId: aSOObjectId [ 
-	aSOObjectId initializeIndex: self objectRepository 
-]
-
 { #category : #accessing }
 SoilTransaction >> atObjectId: objectId putObject: anObject [
 	| record |


### PR DESCRIPTION
Allocating automatically objectId indexes conflicts with object index management in checkpoint