### PR TITLE
SoilBTreeDictionary and start to update BTree to the state of SkiList

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexDictionaryTest.class.st
@@ -1,0 +1,149 @@
+Class {
+	#name : #SoilIndexDictionaryTest,
+	#superclass : #ParametrizedTestCase,
+	#instVars : [
+		'soil',
+		'dict',
+		'classToTest'
+	],
+	#category : #'Soil-Core-Tests'
+}
+
+{ #category : #tests }
+SoilIndexDictionaryTest class >> testParameters [
+	^ ParametrizedTestMatrix new
+		addCase: { #classToTest -> SoilBTreeDictionary };
+		addCase: { #classToTest -> SoilSkipListDictionary };
+		yourself
+]
+
+{ #category : #accessing }
+SoilIndexDictionaryTest >> classToTest [
+
+	^ classToTest
+]
+
+{ #category : #accessing }
+SoilIndexDictionaryTest >> classToTest: anObject [
+
+	classToTest := anObject
+]
+
+{ #category : #accessing }
+SoilIndexDictionaryTest >> path [ 
+	^ 'soil-tests'
+]
+
+{ #category : #running }
+SoilIndexDictionaryTest >> setUp [ 
+	super setUp.
+	soil := Soil path: self path.
+	soil 
+		destroy;
+		initializeFilesystem.
+	dict := classToTest new
+		keySize: 10;
+		maxLevel: 8; "ignored for BTree"
+		yourself
+]
+
+{ #category : #running }
+SoilIndexDictionaryTest >> tearDown [ 
+	soil ifNotNil: [ 
+		soil close ].
+	super tearDown.
+]
+
+{ #category : #tests }
+SoilIndexDictionaryTest >> testAddAndRemoveOnNewList [
+  	self 
+		shouldnt: [ dict at: #foo put: #bar ]
+		raise: Error.
+	self assert: (dict at: #foo) equals: #bar.
+	dict removeKey: #foo.
+	self assert: dict size equals: 0
+]
+
+{ #category : #tests }
+SoilIndexDictionaryTest >> testAddToExistingEmptyList [
+	| tx tx2 tx3 tx4 |
+	"create emtpy skip list dictionary ..."
+	"... and persist it"
+	tx := soil newTransaction.
+	tx root: dict.
+	tx commit.
+	"open a second transaction ..."
+	tx2 := soil newTransaction.
+	"... add a key but do not commit"
+	tx2 root
+		at: #foo put: #bar.
+	"open third transaction and try to read the added key. As tx2
+	is not committed the key should not be visible here"
+	tx3 := soil newTransaction.
+	self deny: (tx3 root at: #foo ifAbsent: [#nope]) equals: #bar.
+	"now commit the second transaction"
+	tx2 commit.
+	"try to read the key again. The key should not be visibile because
+	the readVersion is older than the value for that key"
+	self deny: (tx3 root at: #foo ifAbsent: [#nope]) equals: #bar.
+	tx3 abort.	
+	tx4 := soil newTransaction.
+	self assert: (tx4 root at: #foo) equals: #bar
+]
+
+{ #category : #tests }
+SoilIndexDictionaryTest >> testAddToNewList [
+  	self 
+		shouldnt: [ dict at: #foo put: #bar ]
+		raise: Error.
+	self assert: (dict at: #foo) equals: #bar
+]
+
+{ #category : #tests }
+SoilIndexDictionaryTest >> testFirst [
+	dict at: #foo put: #bar.
+	dict at: #foo2 put: #bar2.
+
+	self assert: dict first equals: #bar.
+	self assert: (dict first: 1) first equals: #bar.
+]
+
+{ #category : #tests }
+SoilIndexDictionaryTest >> testIsEmpty [
+	self assert: dict isEmpty.
+	dict at: #foo put: #bar.
+	self deny: dict isEmpty
+]
+
+{ #category : #tests }
+SoilIndexDictionaryTest >> testLast [
+	dict at: #foo put: #bar.
+	dict at: #foo2 put: #bar2.
+
+	self assert: dict last equals: #bar2
+]
+
+{ #category : #tests }
+SoilIndexDictionaryTest >> testSecond [
+	dict at: #foo put: #bar.
+	dict at: #foo2 put: #bar2.
+
+	self assert: dict second equals: #bar2
+]
+
+{ #category : #tests }
+SoilIndexDictionaryTest >> testSize [
+	dict at: #foo put: #bar.
+	dict at: #foo2 put: #bar2.
+
+	self assert: dict size equals: 2
+]
+
+{ #category : #tests }
+SoilIndexDictionaryTest >> testValues [
+	dict at: #foo put: #bar.
+	dict at: #foo2 put: #bar2.
+
+	self assert: (dict values includes: 'bar').
+	self assert: (dict values includes: 'bar2')
+]

--- a/src/Soil-Core/SoilBTree.class.st
+++ b/src/Soil-Core/SoilBTree.class.st
@@ -28,3 +28,8 @@ SoilBTree >> path: aStringOrFileReference [
 
 	path := aStringOrFileReference asFileReference 
 ]
+
+{ #category : #converting }
+SoilBTree >> thePersistentInstance [
+	^ self
+]

--- a/src/Soil-Core/SoilBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilBTreeDataPage.class.st
@@ -44,15 +44,19 @@ SoilBTreeDataPage >> initialize [
 ]
 
 { #category : #accessing }
-SoilBTreeDataPage >> insert: anItem into: aBtree [
-	| newPage |
-	self hasRoom ifTrue: [ self addItem: anItem. ^ nil ].
+SoilBTreeDataPage >> insert: anItem into: anIterator [
+	| newPage choosenPage |
+	self hasRoom ifTrue: [ anIterator currentPage: self. self addItem: anItem. ^ nil ].
 	
 	"No room, we have to split"	
-	newPage := aBtree splitPage: self.
+	newPage := anIterator index splitPage: self.
+	
+	choosenPage := 
 	((self biggestKey < anItem key)
 						ifTrue: [ newPage ]
-						ifFalse: [ self ]) addItem: anItem.
+						ifFalse: [ self ]).
+	choosenPage addItem: anItem.
+	anIterator currentPage: choosenPage.
 	^newPage 
 
 
@@ -61,6 +65,23 @@ SoilBTreeDataPage >> insert: anItem into: aBtree [
 { #category : #testing }
 SoilBTreeDataPage >> isLastPage [
 	^ next == 0
+]
+
+{ #category : #accessing }
+SoilBTreeDataPage >> itemAt: anInteger ifAbsent: aBlock [
+	^ items 
+		findBinaryIndex: [ :each |  anInteger - each key ] 
+		do: [:ind | items at: ind ]
+		ifNone: [ aBlock value ]
+]
+
+{ #category : #accessing }
+SoilBTreeDataPage >> itemAt: key put: anObject [ 
+	| removedItem |
+	removedItem := self itemRemoveAt: key ifAbsent: [ KeyNotFound signal: 'this method is just for replacing items'].
+	items add: (key -> anObject).
+	dirty := true.
+	^ removedItem
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilBTreeDictionary.class.st
+++ b/src/Soil-Core/SoilBTreeDictionary.class.st
@@ -1,0 +1,47 @@
+Class {
+	#name : #SoilBTreeDictionary,
+	#superclass : #SoilSkipListDictionary,
+	#category : #'Soil-Core-Index-BTree'
+}
+
+{ #category : #initialization }
+SoilBTreeDictionary >> initialize [ 
+	newValues := OrderedDictionary new.
+	oldValues := Dictionary new.
+	removedValues := OrderedDictionary new.
+	id := UUID new asString36.
+	index := SoilBTree new
+		initializeHeaderPage;
+		valueSize: 8;
+		yourself
+]
+
+{ #category : #'as yet unclassified' }
+SoilBTreeDictionary >> journalEntries [
+	| entries segment |
+	entries := OrderedCollection new.
+	segment := (transaction objectIdOf: self) segment.
+	self isRegistered ifFalse: [
+		entries add: (SoilNewBTreeListIndexEntry new 
+			transactionId: transaction writeVersion;
+			segment: segment;
+			id: id;
+			keySize: index keySize;
+			valueSize: index valueSize) ].
+	newValues keysAndValuesDo: [ :key :value |
+		entries add: (SoilAddKeyEntry new 
+			transactionId: transaction writeVersion;
+			segment: segment;
+			id: id;
+			key: key;
+			value: value;
+			oldValue: (oldValues at: key ifAbsent: [nil ])) ].
+	removedValues keysAndValuesDo: [ :key :value |
+		entries add: (SoilRemoveKeyEntry new 
+			transactionId: transaction writeVersion;
+			segment: segment;
+			id: id;
+			key: key; 
+			oldValue: value) ].
+	^ entries
+]

--- a/src/Soil-Core/SoilBTreeHeaderPage.class.st
+++ b/src/Soil-Core/SoilBTreeHeaderPage.class.st
@@ -45,7 +45,9 @@ SoilBTreeHeaderPage >> readFrom: aStream [
 SoilBTreeHeaderPage >> readHeaderFrom: aStream [
 	keySize := (aStream next: 2) asInteger.
 	valueSize := (aStream next: 2) asInteger.
-	lastPageIndex :=(aStream next: 2) asInteger 
+	lastPageIndex :=(aStream next: 2) asInteger.
+	self readLastTransactionFrom: aStream
+
 	
 ]
 
@@ -58,7 +60,8 @@ SoilBTreeHeaderPage >> writeOn: aStream [
 		nextPutAll: (next asByteArrayOfSize: self pointerSize);
 		nextPutAll: (keySize asByteArrayOfSize: 2);
 		nextPutAll: (valueSize asByteArrayOfSize: 2);
-		nextPutAll: (lastPageIndex asByteArrayOfSize: 2).
+		nextPutAll: (lastPageIndex asByteArrayOfSize: 2);
+		nextPutAll: (lastTransaction asByteArrayOfSize: 8).
 		
 	self 
 		writeItemsOn: aStream

--- a/src/Soil-Core/SoilBTreeIndexPage.class.st
+++ b/src/Soil-Core/SoilBTreeIndexPage.class.st
@@ -36,17 +36,17 @@ SoilBTreeIndexPage >> headerSize [
 ]
 
 { #category : #accessing }
-SoilBTreeIndexPage >> insert: anItem into: aBtree [
+SoilBTreeIndexPage >> insert: anItem into: anIterator [
 	| indexPage newPage indexItem newIndexPage  |
-	indexPage := self findPageFor: anItem key with: aBtree.
+	indexPage := self findPageFor: anItem key with: anIterator index.
 	indexPage ifNil: [ ^nil ]. "nothing to do"
-	newPage := indexPage insert: anItem into: aBtree.
+	newPage := indexPage insert: anItem into: anIterator.
 	newPage ifNil: [ ^nil ]. "nothing to do"
 	
 	indexItem := newPage smallestKey -> newPage index.
 	"if the insert resulted in a split, we have to update the index, which might habe to split, too"
 	self hasRoom ifTrue: [ self addItem: indexItem . ^ nil ].
-	newIndexPage := aBtree splitIndexPage: self.				
+	newIndexPage := anIterator index splitIndexPage: self.				
 	((newIndexPage smallestKey <= anItem key) 
 		ifTrue: [ newIndexPage ] 
 		ifFalse: [ self ]) addItem: indexItem.

--- a/src/Soil-Core/SoilBTreeIterator.class.st
+++ b/src/Soil-Core/SoilBTreeIterator.class.st
@@ -4,11 +4,44 @@ Class {
 	#category : #'Soil-Core-Index-BTree'
 }
 
+{ #category : #accessing }
+SoilBTreeIterator >> at: aKeyObject ifAbsent: aBlock [
+	currentKey := (aKeyObject asSkipListKeyOfSize: index keySize) asInteger.
+	^ self find: currentKey ifAbsent: aBlock
+]
+
+{ #category : #accessing }
+SoilBTreeIterator >> at: aKeyObject put: anObject [
+	| key |
+	key := (aKeyObject asSkipListKeyOfSize: index keySize) asInteger.
+	^ self 
+		basicAt: key 
+		put: anObject
+]
+
+{ #category : #accessing }
+SoilBTreeIterator >> basicAt: key put: anObject [
+	index rootPage insert: key -> anObject into: self.
+	^anObject
+]
+
 { #category : #private }
 SoilBTreeIterator >> find: key [
 	currentKey := key.
 	currentPage := index rootPage find: key with: index.
 	^ currentPage valueAt: currentKey
+]
+
+{ #category : #private }
+SoilBTreeIterator >> find: key ifAbsent: aBlock [
+	currentKey := key.
+	currentPage := index rootPage find: key with: index.
+	^ currentPage valueAt: currentKey ifAbsent: aBlock
+]
+
+{ #category : #accessing }
+SoilBTreeIterator >> index [
+	^index
 ]
 
 { #category : #accessing }
@@ -47,4 +80,9 @@ SoilBTreeIterator >> nextAssociation [
 				currentPage isEmpty ifTrue: [ ^ nil ].
 				^ currentPage firstItem ifNotNil: [ :item2 | currentKey := item2 key. item2 ] ] ].
 	Error signal: 'shouldnt happen'
+]
+
+{ #category : #'as yet unclassified' }
+SoilBTreeIterator >> updateCurrentTransaction: anInteger [ 
+	currentPage lastTransaction: anInteger
 ]

--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #SoilIndexPage,
 	#instVars : [
 		'items',
-		'keySize'
+		'keySize',
+		'lastTransaction'
 	],
 	#category : #'Soil-Core-Index-BTree'
 }
@@ -75,6 +76,7 @@ SoilBTreePage >> indexOfKey: anInteger [
 SoilBTreePage >> initialize [ 
 	super initialize.
 	items := SortedCollection new.
+	lastTransaction := 0.
 	dirty := true
 ]
 
@@ -86,6 +88,11 @@ SoilBTreePage >> insert: anItem into: aBtree [
 { #category : #testing }
 SoilBTreePage >> isEmpty [
 	^ items isEmpty 
+]
+
+{ #category : #testing }
+SoilBTreePage >> isOlderThan: aVersionNumber [ 
+	^ lastTransaction <= aVersionNumber 
 ]
 
 { #category : #'as yet unclassified' }
@@ -146,6 +153,16 @@ SoilBTreePage >> keySize: anInteger [
 ]
 
 { #category : #accessing }
+SoilBTreePage >> lastTransaction [
+	^ lastTransaction
+]
+
+{ #category : #accessing }
+SoilBTreePage >> lastTransaction: anInteger [ 
+	lastTransaction := anInteger
+]
+
+{ #category : #accessing }
 SoilBTreePage >> numberOfItems [
 	^ items size
 ]
@@ -156,12 +173,23 @@ SoilBTreePage >> pointerSize [
 ]
 
 { #category : #reading }
+SoilBTreePage >> readFrom: aStream [ 
+	super readFrom: aStream.
+	self readLastTransactionFrom: aStream
+]
+
+{ #category : #reading }
 SoilBTreePage >> readItemsFrom: aStream [ 
 	| numberOfItems |
 	numberOfItems := (aStream next: self itemsSizeSize) asInteger.
 	items := SortedCollection new: numberOfItems.
 	numberOfItems timesRepeat: [ 
 		items add: (aStream next: self keySize) asInteger -> (aStream next: self valueSize) ]
+]
+
+{ #category : #writing }
+SoilBTreePage >> readLastTransactionFrom: aStream [ 
+	lastTransaction := (aStream next: 8) asInteger.
 ]
 
 { #category : #initialization }
@@ -199,6 +227,12 @@ SoilBTreePage >> valueAt: anInteger ifAbsent: aBlock [
 	^ (self 
 		associationAt: anInteger
 		ifAbsent: aBlock) value
+]
+
+{ #category : #writing }
+SoilBTreePage >> writeHeaderOn: aStream [ 
+	super writeHeaderOn: aStream.
+	aStream nextPutAll: (lastTransaction asByteArrayOfSize: 8)
 ]
 
 { #category : #writing }

--- a/src/Soil-Core/SoilBTreeRootPage.class.st
+++ b/src/Soil-Core/SoilBTreeRootPage.class.st
@@ -16,20 +16,20 @@ SoilBTreeRootPage >> initialize [
 ]
 
 { #category : #accessing }
-SoilBTreeRootPage >> insert: anItem into: aBtree [
+SoilBTreeRootPage >> insert: anItem into: anIterator [
 	| indexPage newPage indexItem newIndexPage1 newIndexPage2 |
 		
-	indexPage := self findPageFor: anItem key with: aBtree.
+	indexPage := self findPageFor: anItem key with: anIterator index.
 	indexPage ifNil: [ ^nil ]. "nothing to do"
-	newPage := indexPage insert: anItem into: aBtree.
+	newPage := indexPage insert: anItem into: anIterator.
 	newPage ifNil: [ ^nil ]. "nothing to do"
 	
 	indexItem := newPage smallestKey -> newPage index.
 	"if the insert resulted in a split, we have to update the index, which might habe to split, too"
 	self hasRoom ifTrue: [ self addItem: indexItem . ^ nil ].
-	newIndexPage1 := aBtree splitIndexPage: self.
+	newIndexPage1 := anIterator index splitIndexPage: self.
 	"we are the root index page, thus we have to create another index page and move items there"
-	newIndexPage2 := aBtree newIndexPageFromRoot: self.
+	newIndexPage2 := anIterator index newIndexPageFromRoot: self.
 	
 	"here now add entries for newIndexPage1 and newIndexPage2 to self"
 	self addItem: newIndexPage1 smallestKey -> newIndexPage1 index.

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -31,9 +31,10 @@ SoilBasicBTree >> at: anObject ifAbsent: aBlock [
 { #category : #accessing }
 SoilBasicBTree >> at: aKeyObject put: anObject [
 
-	| key |
-	key := (aKeyObject asSkipListKeyOfSize: self keySize) asInteger.
-	self rootPage insert: key -> anObject into: self.
+	self newIterator 
+		at: aKeyObject 
+		put: anObject.
+
 ]
 
 { #category : #'initialize-release' }
@@ -62,6 +63,11 @@ SoilBasicBTree >> first: anInteger [
 			ifNotNil: [ :value | col add: value ]
 			ifNil: [ ^ col ]].
 	^ col
+]
+
+{ #category : #accessing }
+SoilBasicBTree >> flush [
+	self store flush
 ]
 
 { #category : #accessing }
@@ -104,6 +110,11 @@ SoilBasicBTree >> keySize: anInteger [
 { #category : #accessing }
 SoilBasicBTree >> last [
 	^ self newIterator last
+]
+
+{ #category : #accessing }
+SoilBasicBTree >> maxLevel: anIntegeer [
+	"ignored, this allows to switch SkiList and BTree easily"
 ]
 
 { #category : #'instance creation' }
@@ -245,6 +256,17 @@ SoilBasicBTree >> splitPage: page [
 SoilBasicBTree >> store [
 	^ store ifNil: [ 
 		store := self newFileStore ]
+]
+
+{ #category : #accessing }
+SoilBasicBTree >> store: anObject [
+	anObject index: self.
+	store := anObject
+]
+
+{ #category : #converting }
+SoilBasicBTree >> thePersistentInstance [
+	^ self subclassResponsibility
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilCopyOnWriteBTree.class.st
+++ b/src/Soil-Core/SoilCopyOnWriteBTree.class.st
@@ -12,7 +12,7 @@ SoilCopyOnWriteBTree >> isRegistered [
 	^ wrappedBTree isRegistered
 ]
 
-{ #category : #testing }
+{ #category : #converting }
 SoilCopyOnWriteBTree >> thePersistentInstance [
 	^ wrappedBTree
 ]
@@ -26,5 +26,6 @@ SoilCopyOnWriteBTree >> wrappedBTree [
 { #category : #accessing }
 SoilCopyOnWriteBTree >> wrappedBTree: anObject [
 
-	wrappedBTree := anObject
+	wrappedBTree := anObject.
+	self store: wrappedBTree store asCopyOnWriteStore 
 ]

--- a/src/Soil-Core/SoilNewBTreeListIndexEntry.class.st
+++ b/src/Soil-Core/SoilNewBTreeListIndexEntry.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #SoilNewBTreeListIndexEntry,
+	#superclass : #SoilNewIndexEntry,
+	#category : #'Soil-Core-Journal'
+}
+
+{ #category : #committing }
+SoilNewBTreeListIndexEntry >> commitIn: aSoilTransaction [
+
+	| index indexManager |
+	indexManager := (aSoilTransaction segmentAt: segment) indexManager.
+	index := SoilBTree new
+		path: (indexManager pathFor: id);
+		initializeFilesystem;
+		initializeHeaderPage;
+		keySize: keySize;
+		valueSize: valueSize;
+		flush.
+	indexManager at: id put: index
+]


### PR DESCRIPTION
- add SoilBTreeDictionary (as a subclass of SoilSkipListDictionary to see how much we can share)
- add Matrix test SoilIndexDictionaryTest that tests SoilSkipListDictionary and SoilBTreeDictionary at the same time 
- add some tesets from the Skiplist dictionary tests 
- write last transaction in the BTree pages
- start to adapt BTree code to the changes done

More has to be done, but tests are green so it is a good sync point to merge