### PR TITLE
remove three block creations from index valueAt: code path

### DIFF
--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -36,7 +36,7 @@ SoilBTreePage >> associationAt: anInteger [
 SoilBTreePage >> associationAt: anInteger ifAbsent: aBlock [
 	^ items 
 		detect: [:each | each key = anInteger ] 
-		ifNone: [ aBlock value ]
+		ifNone: aBlock
 ]
 
 { #category : #accessing }
@@ -191,14 +191,14 @@ SoilBTreePage >> split: newPage [
 SoilBTreePage >> valueAt: anInteger [ 
 	^ self 
 		valueAt: anInteger 
-		ifAbsent: [ nil ]
+		ifAbsent: nil 
 ]
 
 { #category : #accessing }
 SoilBTreePage >> valueAt: anInteger ifAbsent: aBlock [
 	^ (self 
 		associationAt: anInteger
-		ifAbsent: [ ^ aBlock value ]) value
+		ifAbsent: aBlock) value
 ]
 
 { #category : #writing }

--- a/src/Soil-Core/SoilSkipListIterator.class.st
+++ b/src/Soil-Core/SoilSkipListIterator.class.st
@@ -15,7 +15,7 @@ SoilSkipListIterator >> at: aKeyObject ifAbsent: aBlock [
 		startingAt: index headerPage.
 	^ currentPage 
 		valueAt: currentKey
-		ifAbsent: [ aBlock value ]
+		ifAbsent: aBlock 
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -45,7 +45,7 @@ SoilSkipListPage >> associationAt: anInteger [
 SoilSkipListPage >> associationAt: key ifAbsent: aBlock [
 	^ items 
 		detect: [:each | each key = key ] 
-		ifNone: [ aBlock value ]
+		ifNone: aBlock
 ]
 
 { #category : #'as yet unclassified' }
@@ -343,14 +343,14 @@ SoilSkipListPage >> split: newPage [
 SoilSkipListPage >> valueAt: anInteger [ 
 	^ self 
 		valueAt: anInteger 
-		ifAbsent: [ nil ]
+		ifAbsent: nil
 ]
 
 { #category : #accessing }
-SoilSkipListPage >> valueAt: key ifAbsent: aBlock [ 
+SoilSkipListPage >> valueAt: anInteger ifAbsent: aBlock [
 	^ (self 
-		associationAt: key
-		ifAbsent: [ ^ aBlock value ]) value
+		associationAt: anInteger
+		ifAbsent: aBlock) value
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This PR removes some not-needed [ aBlock value ] for cases where the block is really created.

This avoids some creation of blocks for each call of  #valueAt: