### PR TITLE
checkpoint and continue should both do nothing when recordsToCommit isEmpty

### DIFF
--- a/src/Soil-Core-Tests/SoilTest.class.st
+++ b/src/Soil-Core-Tests/SoilTest.class.st
@@ -50,6 +50,41 @@ SoilTest >> tearDown [
 ]
 
 { #category : #tests }
+SoilTest >> testCheckpointEmptyRecordsToCommit [
+	| tx root skipList obj items |
+	tx := soil newTransaction.
+	root := SoilPersistentDictionary new.
+	"N.B. Having the skip list at the root, did not trigger the error"
+	tx makeRoot: root.
+	tx root: root.
+	tx checkpointAndContinue.
+
+	skipList := SoilSkipListDictionary new keySize: 32; maxLevel: 8; yourself.
+	tx makeRoot: skipList.
+	tx root at: 123 put: skipList.
+
+	obj := SoilTestClass1 new one: #oneA; yourself.
+	tx makeRoot: obj.
+	skipList at: 'aaa' asByteArray put: obj.
+
+	obj := SoilTestClass1 new one: #oneB; yourself.
+	tx makeRoot: obj.
+	skipList at: 'bbb' asByteArray put: obj.
+
+	tx checkpointAndContinue.
+
+	self
+		shouldnt: [
+			"Doesn't always trigger error. Try more repeats, if don't see the error"
+			5 timesRepeat: [
+				skipList := tx root at: 123.
+				"N.B. Have to actually pull in the proxy object to trigger error"
+				items := skipList values collect: [ :each | each one ].
+				tx checkpointAndContinue ] ]
+		raise: Error
+]
+
+{ #category : #tests }
 SoilTest >> testIncompatibleDatabaseFormatVersion [ 
 	soil settings databaseFormatVersion: 2.
 	soil close.

--- a/src/Soil-Core/SoilTransaction.class.st
+++ b/src/Soil-Core/SoilTransaction.class.st
@@ -234,6 +234,8 @@ SoilTransaction >> commit [
 
 { #category : #actions }
 SoilTransaction >> continue [
+	"recordsToCommit ifEmpty: [ self crTrace: 'EMPTY recordsToCommit' ]."
+	recordsToCommit ifEmpty: [ ^ self ].
 	recordsToCommit do: [ :record | | persistentRecord |
 		persistentRecord := record asPersistentClusterVersion.
 		objectMap at: record object put: persistentRecord.

--- a/src/Soil-Core/SoilTransaction.class.st
+++ b/src/Soil-Core/SoilTransaction.class.st
@@ -234,7 +234,6 @@ SoilTransaction >> commit [
 
 { #category : #actions }
 SoilTransaction >> continue [
-	"recordsToCommit ifEmpty: [ self crTrace: 'EMPTY recordsToCommit' ]."
 	recordsToCommit ifEmpty: [ ^ self ].
 	recordsToCommit do: [ :record | | persistentRecord |
 		persistentRecord := record asPersistentClusterVersion.


### PR DESCRIPTION
Add guard clause to SoilTransaction>>#continue when recordsToCommit is empty, which parallels what happens in #checkpoint. Otherwise, the journal entry sometimes has a writeVersion of nil, leading to an error.