### PR TITLE
413-testLastWithTransaction-and-implement-last-and-lasTransaction-as-we-have-first 

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexDictionaryTest.class.st
@@ -169,7 +169,9 @@ SoilIndexDictionaryTest >> testFirstWithTransaction [
 	| tx tx2 |
 	tx := soil newTransaction.
 	tx root: dict.
-	dict at: #foo put: #one.
+	dict at: 1 put: #one.
+	dict at: 2 put: #two.
+	self assert: dict first equals: #one.
 	tx commit.
 	"open a second transaction ..."
 	tx2 := soil newTransaction.
@@ -198,6 +200,21 @@ SoilIndexDictionaryTest >> testLastWithSingleRemovedItem [
 	dict at: #foo put: #bar.
 	dict removeKey: #foo.
 	self assert: dict lastAssociation equals: nil
+]
+
+{ #category : #tests }
+SoilIndexDictionaryTest >> testLastWithTransaction [
+	| tx tx2 |
+	tx := soil newTransaction.
+	tx root: dict.
+	dict at: 1 put: #one.
+	dict at: 2 put: #two.
+	"self assert: dict last equals: #two."
+	tx commit.
+	"open a second transaction ..."
+	tx2 := soil newTransaction.
+	"and test last"
+	self assert: tx2 root last equals: #two
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/SoilSkipListDictionary.class.st
+++ b/src/Soil-Core/SoilSkipListDictionary.class.st
@@ -250,19 +250,17 @@ SoilSkipListDictionary >> keySize: anInteger [
 
 { #category : #accessing }
 SoilSkipListDictionary >> last [
-	| assoc |
 	^ transaction 
-		ifNotNil: [  
-			assoc := self index newIterator lastAssociation.
-			assoc ifNil: [ ^ nil ].
-			assoc value isRemoved ifTrue: [ ^ nil ].
-			assoc key -> (transaction proxyForObjectId: assoc value asSoilObjectId) ]
+		ifNotNil: [ self proxyFromByteArray: self index last ]
 		ifNil: [ newValues associations last value ]
 ]
 
 { #category : #accessing }
 SoilSkipListDictionary >> lastAssociation [
-	^ self index newIterator lastAssociation ifNotNil: [ :assoc | 
+	self index isRegistered ifFalse: [
+		newValues ifEmpty: [ ^nil ].
+		^ newValues at: (newValues keyAtIndex: newValues size) ].
+	^ index newIterator lastAssociation ifNotNil: [ :assoc | 
 		assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ]
 
 ]


### PR DESCRIPTION
- add test #testLastWithTransaction for SoilIndexDictionaryTest

- implement SoilSkipListDictionary #last and #lastAssociation the same as #first and #firstAssociation  (the isRemoved check is done by #lastAssociation of the iterator)

- add isRegistered check for SoilSkipListDictionary>>lastAssociation as we have it for firstAssociation
	
- improve test testFirstWithTransaction to have two keyes

fixes #413

This adds the #isRegistered check to be in sync with  #firstAssociation, but that is odd (see #408)