### PR TITLE
use optimized and: instead of &

### DIFF
--- a/src/Soil-Core/SoilObjectId.class.st
+++ b/src/Soil-Core/SoilObjectId.class.st
@@ -76,7 +76,7 @@ SoilObjectId >> asSoilObjectProxy [
 
 { #category : #testing }
 SoilObjectId >> hasSameSegment: aSegment andIndex: anIndex [ 
-	^ (segment = aSegment) & (index = anIndex) 
+	^ (segment = aSegment) and: [ index = anIndex ]
 ]
 
 { #category : #comparing }
@@ -115,7 +115,7 @@ SoilObjectId >> isObjectId [
 
 { #category : #testing }
 SoilObjectId >> isRemoved [ 
-	^ (segment = 0) & (index = 0)
+	^ (segment = 0) and: [index = 0]
 ]
 
 { #category : #testing }

--- a/src/Soil-Core/SoilPersistentClusterVersion.class.st
+++ b/src/Soil-Core/SoilPersistentClusterVersion.class.st
@@ -156,5 +156,5 @@ SoilPersistentClusterVersion >> serializeOn: stream [
 
 { #category : #asserting }
 SoilPersistentClusterVersion >> shouldBeCommitted [ 
-	^ changed & committed not
+	^ changed and: [ committed not ]
 ]

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -103,7 +103,7 @@ SoilSkipListPage >> initializeLevel: anInteger [
 	| promote level |
 	level := 1. 
 	promote := true.
-	[ (level < anInteger) & (promote = true) ] whileTrue: [ 
+	[ (level < anInteger) and: [ promote ] ] whileTrue: [ 
 		level := level + 1.
 		promote := self class random next > 0.5 ].
 	right := Array new: level withAll: 0. 

--- a/src/Soil-File/SoilLockableStream.class.st
+++ b/src/Soil-File/SoilLockableStream.class.st
@@ -150,7 +150,7 @@ SoilLockableStream >> unlockFrom: from to: to for: lockContext [
 	| lock |
 	lock := locks 
 		detect: [ :each | 
-			(each from = from) & (each to = to) & (each context = lockContext) ]
+			(each from = from) and: [ (each to = to) and: [ each context = lockContext ] ] ]
 		ifNone: [ NotFound signal: 'cannot find lock' ].
 	lock release.
 	locks remove: lock

--- a/src/Soil-File/SoilRangeLock.class.st
+++ b/src/Soil-File/SoilRangeLock.class.st
@@ -30,7 +30,7 @@ SoilRangeLock class >> from: from to: to context: lockContext [
 { #category : #'as yet unclassified' }
 SoilRangeLock >> conflictsFrom: aFrom to: aTo context: contextObject [ 
 	"conflicts if ranges overlap but only for different contexts"
-	^ (self intersectsFrom: aFrom to: aTo) &  (context ~~ contextObject)
+	^ (self intersectsFrom: aFrom to: aTo) and: [ context ~~ contextObject ]
 ]
 
 { #category : #'as yet unclassified' }
@@ -72,8 +72,9 @@ SoilRangeLock >> intersectsFrom: otherFrom to: otherTo [
 ]
 
 { #category : #testing }
-SoilRangeLock >> isFrom: aFrom to: aTo for: contextObject [ 
-	^ (from = aFrom)& (to = aTo) & (context = contextObject)
+SoilRangeLock >> isFrom: aFrom to: aTo for: contextObject [
+
+	^ from = aFrom and: [ to = aTo and: [ context = contextObject ] ]
 ]
 
 { #category : #'as yet unclassified' }


### PR DESCRIPTION
& is a message send and always executes the right hand, while #and: is optimized to ifTrue and does not eval the right hand if receiver is false

Will not have a huge impact, but does removes some message sends