### PR TITLE
SoilSkipListDictionary: #lastAssociation check transaction, not #isRegistered

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexDictionaryTest.class.st
@@ -157,11 +157,19 @@ SoilIndexDictionaryTest >> testFirst [
 ]
 
 { #category : #tests }
-SoilIndexDictionaryTest >> testFirstWithSingleRemovedItem [ 
+SoilIndexDictionaryTest >> testFirstAssociationWithSingleRemovedItem [ 
 	
 	dict at: #foo put: #bar.
 	dict removeKey: #foo.
 	self assert: dict firstAssociation equals: nil
+]
+
+{ #category : #tests }
+SoilIndexDictionaryTest >> testFirstWithSingleRemovedItem [ 
+	
+	dict at: #foo put: #bar.
+	dict removeKey: #foo.
+	self assert: dict first equals: nil
 ]
 
 { #category : #tests }
@@ -196,10 +204,17 @@ SoilIndexDictionaryTest >> testLast [
 ]
 
 { #category : #tests }
-SoilIndexDictionaryTest >> testLastWithSingleRemovedItem [ 
+SoilIndexDictionaryTest >> testLastAssociationWithSingleRemovedItem [ 
 	dict at: #foo put: #bar.
 	dict removeKey: #foo.
 	self assert: dict lastAssociation equals: nil
+]
+
+{ #category : #tests }
+SoilIndexDictionaryTest >> testLastWithSingleRemovedItem [ 
+	dict at: #foo put: #bar.
+	dict removeKey: #foo.
+	self assert: dict last equals: nil
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/SoilSkipListDictionary.class.st
+++ b/src/Soil-Core/SoilSkipListDictionary.class.st
@@ -131,8 +131,10 @@ SoilSkipListDictionary >> do: aBlock [
 { #category : #accessing }
 SoilSkipListDictionary >> first [
 	^ transaction 
-		ifNotNil: [ self proxyFromByteArray: self index first ]
-		ifNil: [ newValues associations first value ]
+		ifNotNil: [ self proxyFromByteArray: self index newIterator first ]
+		ifNil: [ 
+			"associations is sorted"
+			newValues associations ifNotEmpty: [:nv | nv first value ] ifEmpty: nil]
 ]
 
 { #category : #accessing }
@@ -144,14 +146,16 @@ SoilSkipListDictionary >> first: anInteger [
 		ifNil: [ (newValues associations first: anInteger) collect: #value ]  
 ]
 
-{ #category : #accesing }
+{ #category : #accessing }
 SoilSkipListDictionary >> firstAssociation [
-	self index isRegistered ifFalse: [
-		newValues ifEmpty: [ ^nil ].
-		^ newValues at: (newValues keyAtIndex: 1) ].
-	^ index newIterator firstAssociation ifNotNil: [ :assoc | 
-			assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ]
 
+	^ transaction
+		  ifNotNil: [
+			  index newIterator firstAssociation ifNotNil: [ :assoc |
+				  assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ] ]
+		  ifNil: [ 
+			"associations is sorted" 
+			newValues associations ifNotEmpty: [:nv | nv first ] ifEmpty: nil]
 ]
 
 { #category : #'as yet unclassified' }
@@ -251,18 +255,22 @@ SoilSkipListDictionary >> keySize: anInteger [
 { #category : #accessing }
 SoilSkipListDictionary >> last [
 	^ transaction 
-		ifNotNil: [ self proxyFromByteArray: self index last ]
-		ifNil: [ newValues associations last value ]
+		ifNotNil: [ self proxyFromByteArray: self index newIterator last ]
+		ifNil: [ 
+			"associations is sorted"
+			newValues associations ifNotEmpty: [:nv | nv last value ] ifEmpty: nil ]
 ]
 
 { #category : #accessing }
 SoilSkipListDictionary >> lastAssociation [
-	self index isRegistered ifFalse: [
-		newValues ifEmpty: [ ^nil ].
-		^ newValues at: (newValues keyAtIndex: newValues size) ].
-	^ index newIterator lastAssociation ifNotNil: [ :assoc | 
-		assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ]
 
+	^ transaction
+		  ifNotNil: [
+			  index newIterator lastAssociation ifNotNil: [ :assoc |
+				  assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ] ]
+		  ifNil: [ 
+			"associations is sorted" 
+			newValues associations ifNotEmpty: [:nv | nv last ] ifEmpty: nil ]
 ]
 
 { #category : #private }


### PR DESCRIPTION
- make sure to have test for #first, firstAssociation,  #last and #lastAssociation without transaction

- in #lastAssociation and #firstAssociation, check for transaction nil, not #isRegistered
- guard first and last for empty newValues
- use sorted #associations in #lastAssociation and #firstAssociation as we did alread in #last and #first

Fixes #419