### PR TITLE
SoilMaterializer #nextMessage: is dead code, remove it

### DIFF
--- a/src/Soil-Serializer/SoilMaterializer.class.st
+++ b/src/Soil-Serializer/SoilMaterializer.class.st
@@ -182,16 +182,6 @@ SoilMaterializer >> nextInternalReference [
 ]
 
 { #category : #reading }
-SoilMaterializer >> nextMessage: aClass [ 
-	| message |
-	message := aClass new.
-	self registerObject: message.
-	^ message
-		setSelector: self nextSoilObject arguments: self nextSoilObject;
-		yourself
-]
-
-{ #category : #reading }
 SoilMaterializer >> nextOrderedCollection: aClass [ 
 		| size collection |
 	size := self  nextLengthEncodedInteger.


### PR DESCRIPTION
.. I forgot to remove that when we removed the type code for Message