### PR TITLE
- Moved flushing of indexes into the journal so that replication has …

### DIFF
--- a/src/Soil-Core/SoilJournal.class.st
+++ b/src/Soil-Core/SoilJournal.class.st
@@ -39,7 +39,7 @@ SoilJournal >> inspectionContent [
 	<inspectorPresentationOrder: 0 title: 'transaction journals'>
 
 	^ SpTablePresenter new
-		items: (self allTransactionJournals);
+		items: (self transactionJournals);
 		addColumn: (SpStringTableColumn new 
 			title: 'id';
 			evaluated: #id;

--- a/src/Soil-Core/SoilNewCheckpointEntry.class.st
+++ b/src/Soil-Core/SoilNewCheckpointEntry.class.st
@@ -23,7 +23,14 @@ SoilNewCheckpointEntry >> checkpointedAt [
 ]
 
 { #category : #committing }
-SoilNewCheckpointEntry >> commitIn: aTransaction [ 
+SoilNewCheckpointEntry >> commitIn: aTransaction [
+	"make sure behavior registry gets flushed at the end of 
+	a transaction"
+	aTransaction behaviorRegistry flush.
+	"as indexes are just created and keys/values being added,
+	we need to flush sometime and the checkpoint time is good
+	for this"
+	aTransaction indexes do: #flush.
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilTransaction.class.st
+++ b/src/Soil-Core/SoilTransaction.class.st
@@ -207,9 +207,7 @@ SoilTransaction >> checkpoint [
 			write;
 			commitIn: self;
 			checkpoint: self; 
-			close.
-		indexes values do: #flush.
-		soil behaviorRegistry flush ]
+			close ]
 				ensure: [self releaseLocks ] ]
 
 ]
@@ -270,7 +268,7 @@ SoilTransaction >> initialize [
 	objectMap := IdentityDictionary new.
 	behaviorDescriptions := Dictionary new.
 	locks := OrderedCollection new.
-	indexes := IdentityDictionary new
+	indexes := Dictionary new
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Soil-Core/SoilTransactionJournal.class.st
+++ b/src/Soil-Core/SoilTransactionJournal.class.st
@@ -40,7 +40,8 @@ SoilTransactionJournal >> checkpoint: aTransaction [
 		transactionId: aTransaction writeVersion.
 	self addEntry: entry.
 	entry writeOn: stream.
-	stream flush
+	stream flush.
+	entry commitIn: aTransaction.
 ]
 
 { #category : #'as yet unclassified' }


### PR DESCRIPTION
…the same functionality.

- Changed in transaction indexes IdentityDictionary to Dictionary. It used to be a mapping from object to index before. With strings there are duplicates