### PR TITLE
429-SoilPagedFileIndexStorewriteHeaderPage-is-never-called

### DIFF
--- a/src/Soil-Core/SoilPagedFileIndexStore.class.st
+++ b/src/Soil-Core/SoilPagedFileIndexStore.class.st
@@ -127,16 +127,9 @@ SoilPagedFileIndexStore >> stream [
 ]
 
 { #category : #writing }
-SoilPagedFileIndexStore >> writeHeaderPage [
-	streamSemaphore critical: [  
-		self stream position: 0.
-		self headerPage writeOn: self stream ]
-]
-
-{ #category : #writing }
 SoilPagedFileIndexStore >> writePage: aPage [ 
-	| pagePosition |
 	streamSemaphore critical: [  
+		| pagePosition |
 		pagePosition := self positionOfPageIndex: aPage index.  
 		stream position: pagePosition.
 		aPage writeOn: stream.

--- a/src/Soil-Core/SoilSkipList.class.st
+++ b/src/Soil-Core/SoilSkipList.class.st
@@ -121,11 +121,6 @@ SoilSkipList >> thePersistentInstance [
 ]
 
 { #category : #writing }
-SoilSkipList >> writeHeaderPage [
-	self store writeHeaderPage
-]
-
-{ #category : #writing }
 SoilSkipList >> writePages [
 	self store flushPages
 ]


### PR DESCRIPTION
Cleanup, the writing happes as part of storing the using SoilPagedFileIndexStore>>#flushPages

fixes #429