### PR TITLE
 422-SoilSkipListDictionarynextAfter-needs-to-check-newValues 

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexDictionaryTest.class.st
@@ -249,6 +249,14 @@ SoilIndexDictionaryTest >> testLastWithTransactionRemoveLast [
 ]
 
 { #category : #tests }
+SoilIndexDictionaryTest >> testNextAfter [
+	dict at: 1 put: #bar.
+	dict at: 2 put: #bar2.
+
+	self assert:( dict nextAfter: 1) equals: #bar2
+]
+
+{ #category : #tests }
 SoilIndexDictionaryTest >> testNextAfterWithTransaction [
 	| tx tx2 |
 	tx := soil newTransaction.

--- a/src/Soil-Core/SoilSkipListDictionary.class.st
+++ b/src/Soil-Core/SoilSkipListDictionary.class.st
@@ -289,6 +289,12 @@ SoilSkipListDictionary >> maxLevel: anInteger [
 { #category : #accessing }
 SoilSkipListDictionary >> nextAfter: key [  
 	| iterator |
+	transaction ifNil: [ 
+		| newValueSorted |
+		self flag: #TODO. "need to sort in key order"
+		newValueSorted := newValues associations.
+		^ (newValueSorted after: (newValues associationAt: key)) value  ].
+
 	iterator := self index newIterator 
 		find: key asInteger;
 		yourself.


### PR DESCRIPTION
- Add #testNextAfter
- fix #nextAfter: to lool into the newValues

Fixes #422

This does not yet fix the case (that we have for all these), that newValues need to be ordered by keyOrder (see https://github.com/ApptiveGrid/Soil/issues/415) (but nevertheless good to merge, there is a #flag:)