### PR TITLE
SoilBasicSerializer: do not use OrderedCollection for keeping track of already seen Objects

### DIFF
--- a/src/Soil-Serializer/SoilBasicSerializer.class.st
+++ b/src/Soil-Serializer/SoilBasicSerializer.class.st
@@ -24,7 +24,7 @@ SoilBasicSerializer >> basicNextPutSymbol: aSymbol [
 { #category : #initialization }
 SoilBasicSerializer >> initialize [ 
 	super initialize.
-	objectIdTable := OrderedCollection new
+	objectIdTable := SoilObjectTable new
 ]
 
 { #category : #'writing - basic' }


### PR DESCRIPTION
This PR changes SoilBasicSerializer to not use a OrderedCollection to store the already seen objects, but instead a SoilObjectTable.

The SoilObjectTable uses an IdentityDictionary. Checking of we have seen an object already is much faster.

fixes #312