### PR TITLE
Trivial: tag #isAbstract methods for code coverage, categorize Soil-Files

### DIFF
--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #testing }
 SoilIndexIterator class >> isAbstract [
-
+	<ignoreForCoverage>
 	^ self == SoilIndexIterator
 ]
 

--- a/src/Soil-Core/SoilPagedIndexStore.class.st
+++ b/src/Soil-Core/SoilPagedIndexStore.class.st
@@ -11,6 +11,7 @@ Class {
 
 { #category : #testing }
 SoilPagedIndexStore class >> isAbstract [
+	<ignoreForCoverage>
 	^ self == SoilPagedIndexStore
 ]
 

--- a/src/Soil-File/SoilFileLockRegistry.class.st
+++ b/src/Soil-File/SoilFileLockRegistry.class.st
@@ -27,7 +27,7 @@ SoilFileLockRegistry class >> initialize [
 	self reset
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SoilFileLockRegistry class >> numberOfRegistries [
 	^ registries size
 ]
@@ -61,7 +61,7 @@ SoilFileLockRegistry >> initialize [
 	semaphore := Semaphore forMutualExclusion
 ]
 
-{ #category : #accessing }
+{ #category : #locking }
 SoilFileLockRegistry >> lockFrom: from to: to for: currentLockingObject [ 
 	^ self addLock: (SoilRangeLock from: from to: to context: currentLockingObject)
 ]
@@ -95,7 +95,7 @@ SoilFileLockRegistry >> removeLock: aSORangeLock [
 		locks remove: aSORangeLock ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #locking }
 SoilFileLockRegistry >> unlockFrom: from to: to for: contextObject [ 
 	| lock |
 	^ semaphore critical: [  

--- a/src/Soil-File/SoilLockableStream.class.st
+++ b/src/Soil-File/SoilLockableStream.class.st
@@ -18,7 +18,7 @@ SoilLockableStream class >> path: aStringOrFileReference [
 		yourself
 ]
 
-{ #category : #'initialize-release' }
+{ #category : #'open/close' }
 SoilLockableStream >> close [
 	self releaseAllLocks.
 	fileStream ifNotNil: [  

--- a/src/Soil-File/SoilRangeLock.class.st
+++ b/src/Soil-File/SoilRangeLock.class.st
@@ -27,13 +27,13 @@ SoilRangeLock class >> from: from to: to context: lockContext [
 		context: lockContext 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SoilRangeLock >> conflictsFrom: aFrom to: aTo context: contextObject [ 
 	"conflicts if ranges overlap but only for different contexts"
 	^ (self intersectsFrom: aFrom to: aTo) and: [ context ~~ contextObject ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SoilRangeLock >> conflictsWith: aSORangeLock [ 
 	^ aSORangeLock conflictsFrom: from to: to context: context
 ]
@@ -62,7 +62,7 @@ SoilRangeLock >> from: anObject [
 	from := anObject
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SoilRangeLock >> intersectsFrom: otherFrom to: otherTo [ 
 	"other range is before"
 	(otherTo < from) ifTrue: [ ^ false ].
@@ -77,13 +77,13 @@ SoilRangeLock >> isFrom: aFrom to: aTo for: contextObject [
 	^ from = aFrom and: [ to = aTo and: [ context = contextObject ] ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #locking }
 SoilRangeLock >> lockInMemory: aLockRegistry [ 
 	aLockRegistry addLock: self 
 	 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #locking }
 SoilRangeLock >> lockOn: aStream [ 
 	stream := aStream wrappedStream.
 	stream lockAt: from length: to - from 


### PR DESCRIPTION
- make sure all #isAbtract methods are inored for code coverage
- categorize all method in the Soil-File package