### PR TITLE
Code Coverage + fix  SoilIndexedDictionary>>#removeKey:ifAbsent:

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -165,6 +165,21 @@ SoilIndexedDictionaryTest >> testAtIndex [
 ]
 
 { #category : #tests }
+SoilIndexedDictionaryTest >> testAtIndexWithTransaction [
+	| tx tx2 |
+	tx := soil newTransaction.
+	tx root: dict.
+	dict at: 1 put: #one.
+	dict at: 2 put: #two.
+	tx commit.
+	"open a second transaction ..."
+	tx2 := soil newTransaction.
+	"and test atIndex:"
+	self assert: (tx2 root atIndex: 1) equals: #one
+
+]
+
+{ #category : #tests }
 SoilIndexedDictionaryTest >> testDo [
 	| counter |
 	dict at: #foo2 put: #bar2.

--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -367,6 +367,30 @@ SoilIndexedDictionaryTest >> testRemoveKey [
 ]
 
 { #category : #tests }
+SoilIndexedDictionaryTest >> testRemoveKeyIfAbsentWithTransaction [
+
+
+	| tx tx2 tag |
+	tx := soil newTransaction.
+	tx root: dict.
+	dict at: 1 put: #one.
+	dict at: 2 put: #two.
+	"self assert: dict last equals: #two."
+	tx commit.
+	"open a second transaction ..."
+	tx2 := soil newTransaction.
+	"remove the key"
+	tx2 root removeKey: 2.
+	self assert: tx2 root size equals: 1.
+	"remove again to test absent case"
+	tag := false.
+	tx2 root removeKey: 3 ifAbsent: [ tag := true ].
+	self assert: tag.
+	
+
+]
+
+{ #category : #tests }
 SoilIndexedDictionaryTest >> testSecond [
 	dict at: #foo put: #bar.
 	dict at: #foo2 put: #bar2.

--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -165,6 +165,19 @@ SoilIndexedDictionaryTest >> testAtIndex [
 ]
 
 { #category : #tests }
+SoilIndexedDictionaryTest >> testDo [
+	| counter |
+	dict at: #foo2 put: #bar2.
+	dict at: #foo put: #bar.
+	
+	counter := 0.
+	dict do: [ :each |
+		self assert: (each beginsWith: 'bar').
+		counter := counter + 1].
+	self assert: counter equals: 2
+]
+
+{ #category : #tests }
 SoilIndexedDictionaryTest >> testFirst [
 	dict at: #foo2 put: #bar2.
 	dict at: #foo put: #bar.

--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -386,6 +386,10 @@ SoilIndexedDictionaryTest >> testRemoveKeyIfAbsentWithTransaction [
 	tag := false.
 	tx2 root removeKey: 3 ifAbsent: [ tag := true ].
 	self assert: tag.
+	"remove again to test absent case with already removed key"
+	tag := false.
+	tx2 root removeKey: 2 ifAbsent: [ tag := true ].
+	self assert: tag.
 	
 
 ]

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -43,6 +43,16 @@ SoilBasicBTree >> at: aKeyObject put: anObject [
 
 ]
 
+{ #category : #accessing }
+SoilBasicBTree >> atIndex: anInteger [
+	| current iterator |
+	iterator := self newIterator.
+	current := iterator first.
+	2 to: anInteger do: [ :idx |
+		current := iterator next ].
+	^ current value
+]
+
 { #category : #'open/close' }
 SoilBasicBTree >> close [
 	self store close

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -23,6 +23,11 @@ SoilIndexIterator class >> on: aSoilIndex [
 ]
 
 { #category : #accessing }
+SoilIndexIterator >> at: aKeyObject [
+	^ self at: aKeyObject ifAbsent: [ KeyNotFound signalFor: aKeyObject in: self  ] 
+]
+
+{ #category : #accessing }
 SoilIndexIterator >> at: aKeyObject ifAbsent: aBlock [ 
 	^ self subclassResponsibility
 ]

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -315,6 +315,7 @@ SoilIndexedDictionary >> removeKey: key ifAbsent: aBlock [
 			transaction markDirty: self.
 			iterator := self index newIterator.
 			v := iterator at: key ifAbsent: [^ aBlock value ].
+			v isRemoved ifTrue: [ ^ aBlock value ].
 			removedValues 
 				at: key 
 				put: v asSoilObjectId.

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -133,10 +133,7 @@ SoilIndexedDictionary >> do: aBlock [
 					 iterator: iterator) ifNotNil: [ :objectId | 
 					aBlock value: (transaction proxyForObjectId: objectId) ] ] ]
 		ifNil: [ 
-			newValues valuesDo: [ :each | 
-				aBlock value: (each isObjectId
-						 ifTrue: [ transaction proxyForObjectId: each ]
-						 ifFalse: [ each ]) ] ]
+			newValues valuesDo: [ :each | aBlock value: each ] ]
 ]
 
 { #category : #accessing }
@@ -317,7 +314,7 @@ SoilIndexedDictionary >> removeKey: key ifAbsent: aBlock [
 			newValues removeKey: key ifAbsent: nil.
 			transaction markDirty: self.
 			iterator := self index newIterator.
-			v := iterator at: key ifAbsent: [ Error signal ].
+			v := iterator at: key.
 			removedValues 
 				at: key 
 				put: v asSoilObjectId.

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -314,7 +314,7 @@ SoilIndexedDictionary >> removeKey: key ifAbsent: aBlock [
 			newValues removeKey: key ifAbsent: nil.
 			transaction markDirty: self.
 			iterator := self index newIterator.
-			v := iterator at: key.
+			v := iterator at: key ifAbsent: [^ aBlock value ].
 			removedValues 
 				at: key 
 				put: v asSoilObjectId.

--- a/src/Soil-Serializer/SoilPersistentDictionary.class.st
+++ b/src/Soil-Serializer/SoilPersistentDictionary.class.st
@@ -113,9 +113,16 @@ SoilPersistentDictionary >> postCopy [
 ]
 
 { #category : #forwarded }
-SoilPersistentDictionary >> removeKey: anObject [
+SoilPersistentDictionary >> removeKey: key [
+	^ self 
+		removeKey: key 
+		ifAbsent: [ KeyNotFound signalFor: key in: self ]
+]
+
+{ #category : #forwarded }
+SoilPersistentDictionary >> removeKey: anObject ifAbsent: aBlock [
 	| return |
-	return := dict removeKey: anObject.
+	return := dict removeKey: anObject ifAbsent: aBlock.
 	transaction markDirty: self.
 	^return
 ]


### PR DESCRIPTION
- add a version of #at: to #SoilIndexIterator (to not by mistake end up in Object>>#at:)
- add failing test testRemoveKeyIfAbsentWithTransaction
- make sure to evaluate the absent block in SoilIndexedDictionary>>#removeKey:ifAbsent: instead of raising an Error

- SoilIndexedDictionary>> #do:

We do not check in any other method for isObjectId in case of no transaction, we can remove it here, too.

- add a test for do: for indexed dict without transaction