### PR TITLE
Index: Cleanup low level unused removeKey:

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -312,21 +312,6 @@ SoilBTreeTest >> testPageAddFirstAndLoad [
 ]
 
 { #category : #tests }
-SoilBTreeTest >> testRemoveKey [
-
-	| capacity |
-	capacity := btree headerPage itemCapacity.
-	1 to: capacity do: [ :n | btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	
-	btree removeKey: 20.
-	
-	self assert: (btree at: 1) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (btree at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self should: [ btree at: 20 ] raise: KeyNotFound.
-	self should: [ btree removeKey: 20  ] raise: KeyNotFound.
-]
-
-{ #category : #tests }
 SoilBTreeTest >> testSize [
 	
 	| capacity |

--- a/src/Soil-Core-Tests/SoilSkipListTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListTest.class.st
@@ -380,24 +380,6 @@ SoilSkipListTest >> testPageAddFirst [
 ]
 
 { #category : #tests }
-SoilSkipListTest >> testRemoveKey [
-
-	| capacity |
-	capacity := skipList headerPage itemCapacity.
-	1 to: capacity do: [ :n | skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	
-	skipList removeKey: 20.
-	
-	self assert: (skipList at: 1) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (skipList at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self should: [ skipList at: 20  ] raise: KeyNotFound.
-	skipList at: 20 put: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (skipList at: 20) equals: #[ 1 2 3 4 5 6 7 8 ].
-	
-	self should: [ skipList removeKey: capacity + 1 ] raise: KeyNotFound
-]
-
-{ #category : #tests }
 SoilSkipListTest >> testSize [
 	
 	| capacity |

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -224,25 +224,6 @@ SoilBasicBTree >> readPageFrom: aStream [
 	^ SoilBTreePage readPageFrom: aStream keySize: self keySize valueSize: self valueSize
 ]
 
-{ #category : #removing }
-SoilBasicBTree >> removeKey: key [ 
-	^ self
-		removeKey: key 
-		ifAbsent: [ KeyNotFound signalFor: key in: self ]
-]
-
-{ #category : #removing }
-SoilBasicBTree >> removeKey: aString ifAbsent: aBlock [
-	| page index key |
-	key := (aString asSkipListKeyOfSize: self keySize) asInteger.
-	page := self newIterator 
-		find: key;
-		currentPage.
-	^ ((index := page indexOfKey: key) > 0) 
-		ifTrue: [ (page itemRemoveIndex: index) value ]
-		ifFalse: [ aBlock value ]
-]
-
 { #category : #accessing }
 SoilBasicBTree >> rootPage [
 	^ self store pageAt: 2

--- a/src/Soil-Core/SoilBasicSkipList.class.st
+++ b/src/Soil-Core/SoilBasicSkipList.class.st
@@ -163,25 +163,6 @@ SoilBasicSkipList >> pages [
 	^ self store pages
 ]
 
-{ #category : #removing }
-SoilBasicSkipList >> removeKey: key [ 
-	^ self
-		removeKey: key 
-		ifAbsent: [ KeyNotFound signalFor: key in: self ]
-]
-
-{ #category : #removing }
-SoilBasicSkipList >> removeKey: aString ifAbsent: aBlock [
-	| page index key |
-	key := (aString asSkipListKeyOfSize: self keySize) asInteger.
-	page := self newIterator 
-		find: key;
-		currentPage.
-	^ ((index := page indexOfKey: key) > 0) 
-		ifTrue: [ (page itemRemoveIndex: index) value ]
-		ifFalse: [ aBlock value ]
-]
-
 { #category : #accessing }
 SoilBasicSkipList >> size [
 	"We iterate over all elements to get the size. Slow!"


### PR DESCRIPTION
The low level indexes (BTree and SkipList) can not implement a naive #removeKey:

#removeKey: is implemented on the level of IndexedDictionary and marks the entry as deleted. This can only be cleaned up later, one idea is to do it on save (see #459). At that point then we have to remove the deleted item, possibly merge pages and update the index.

This PR removes the #removeKey: implementation on Btree and SkipList, as it is very confusing
- it is not called outside fo the low level tests (not used by IndexDictionary and can not be used by it)
- does not update the indexes 

closes  #272