### PR TITLE
added critical section for reading and writing database version

### DIFF
--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -80,12 +80,14 @@ Soil >> critical: aBlock [
 
 { #category : #accessing }
 Soil >> databaseVersion [
-	^ settings databaseVersion
+	"avoid concurrent reading of the stream"
+	^ semaphore critical: [settings databaseVersion]
 ]
 
 { #category : #accessing }
 Soil >> databaseVersion: anInteger [ 
-	settings databaseVersion: anInteger
+	"avoid concurrent writing of the stream"
+	semaphore critical: [settings databaseVersion: anInteger]
 ]
 
 { #category : #'as yet unclassified' }


### PR DESCRIPTION
I wonder what would could be the result of concurrent reading and writing of the database version.
I don;t know if that's the cause, but it feels like there could be conflicts if two concurrent transaction in the same image try to read and write the setting file at the same time