### PR TITLE
SoilIndexedDictionary: #first/last should use newValues sorted in key-order

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexDictionaryTest.class.st
@@ -149,8 +149,9 @@ SoilIndexDictionaryTest >> testAddToNewList [
 
 { #category : #tests }
 SoilIndexDictionaryTest >> testFirst [
-	dict at: #foo put: #bar.
 	dict at: #foo2 put: #bar2.
+	dict at: #foo put: #bar.
+	
 
 	self assert: dict first equals: #bar.
 	self assert: (dict first: 1) first equals: #bar.
@@ -177,8 +178,8 @@ SoilIndexDictionaryTest >> testFirstWithTransaction [
 	| tx tx2 |
 	tx := soil newTransaction.
 	tx root: dict.
-	dict at: 1 put: #one.
-	dict at: 2 put: #two.
+	dict at: #foo2 put: #two.
+	dict at: #foo put: #one.
 	self assert: dict first equals: #one.
 	tx commit.
 	"open a second transaction ..."

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -133,8 +133,7 @@ SoilIndexedDictionary >> first [
 	^ transaction 
 		ifNotNil: [ self proxyFromByteArray: self index newIterator first ]
 		ifNil: [ 
-			"associations is sorted"
-			newValues associations ifNotEmpty: [:nv | nv first value ] ifEmpty: nil]
+			self newValuesSortedByKeyOrder ifNotEmpty: [:nv | nv first value ] ifEmpty: nil]
 ]
 
 { #category : #accessing }
@@ -143,7 +142,7 @@ SoilIndexedDictionary >> first: anInteger [
 		ifNotNil: [ 
 			(self index first: anInteger) 
 				collect: [ :each | self proxyFromByteArray: each ] ]
-		ifNil: [ (newValues associations first: anInteger) collect: #value ]  
+		ifNil: [ (self newValuesSortedByKeyOrder first: anInteger) collect: #value ]  
 ]
 
 { #category : #accessing }
@@ -153,9 +152,8 @@ SoilIndexedDictionary >> firstAssociation [
 		  ifNotNil: [
 			  index newIterator firstAssociation ifNotNil: [ :assoc |
 				  assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ] ]
-		  ifNil: [ 
-			"associations is sorted" 
-			newValues associations ifNotEmpty: [:nv | nv first ] ifEmpty: nil]
+		  ifNil: [
+			self newValuesSortedByKeyOrder ifNotEmpty: [:nv | nv first ] ifEmpty: nil]
 ]
 
 { #category : #'as yet unclassified' }
@@ -257,8 +255,7 @@ SoilIndexedDictionary >> last [
 	^ transaction 
 		ifNotNil: [ self proxyFromByteArray: self index newIterator last ]
 		ifNil: [ 
-			"associations is sorted"
-			newValues associations ifNotEmpty: [:nv | nv last value ] ifEmpty: nil ]
+			self newValuesSortedByKeyOrder ifNotEmpty: [:nv | nv last value ] ifEmpty: nil ]
 ]
 
 { #category : #accessing }
@@ -269,8 +266,7 @@ SoilIndexedDictionary >> lastAssociation [
 			  index newIterator lastAssociation ifNotNil: [ :assoc |
 				  assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ] ]
 		  ifNil: [ 
-			"associations is sorted" 
-			newValues associations ifNotEmpty: [:nv | nv last ] ifEmpty: nil ]
+			self newValuesSortedByKeyOrder ifNotEmpty: [:nv | nv last ] ifEmpty: nil ]
 ]
 
 { #category : #private }
@@ -287,12 +283,19 @@ SoilIndexedDictionary >> maxLevel: anInteger [
 ]
 
 { #category : #accessing }
+SoilIndexedDictionary >> newValuesSortedByKeyOrder [
+
+	^ newValues associations sort: [ :a :b |
+		(a key asSkipListKeyOfSize: self index keySize) asInteger 
+		< (b key asSkipListKeyOfSize: self index keySize) asInteger ]
+]
+
+{ #category : #accessing }
 SoilIndexedDictionary >> nextAfter: key [  
 	| iterator |
 	transaction ifNil: [ 
 		| newValueSorted |
-		self flag: #TODO. "need to sort in key order"
-		newValueSorted := newValues associations.
+		newValueSorted := self newValuesSortedByKeyOrder.
 		^ (newValueSorted after: (newValues associationAt: key)) value  ].
 
 	iterator := self index newIterator 
@@ -373,7 +376,7 @@ SoilIndexedDictionary >> restoreValue: value forKey: key iterator: iterator [
 SoilIndexedDictionary >> second [
 	^ transaction 
 		ifNotNil: [ self proxyFromByteArray: (index newIterator first; next) ]
-		ifNil: [ newValues associations second value ]
+		ifNil: [ self newValuesSortedByKeyOrder second value ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This PR makes sure that we use first/last and nextAfter: only on a newValues that is sorted the same way than it will be sorted in the index.

see #testFirst for a test that failed before. testFirstWithTransaction test the same with a transaction present (which already worked)

fixes #415