### PR TITLE
Do not use ifEmpty:

### DIFF
--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -200,7 +200,7 @@ SoilSkipListPage >> keyOrClosestAfter: key [
 	"find the closest key in this page. This returns the exact key if 
 	present or the key that comes after. Else returns nil. This is useful if we enter the
 	list at an unknown point"
-	items ifEmpty: [ ^ nil ].
+	items isEmpty ifTrue: [ ^ nil ].
 	self lastKey < key ifTrue: [ ^ nil ].
 	^ items 
 		findBinaryIndex: [ :each | key - each key ] 

--- a/src/Soil-Core/SoilTransaction.class.st
+++ b/src/Soil-Core/SoilTransaction.class.st
@@ -190,7 +190,7 @@ SoilTransaction >> checkpoint [
 	self prepareRecordsForCommit.
 	"if there are no records to commit we can just return and don't allocate any
 	resources"
-	recordsToCommit ifEmpty: [ ^ self ].
+	recordsToCommit isEmpty ifTrue: [ ^ self ].
 	"only one transactions is allowed at a time. We use the critical block of the database
 	to avoid parallel committing"
 	soil critical: [ 
@@ -238,7 +238,7 @@ SoilTransaction >> commit [
 
 { #category : #actions }
 SoilTransaction >> continue [
-	recordsToCommit ifEmpty: [ ^ self ].
+	recordsToCommit isEmpty ifTrue: [ ^ self ].
 	recordsToCommit do: [ :record | | persistentRecord |
 		persistentRecord := record asPersistentClusterVersion.
 		objectMap at: record object put: persistentRecord.

--- a/src/Soil-Serializer-Tests/SoilObjectTableTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilObjectTableTest.class.st
@@ -30,12 +30,3 @@ SoilObjectTableTest >> testIdenityIndexOf [
 	self assert: (table identityIndexOf: 'Hello') equals: 1.
 	self assert: (table identityIndexOf: '2') equals: 0.
 ]
-
-{ #category : #tests }
-SoilObjectTableTest >> testIfEmpty [
-	| table |
-	table := SoilObjectTable new.
-	table ifEmpty: [ self assert: true ].
-	table add: 'Hello'.
-	table ifEmpty: [ self assert: false ].
-]

--- a/src/Soil-Serializer/SoilObjectTable.class.st
+++ b/src/Soil-Serializer/SoilObjectTable.class.st
@@ -20,13 +20,6 @@ SoilObjectTable >> identityIndexOf: anObject [
 ]
 
 { #category : #initialization }
-SoilObjectTable >> ifEmpty: aBlock [
-	^ self isEmpty
-		ifTrue: [ aBlock value ]
-		ifFalse: [ self ]
-]
-
-{ #category : #initialization }
 SoilObjectTable >> initialize [
 	table := IdentityDictionary new
 ]

--- a/src/Soil-Serializer/SoilSerializer.class.st
+++ b/src/Soil-Serializer/SoilSerializer.class.st
@@ -168,11 +168,11 @@ SoilSerializer >> registerIndexId: aString [
 { #category : #registry }
 SoilSerializer >> registerObject: anObject ifAbsent: aBlock [
 	| index externalIndex |
-	objectIdTable ifEmpty: [
+	objectIdTable isEmpty ifTrue: [
 		"the cluster root is serialized first so we put it in the object able
 		for later references. Above we checked for an empty object table so
 		later references to the cluster root will become an internal reference"
-		objectIdTable ifEmpty: [ objectIdTable add: anObject ].
+		objectIdTable add: anObject.
 		^ aBlock value ].
 	index := objectIdTable identityIndexOf: anObject.
 	(index > 0) ifTrue: [


### PR DESCRIPTION
ifEmpty: is compiled so that we have to create the block and do a send, if we replace it with "isEmpty ifTrue", we inline the block.

- remove all ifEmpty sends (and the test/implementation for the SoilObjectTable)
- #registerObject: in the SoilBasicSerializer was checking twice for empty