### PR TITLE
Refactor visitors

### DIFF
--- a/src/Soil-Core-Tests/SoilTest.class.st
+++ b/src/Soil-Core-Tests/SoilTest.class.st
@@ -105,6 +105,22 @@ SoilTest >> testCheckpointEmptyRecordsToCommit [
 ]
 
 { #category : #tests }
+SoilTest >> testFindRecordWithIndex [ 
+	| tx skipList rec |
+	tx := soil newTransaction.
+	skipList := SoilSkipListDictionary new 
+		maxLevel: 16;
+		keySize: 10.
+	tx root: { Dictionary new 
+		at: #skipList put: skipList;
+		yourself }.
+	tx makeRoot: skipList.
+	tx commit.
+	rec := soil findRecord: [ :record | record usesIndexId: skipList id ].
+	self assert: (rec indexIds includes: skipList id)
+]
+
+{ #category : #tests }
 SoilTest >> testIncompatibleDatabaseFormatVersion [ 
 	soil settings databaseFormatVersion: 2.
 	soil close.

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -95,6 +95,14 @@ Soil >> destroy [
 	path delete
 ]
 
+{ #category : #'as yet unclassified' }
+Soil >> findRecord: aBlock [ 
+	| tx |
+	tx := self newTransaction.
+	^ [ tx findRecord: aBlock ]
+		ensure: [ tx abort ]
+]
+
 { #category : #initialization }
 Soil >> initialize [ 
 	super initialize.

--- a/src/Soil-Core/SoilBehaviorRegistry.class.st
+++ b/src/Soil-Core/SoilBehaviorRegistry.class.st
@@ -91,8 +91,7 @@ SoilBehaviorRegistry >> loadHistoryForBehaviorWithIndex: objectIndex transaction
 	chain := records collect: [ :record |
 		record
 			transaction: transaction;
-			materializeObject;
-			object  ].
+			materializeObject  ].
 
 	versions
 		at: objectIndex

--- a/src/Soil-Core/SoilClusterRecord.class.st
+++ b/src/Soil-Core/SoilClusterRecord.class.st
@@ -217,6 +217,11 @@ SoilClusterRecord >> transaction: aSOTransaction [
 	transaction := aSOTransaction 
 ]
 
+{ #category : #testing }
+SoilClusterRecord >> usesIndexId: aString [ 
+	^ indexIds includes: aString
+]
+
 { #category : #accessing }
 SoilClusterRecord >> version [
 

--- a/src/Soil-Core/SoilFindRecordVisitor.class.st
+++ b/src/Soil-Core/SoilFindRecordVisitor.class.st
@@ -1,12 +1,10 @@
 Class {
 	#name : #SoilFindRecordVisitor,
-	#superclass : #SoilVisitor,
+	#superclass : #SoilTransactionalVisitor,
 	#instVars : [
 		'seen',
-		'soil',
 		'condition',
-		'object',
-		'transaction'
+		'object'
 	],
 	#category : #'Soil-Core-Model'
 }

--- a/src/Soil-Core/SoilIndexConsistencyVisitor.class.st
+++ b/src/Soil-Core/SoilIndexConsistencyVisitor.class.st
@@ -1,8 +1,7 @@
 Class {
 	#name : #SoilIndexConsistencyVisitor,
-	#superclass : #SoilVisitor,
+	#superclass : #SoilInstanceVisitor,
 	#instVars : [
-		'soil',
 		'seen'
 	],
 	#category : #'Soil-Core-Model'
@@ -36,13 +35,4 @@ SoilIndexConsistencyVisitor >> visitPagedFileIndexStore: aSoilPagedFileIndexStor
 		page := aSoilPagedFileIndexStore pageAt: pageIndex.
 		(page right allSatisfy: #isZero) ifTrue: [ 
 			(page index = numberOfPages)  ifFalse: [ self halt ] ] ]
-]
-
-{ #category : #visiting }
-SoilIndexConsistencyVisitor >> visitPersistentClusterVersion: aSoilPersistentClusterVersion [ 
-	aSoilPersistentClusterVersion references do: [ :reference |
-		self visit: reference ].
-	aSoilPersistentClusterVersion indexIds do:[ :indexId |
-		self visit: ((soil objectRepository segmentAt: aSoilPersistentClusterVersion  segment) indexAt: indexId)  ].
-	^ aSoilPersistentClusterVersion 
 ]

--- a/src/Soil-Core/SoilInstanceVisitor.class.st
+++ b/src/Soil-Core/SoilInstanceVisitor.class.st
@@ -1,0 +1,28 @@
+Class {
+	#name : #SoilInstanceVisitor,
+	#superclass : #SoilVisitor,
+	#instVars : [
+		'soil'
+	],
+	#category : #'Soil-Core-Model'
+}
+
+{ #category : #accessing }
+SoilInstanceVisitor >> soil [
+
+	^ soil
+]
+
+{ #category : #accessing }
+SoilInstanceVisitor >> soil: anObject [
+
+	soil := anObject
+]
+
+{ #category : #visiting }
+SoilInstanceVisitor >> visitPersistentClusterVersion: aSoilPersistentClusterVersion [ 
+	super visitPersistentClusterVersion: aSoilPersistentClusterVersion.
+	aSoilPersistentClusterVersion indexIds do:[ :indexId |
+		self visit: ((soil objectRepository segmentAt: aSoilPersistentClusterVersion segment) indexAt: indexId)  ].
+	^ aSoilPersistentClusterVersion 
+]

--- a/src/Soil-Core/SoilPersistentClusterVersion.class.st
+++ b/src/Soil-Core/SoilPersistentClusterVersion.class.st
@@ -55,7 +55,8 @@ SoilPersistentClusterVersion >> materializeObject [
 	object := self newMaterializer 
 		stream: bytes readStream;
 		externalObjectRegistry: self;
-		materialize
+		materialize.
+	^ object
 ]
 
 { #category : #'instance creation' }

--- a/src/Soil-Core/SoilTransaction.class.st
+++ b/src/Soil-Core/SoilTransaction.class.st
@@ -266,7 +266,7 @@ SoilTransaction >> dirtyObjects [
 SoilTransaction >> findObject: aBlock [ 
 	"scan all records in the database where the materialized object matches 
 	the condition in aBlock. Return the object of the record instead"
-	^ (self findRecord: [:record | aBlock value: (record materializeObject; object) ]) object
+	^ (self findRecord: [:record | aBlock value: record materializeObject ]) object
 ]
 
 { #category : #'as yet unclassified' }
@@ -415,7 +415,8 @@ SoilTransaction >> markDirty: anObject [
 SoilTransaction >> materializeRecord: record [
 	^ record
 		transaction: self;
-		materializeObject
+		materializeObject;
+		yourself
 ]
 
 { #category : #'instance creation' }

--- a/src/Soil-Core/SoilTransactionalVisitor.class.st
+++ b/src/Soil-Core/SoilTransactionalVisitor.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #SoilTransactionalVisitor,
+	#superclass : #SoilInstanceVisitor,
+	#instVars : [
+		'transaction'
+	],
+	#category : #'Soil-Core-Model'
+}
+
+{ #category : #accessing }
+SoilTransactionalVisitor >> transaction [
+
+	^ transaction
+]
+
+{ #category : #accessing }
+SoilTransactionalVisitor >> transaction: anObject [
+
+	transaction := anObject
+]

--- a/src/Soil-Core/SoilVisitor.class.st
+++ b/src/Soil-Core/SoilVisitor.class.st
@@ -73,8 +73,6 @@ SoilVisitor >> visitParameters: aSoilParameterFile [
 SoilVisitor >> visitPersistentClusterVersion: aSoilPersistentClusterVersion [ 
 	aSoilPersistentClusterVersion references do: [ :reference |
 		self visit: reference ].
-	"aSoilPersistentClusterVersion indexIds do:[ :indexId |
-		self visit: ((soil objectRepository segmentAt: aSoilPersistentClusterVersion  segment) indexAt: indexId)  ]."
 	^ aSoilPersistentClusterVersion 
 ]
 

--- a/src/Soil-Serializer-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilSerializationTest.class.st
@@ -15,7 +15,7 @@ Class {
 SoilSerializationTest >> materializeFromBytes: aByteArray [
 	^ (transaction newPersistentClusterVersion 
 		readFrom: aByteArray readStream)
-		materializeObject  object
+		materializeObject 
 ]
 
 { #category : #'instance creation' }


### PR DESCRIPTION
- Separated visitors for using only structure, a soil instance, a transaction
- added findRecord: on the soil level