### PR TITLE
421-SoilIndexIteratorlastAssociation-when-last-value-was-removed 

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexDictionaryTest.class.st
@@ -233,6 +233,22 @@ SoilIndexDictionaryTest >> testLastWithTransaction [
 ]
 
 { #category : #tests }
+SoilIndexDictionaryTest >> testLastWithTransactionRemoveLast [
+	| tx tx2 |
+	tx := soil newTransaction.
+	tx root: dict.
+	dict at: 1 put: #one.
+	dict at: 2 put: #two.
+	"self assert: dict last equals: #two."
+	tx commit.
+	"open a second transaction ..."
+	tx2 := soil newTransaction.
+	tx2 root removeKey: 2.
+	"and test last"
+	self assert: tx2 root last equals: #one
+]
+
+{ #category : #tests }
 SoilIndexDictionaryTest >> testNextAfterWithTransaction [
 	| tx tx2 |
 	tx := soil newTransaction.

--- a/src/Soil-Core/SoilBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilBTreeDataPage.class.st
@@ -85,14 +85,16 @@ SoilBTreeDataPage >> itemAt: key put: anObject [
 ]
 
 { #category : #accessing }
+SoilBTreeDataPage >> itemBefore: key [ 
+	| item |
+	item := items at: key ifAbsent: nil.
+	^ items before: item ifAbsent: nil
+]
+
+{ #category : #accessing }
 SoilBTreeDataPage >> lastItem [
-	| item maxKey |
-	items ifEmpty: [ ^ nil ].
-	maxKey := (2 raisedTo: (keySize * 8)) - 1. 
-	item := items last.
-	^ (item key = maxKey)
-		ifTrue: [ items at: items size - 1 ]
-		ifFalse: [ item ] 
+
+	^ items ifEmpty: [ nil ] ifNotEmpty: [ :itms | itms last ]
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilBTreeDataPage.class.st
@@ -85,9 +85,10 @@ SoilBTreeDataPage >> itemAt: key put: anObject [
 ]
 
 { #category : #accessing }
-SoilBTreeDataPage >> itemBefore: key [ 
+SoilBTreeDataPage >> itemBefore: key [
+
 	| item |
-	item := items at: key ifAbsent: nil.
+	item := items at: key ifAbsent: [ ^ nil ].
 	^ items before: item ifAbsent: nil
 ]
 

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -87,7 +87,8 @@ SoilIndexIterator >> lastAssociation [
 	[item notNil and: [ item value isRemoved ]] whileTrue: [  
 		item := lastPage itemBefore: item key].
 	
-	"if we did not find it in the last page, it does not exist"
+	self flag: #TODO.
+	"if we did not find it in the last page, we need to check the page before"
 	item ifNil: [ ^nil ].	
 	currentKey := item key.
 	^ item 

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -79,16 +79,19 @@ SoilIndexIterator >> last [
 
 { #category : #accessing }
 SoilIndexIterator >> lastAssociation [
-	self flag: #todo.
-	"this does not work if the last item has been removed. 
-	Going back is not easy in a skip list"
-	^ self lastPage lastItem  "sets currentPage"
-		ifNotNil: [: assoc | 
-			assoc value isRemoved 
-				ifTrue: [ nil ]
-				ifFalse: [ 
-					currentKey := assoc key.
-					assoc ] ]
+	| lastPage item |
+	lastPage := self lastPage.
+	item := lastPage lastItem.  "sets currentPage"
+	
+	"if the last value is removed, take the one before"
+	[item notNil and: [ item value isRemoved ]] whileTrue: [  
+		item := lastPage itemBefore: item key].
+	
+	"if we did not find it in the last page, it does not exist"
+	item ifNil: [ ^nil ].	
+	currentKey := item key.
+	^ item 
+	
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -150,6 +150,13 @@ SoilSkipListPage >> itemAt: key put: anObject [
 	^ removedItem
 ]
 
+{ #category : #accessing }
+SoilSkipListPage >> itemBefore: key [ 
+	| item |
+	item := items at: key ifAbsent: nil.
+	^ items before: item ifAbsent: nil
+]
+
 { #category : #'as yet unclassified' }
 SoilSkipListPage >> itemCapacity [
 	^ ((self pageSize - self headerSize) / (self keySize + self valueSize)) floor
@@ -214,8 +221,8 @@ SoilSkipListPage >> keySize: anInteger [
 
 { #category : #accessing }
 SoilSkipListPage >> lastItem [
-	items ifEmpty: [ ^ nil ].
-	^ items last
+
+	^ items ifEmpty: [ nil ] ifNotEmpty: [ :itms | itms last ]
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -151,9 +151,10 @@ SoilSkipListPage >> itemAt: key put: anObject [
 ]
 
 { #category : #accessing }
-SoilSkipListPage >> itemBefore: key [ 
+SoilSkipListPage >> itemBefore: key [
+
 	| item |
-	item := items at: key ifAbsent: nil.
+	item := items at: key ifAbsent: [ ^ nil ].
 	^ items before: item ifAbsent: nil
 ]
 


### PR DESCRIPTION
- add testLastWithTransactionRemoveLast
- simpler #lastItem (especially  later for cleanBlocks)
- implement #itemBefore:
- #lastAssociation of the iterator now looks for the last non-removed association

fixes #421