### PR TITLE
firstAssociation: add check for empty newValues

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexDictionaryTest.class.st
@@ -157,6 +157,28 @@ SoilIndexDictionaryTest >> testFirst [
 ]
 
 { #category : #tests }
+SoilIndexDictionaryTest >> testFirstWithSingleRemovedItem [ 
+	
+	dict at: #foo put: #bar.
+	dict removeKey: #foo.
+	self assert: dict firstAssociation equals: nil
+]
+
+{ #category : #tests }
+SoilIndexDictionaryTest >> testFirstWithTransaction [
+	| tx tx2 |
+	tx := soil newTransaction.
+	tx root: dict.
+	dict at: #foo put: #one.
+	tx commit.
+	"open a second transaction ..."
+	tx2 := soil newTransaction.
+	"and test first"
+	self assert: tx2 root first equals: #one
+
+]
+
+{ #category : #tests }
 SoilIndexDictionaryTest >> testIsEmpty [
 	self assert: dict isEmpty.
 	dict at: #foo put: #bar.
@@ -169,6 +191,13 @@ SoilIndexDictionaryTest >> testLast [
 	dict at: #foo2 put: #bar2.
 
 	self assert: dict last equals: #bar2
+]
+
+{ #category : #tests }
+SoilIndexDictionaryTest >> testLastWithSingleRemovedItem [ 
+	dict at: #foo put: #bar.
+	dict removeKey: #foo.
+	self assert: dict lastAssociation equals: nil
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/SoilSkipListDictionary.class.st
+++ b/src/Soil-Core/SoilSkipListDictionary.class.st
@@ -146,7 +146,8 @@ SoilSkipListDictionary >> first: anInteger [
 
 { #category : #accesing }
 SoilSkipListDictionary >> firstAssociation [
-	self index isRegistered ifFalse: [ 
+	self index isRegistered ifFalse: [
+		newValues ifEmpty: [ ^nil ].
 		^ newValues at: (newValues keyAtIndex: 1) ].
 	^ index newIterator firstAssociation ifNotNil: [ :assoc | 
 			assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ]


### PR DESCRIPTION
- add more tests for the index dictionaries
- #testFirstWithTransaction shows that we need to guard #firstAssociation for empty #newValues