### PR TITLE
this fixes inspecting the journal from a soil instance.

### DIFF
--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -125,16 +125,14 @@ Soil >> initializeFilesystem [
 			yourself.
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tools }
 Soil >> inspectionJournal [
 	<inspectorPresentationOrder: 2000 title: 'journal'>
-	<ignoreNotImplementedSelectors: #(inspectionContent)>
-
 
 	^ self journal inspectionContent
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tools }
 Soil >> inspectionParameters [
 	<inspectorPresentationOrder: 2100 title: 'parameters'>
 

--- a/src/Soil-Core/SoilJournal.class.st
+++ b/src/Soil-Core/SoilJournal.class.st
@@ -34,12 +34,12 @@ SoilJournal >> importEntry: aSoilTransactionJournal [
 	local write
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tools }
 SoilJournal >> inspectionContent [
 	<inspectorPresentationOrder: 0 title: 'transaction journals'>
 
 	^ SpTablePresenter new
-		items: (self allTransactionJournals);
+		items: (self transactionJournals);
 		addColumn: (SpStringTableColumn new 
 			title: 'id';
 			evaluated: #id;


### PR DESCRIPTION
SoilJournal>>#inspectionContent was using #allTransactionJournals, but there is only #transactionJournals

in addition, categorize the inspector methods as 'tools'