### PR TITLE
Iterator: pushup #nextAssociation to superclass

### DIFF
--- a/src/Soil-Core/SoilBTreeIterator.class.st
+++ b/src/Soil-Core/SoilBTreeIterator.class.st
@@ -11,15 +11,6 @@ SoilBTreeIterator >> at: aKeyObject ifAbsent: aBlock [
 ]
 
 { #category : #accessing }
-SoilBTreeIterator >> at: aKeyObject put: anObject [
-	| key |
-	key := (aKeyObject asSkipListKeyOfSize: index keySize) asInteger.
-	^ self 
-		basicAt: key 
-		put: anObject
-]
-
-{ #category : #accessing }
 SoilBTreeIterator >> basicAt: key put: anObject [
 	index rootPage insert: key -> anObject into: self.
 	^anObject

--- a/src/Soil-Core/SoilBTreeIterator.class.st
+++ b/src/Soil-Core/SoilBTreeIterator.class.st
@@ -52,32 +52,3 @@ SoilBTreeIterator >> lastPage [
 		currentPage := self pageAt: pageNumber ].
 	^currentPage
 ]
-
-{ #category : #accessing }
-SoilBTreeIterator >> nextAssociation [
-	| item |
-	nextKey ifNotNil: [ 
-		item := currentPage 
-			itemAt: nextKey 
-			ifAbsent: [ Error signal: 'shoulndt be possible' ].
-		nextKey := nil.
-		^ item ].
-	currentPage ifNil: [ 
-		currentPage := index headerPage.
-		currentKey := nil ].
-	[ currentPage isNil ] whileFalse: [  
-		item := currentKey 
-			ifNotNil: [  
-				(currentPage itemAfter: currentKey)
-					ifNotNil: [ :i | 
-						currentKey := i key. 
-						^ i ]
-					ifNil: [ 
-						(currentPage next == 0) ifTrue: [ ^ nil ].
-						currentPage := self pageAt: currentPage next.
-						currentKey := nil ] ]
-			ifNil: [
-				currentPage isEmpty ifTrue: [ ^ nil ].
-				^ currentPage firstItem ifNotNil: [ :item2 | currentKey := item2 key. item2 ] ] ].
-	Error signal: 'shouldnt happen'
-]

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -23,6 +23,20 @@ SoilIndexIterator class >> on: aSoilIndex [
 ]
 
 { #category : #accessing }
+SoilIndexIterator >> at: aKeyObject ifAbsent: aBlock [ 
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+SoilIndexIterator >> at: aKeyObject put: anObject [
+	| key |
+	key := (aKeyObject asSkipListKeyOfSize: index keySize) asInteger.
+	^ self 
+		basicAt: key 
+		put: anObject
+]
+
+{ #category : #accessing }
 SoilIndexIterator >> currentPage [
 
 	^ currentPage

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -108,6 +108,9 @@ SoilIndexIterator >> next [
 { #category : #accessing }
 SoilIndexIterator >> nextAssociation [
 	| item |
+	"preliminary support for nextKey. This is useful when iterating via #next 
+	in order not jump over the first search key. nextKey implies the currentPage
+	is on the right spot"
 	nextKey ifNotNil: [ 
 		item := currentPage 
 			itemAt: nextKey 
@@ -115,7 +118,7 @@ SoilIndexIterator >> nextAssociation [
 		nextKey := nil.
 		^ item ].
 	currentPage ifNil: [ 
-		currentPage := index headerPage.
+		currentPage := index store headerPage.
 		currentKey := nil ].
 	[ currentPage isNil ] whileFalse: [  
 		item := currentKey 
@@ -125,8 +128,8 @@ SoilIndexIterator >> nextAssociation [
 						currentKey := i key. 
 						^ i ]
 					ifNil: [ 
-						(currentPage next == 0) ifTrue: [ ^ nil ].
-						currentPage := self pageAt: currentPage next.
+						(currentPage next = 0) ifTrue: [ ^ nil ].
+						currentPage := index store pageAt: currentPage next.
 						currentKey := nil ] ]
 			ifNil: [
 				currentPage isEmpty ifTrue: [ ^ nil ].

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -107,7 +107,31 @@ SoilIndexIterator >> next [
 
 { #category : #accessing }
 SoilIndexIterator >> nextAssociation [
-	^ self subclassResponsibility
+	| item |
+	nextKey ifNotNil: [ 
+		item := currentPage 
+			itemAt: nextKey 
+			ifAbsent: [ Error signal: 'shoulndt be possible' ].
+		nextKey := nil.
+		^ item ].
+	currentPage ifNil: [ 
+		currentPage := index headerPage.
+		currentKey := nil ].
+	[ currentPage isNil ] whileFalse: [  
+		item := currentKey 
+			ifNotNil: [  
+				(currentPage itemAfter: currentKey)
+					ifNotNil: [ :i | 
+						currentKey := i key. 
+						^ i ]
+					ifNil: [ 
+						(currentPage next == 0) ifTrue: [ ^ nil ].
+						currentPage := self pageAt: currentPage next.
+						currentKey := nil ] ]
+			ifNil: [
+				currentPage isEmpty ifTrue: [ ^ nil ].
+				^ currentPage firstItem ifNotNil: [ :item2 | currentKey := item2 key. item2 ] ] ].
+	Error signal: 'shouldnt happen'
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilSkipListIterator.class.st
+++ b/src/Soil-Core/SoilSkipListIterator.class.st
@@ -109,38 +109,6 @@ SoilSkipListIterator >> levelAt: anInteger [
 	^ levels at: anInteger 
 ]
 
-{ #category : #accessing }
-SoilSkipListIterator >> nextAssociation [
-	| item |
-	"preliminary support for nextKey. This is useful when iterating via #next 
-	in order not jump over the first search key. nextKey implies the currentPage
-	is on the right spot"
-	nextKey ifNotNil: [ 
-		item := currentPage 
-			itemAt: nextKey 
-			ifAbsent: [ Error signal: 'shoulndt be possible' ].
-		nextKey := nil.
-		^ item ].
-	currentPage ifNil: [ 
-		currentPage := index store headerPage.
-		currentKey := nil ].
-	[ currentPage isNil ] whileFalse: [  
-		item := currentKey 
-			ifNotNil: [  
-				(currentPage itemAfter: currentKey)
-					ifNotNil: [ :i | 
-						currentKey := i key. 
-						^ i ]
-					ifNil: [ 
-						((currentPage right at: 1) = 0) ifTrue: [ ^ nil ].
-						currentPage := index store pageAt: (currentPage rightAt: 1).
-						currentKey := nil ] ]
-			ifNil: [
-				currentPage isEmpty ifTrue: [ ^ nil ].
-				^ currentPage firstItem ifNotNil: [ :item2 | currentKey := item2 key. item2 ] ] ].
-	Error signal: 'shouldnt happen'
-]
-
 { #category : #private }
 SoilSkipListIterator >> nextKeyCloseTo: key [
 

--- a/src/Soil-Core/SoilSkipListIterator.class.st
+++ b/src/Soil-Core/SoilSkipListIterator.class.st
@@ -19,15 +19,6 @@ SoilSkipListIterator >> at: aKeyObject ifAbsent: aBlock [
 ]
 
 { #category : #accessing }
-SoilSkipListIterator >> at: aKeyObject put: anObject [
-	| key |
-	key := (aKeyObject asSkipListKeyOfSize: index keySize) asInteger.
-	^ self 
-		basicAt: key 
-		put: anObject
-]
-
-{ #category : #accessing }
 SoilSkipListIterator >> atLevel: key put: anObject [
 	levels at: key put: anObject 
 ]

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -249,6 +249,11 @@ SoilSkipListPage >> level [
 ]
 
 { #category : #accessing }
+SoilSkipListPage >> next [
+	^ self rightAt: 1
+]
+
+{ #category : #accessing }
 SoilSkipListPage >> numberOfItems [
 	^ items size 
 ]


### PR DESCRIPTION
If we add a method #next to #SoilSkipListPage, we can use the same implementation for #nextAssociation (implement it in SoilBTreeIterator)