### PR TITLE
BTree: Cleanup #writeOn: and #headerSize

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -33,14 +33,14 @@ SoilBTreeTest >> testAddFirstOverflow [
 	capacity := btree headerPage itemCapacity.
 	1 to: capacity do: [ :n | btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
 	self assert: btree pages size equals: 3.
-	self assert: (btree pageAt: 1) numberOfItems equals: 128.
+	self assert: (btree pageAt: 1) numberOfItems equals: 127.
 	"if we add a page, the current one is split and half is moved there"
 	btree at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
 	self assert: btree pages size equals: 3.
 	page := btree pageAt: 3.
 	self assert: page numberOfItems equals: 128.
-	self assert: page items first key equals: 129.
-	self assert: page items last key asByteArray equals: #[ 1 0 ].
+	self assert: page items first key equals: 128.
+	self assert: page items last key asByteArray equals: #[ 255 ].
 	"check that the next pointer is correct after split"
 	self assert: (btree pageAt:((btree headerPage) next)) identicalTo: (btree pageAt: 3)
 ]
@@ -77,13 +77,13 @@ SoilBTreeTest >> testAddSecondOverflow [
 	capacity := btree headerPage itemCapacity.
 	1 to: capacity do: [ :n | btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
 	self assert: btree pages size equals: 3.
-	self assert: (btree pageAt: 1) numberOfItems equals: 128.
+	self assert: (btree pageAt: 1) numberOfItems equals: 127.
 	"if we add a page, the current one is split and half is moved there"
 	1 to: capacity do: [ :n | btree at: capacity + n put: #[ 1 2 3 4 5 6 7 8 ]].
 	self assert: btree pages size equals: 4.
 	page := btree pageAt: 4.
-	self assert: page numberOfItems equals: 254.
-	self assert: page items first key equals: 257.
+	self assert: page numberOfItems equals: 253.
+	self assert: page items first key equals: 256.
 	"check that the next pointer is correct after split"
 	self assert: ((btree headerPage nextPageIn: btree) nextPageIn: btree) identicalTo: (btree pageAt: 4).
 	btree writePages.
@@ -96,13 +96,13 @@ SoilBTreeTest >> testAddSecondOverflowReload [
 	capacity := btree headerPage itemCapacity.
 	1 to: capacity do: [ :n | btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
 	self assert: btree pages size equals: 3.
-	self assert: (btree pageAt: 1) numberOfItems equals: 128.
+	self assert: (btree pageAt: 1) numberOfItems equals: 127.
 	"if we add a page, the current one is split and half is moved there"
 	1 to: capacity do: [ :n | btree at: capacity + n put: #[ 1 2 3 4 5 6 7 8 ]].
 	self assert: btree pages size equals: 4.
 	page := btree pageAt: 4.
-	self assert: page numberOfItems equals: 254.
-	self assert: page items first key equals: 257.
+	self assert: page numberOfItems equals: 253.
+	self assert: page items first key equals: 256.
 	"check that the next pointer is correct after split"
 	self assert: ((btree headerPage nextPageIn: btree) nextPageIn: btree) identicalTo: (btree pageAt: 4).
 
@@ -122,7 +122,7 @@ SoilBTreeTest >> testAt [
 	capacity := btree headerPage itemCapacity.
 	1 to: capacity do: [ :n | btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
 	self assert: btree pages size equals: 3.
-	self assert: (btree pageAt: 1) numberOfItems equals: 128.
+	self assert: (btree pageAt: 1) numberOfItems equals: 127.
 	"if we add a page, the current one is split and half is moved there"
 	btree at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
 	self assert: btree pages size equals: 3.
@@ -140,7 +140,7 @@ SoilBTreeTest >> testAtSecondOverflow [
 	capacity := btree headerPage itemCapacity.
 	1 to: capacity*2 do: [ :n | btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
 	self assert: btree pages size equals: 4.
-	self assert: (btree pageAt: 1) numberOfItems equals: 128.
+	self assert: (btree pageAt: 1) numberOfItems equals: 127.
 	"if we add a page, the current one is split and half is moved there"
 	1 to: capacity do: [ :n | btree at: capacity + n put: #[ 1 2 3 4 5 6 7 8 ] ].
 	self assert: btree pages size equals: 4.
@@ -259,8 +259,8 @@ SoilBTreeTest >> testLastPage [
 	1 to: capacity - 1 do: [ :n |
 		btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
 	btree at: capacity put: #[ 8 7 6 5 4 3 2 1 ].
-	self assert: btree pages size equals: 200.
-	self assert: btree lastPage index equals: 200.
+	self assert: btree pages size equals: 199.
+	self assert: btree lastPage index equals: 199.
 	self assert: btree lastPage isLastPage.
 	lastItem := btree lastPage itemAt: capacity ifAbsent: [nil].
 	self assert: lastItem value equals: #[ 8 7 6 5 4 3 2 1 ].
@@ -278,8 +278,8 @@ SoilBTreeTest >> testOverflowCopyOnWriteSplitting [
 
 	page := copyOnWrite pageAt: 3.
 	self assert: page numberOfItems equals: 127.
-	self assert: page items first key equals: 257.
-	self assert: page items last key asByteArray equals: #[ 1 253 ]
+	self assert: page items first key equals: 255.
+	self assert: page items last key asByteArray equals: #[1 251]
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/SoilBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilBTreeDataPage.class.st
@@ -26,7 +26,9 @@ SoilBTreeDataPage >> hasItems [
 
 { #category : #utilities }
 SoilBTreeDataPage >> headerSize [
-	^ self indexSize + self pointerSize
+	^ super headerSize  
+		+ self pointerSize "next"
+		+ 2 "items size"
 ]
 
 { #category : #initialization }
@@ -131,15 +133,8 @@ SoilBTreeDataPage >> valueSize: anInteger [
 ]
 
 { #category : #'reading-writing' }
-SoilBTreeDataPage >> writeNextOn: aStream [
+SoilBTreeDataPage >> writeHeaderOn: aStream [ 
+	super writeHeaderOn: aStream.
 	aStream
 		nextPutAll: (next asByteArrayOfSize: self pointerSize)
-]
-
-{ #category : #'reading-writing' }
-SoilBTreeDataPage >> writeOn: aStream [ 
-	super writeOn: aStream.
-	self 
-		writeNextOn: aStream;
-		writeItemsOn: aStream
 ]

--- a/src/Soil-Core/SoilBTreeHeaderPage.class.st
+++ b/src/Soil-Core/SoilBTreeHeaderPage.class.st
@@ -12,6 +12,15 @@ SoilBTreeHeaderPage class >> pageCode [
 	^ 3
 ]
 
+{ #category : #utilities }
+SoilBTreeHeaderPage >> headerSize [
+	^ super headerSize  
+		+ 2 "valueSize"
+		+ 2 "keySize"
+		+ self pointerSize "lastPageIndex"
+		
+]
+
 { #category : #accessing }
 SoilBTreeHeaderPage >> lastPageIndex: anObject [
 	lastPageIndex := anObject.
@@ -34,35 +43,19 @@ SoilBTreeHeaderPage >> printOn: aStream [
 SoilBTreeHeaderPage >> readFrom: aStream [ 
 	dirty := false.
 	"we do not read the pageCode, that was done before"
-	self readIndexFrom: aStream.
+	self readLastTransactionFrom: aStream.
 	self readNextFrom: aStream.
-	self readHeaderFrom: aStream.
-
+	keySize := (aStream next: 2) asInteger.
+	valueSize := (aStream next: 2) asInteger.
+	lastPageIndex :=(aStream next: self pointerSize) asInteger.
 	self readItemsFrom: aStream
 ]
 
-{ #category : #'initialize-release' }
-SoilBTreeHeaderPage >> readHeaderFrom: aStream [
-	keySize := (aStream next: 2) asInteger.
-	valueSize := (aStream next: 2) asInteger.
-	lastPageIndex :=(aStream next: 2) asInteger.
-	self readLastTransactionFrom: aStream
-
-	
-]
-
 { #category : #writing }
-SoilBTreeHeaderPage >> writeOn: aStream [ 
-	dirty := false.
-	aStream 
-		nextPut: self class pageCode;
-		nextPutAll: (index asByteArrayOfSize: self indexSize);
-		nextPutAll: (next asByteArrayOfSize: self pointerSize);
+SoilBTreeHeaderPage >> writeHeaderOn: aStream [ 
+	super writeHeaderOn: aStream.
+	aStream
 		nextPutAll: (keySize asByteArrayOfSize: 2);
 		nextPutAll: (valueSize asByteArrayOfSize: 2);
-		nextPutAll: (lastPageIndex asByteArrayOfSize: 2);
-		nextPutAll: (lastTransaction asByteArrayOfSize: 8).
-		
-	self 
-		writeItemsOn: aStream
+		nextPutAll: (lastPageIndex asByteArrayOfSize: self pointerSize)
 ]

--- a/src/Soil-Core/SoilBTreeIndexPage.class.st
+++ b/src/Soil-Core/SoilBTreeIndexPage.class.st
@@ -33,7 +33,8 @@ SoilBTreeIndexPage >> hasRoom [
 
 { #category : #utilities }
 SoilBTreeIndexPage >> headerSize [
-	^ self indexSize
+	^ super headerSize  
+		+ 2 "items size"
 ]
 
 { #category : #searching }
@@ -86,23 +87,12 @@ SoilBTreeIndexPage >> readItemsFrom: aStream [
 ]
 
 { #category : #accessing }
+SoilBTreeIndexPage >> valueSize [
+	"our values are indexes of other pages"
+	^ self pointerSize
+]
+
+{ #category : #accessing }
 SoilBTreeIndexPage >> valueSize: anInteger [
 	"ignore, not used, the index pages store the pageID as the value, size is static defined in #pointerSize"
-]
-
-{ #category : #'reading-writing' }
-SoilBTreeIndexPage >> writeItemsOn: aStream [ 
-
-	aStream
-		nextPutAll: (items size asByteArrayOfSize: self itemsSizeSize).
-	items do: [ :assoc |
-		aStream 
-			nextPutAll: (assoc key asByteArrayOfSize: self keySize);
-			nextPutAll: (assoc value asByteArrayOfSize: self pointerSize)]
-]
-
-{ #category : #'reading-writing' }
-SoilBTreeIndexPage >> writeOn: aStream [ 
-	super writeOn: aStream.
-	self writeItemsOn: aStream
 ]

--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -59,7 +59,7 @@ SoilBTreePage >> hasRoom [
 
 { #category : #utilities }
 SoilBTreePage >> headerSize [
-	self subclassResponsibility
+	^ super headerSize + 8 "last transaction number"
 ]
 
 { #category : #accessing }
@@ -161,7 +161,8 @@ SoilBTreePage >> numberOfItems [
 
 { #category : #accessing }
 SoilBTreePage >> pointerSize [
-	^ 2
+	"this is the size in bytes used to point to other pages"
+	^ 4
 ]
 
 { #category : #copying }
@@ -226,6 +227,11 @@ SoilBTreePage >> valueAt: anInteger ifAbsent: aBlock [
 		ifAbsent: aBlock) value
 ]
 
+{ #category : #accessing }
+SoilBTreePage >> valueSize [
+	^ self subclassResponsibility
+]
+
 { #category : #writing }
 SoilBTreePage >> writeHeaderOn: aStream [ 
 	super writeHeaderOn: aStream.
@@ -240,4 +246,10 @@ SoilBTreePage >> writeItemsOn: aStream [
 		aStream 
 			nextPutAll: (assoc key asByteArrayOfSize: self keySize);
 			nextPutAll: (assoc value asByteArrayOfSize: self valueSize)]
+]
+
+{ #category : #writing }
+SoilBTreePage >> writeOn: aStream [ 
+	super writeOn: aStream.
+	self writeItemsOn: aStream
 ]

--- a/src/Soil-Core/SoilIndexPage.class.st
+++ b/src/Soil-Core/SoilIndexPage.class.st
@@ -55,11 +55,6 @@ SoilIndexPage >> index: anInteger [
 	index := anInteger
 ]
 
-{ #category : #writing }
-SoilIndexPage >> indexSize [
-	^ 2
-]
-
 { #category : #testing }
 SoilIndexPage >> isDirty [
 	^ dirty 
@@ -96,15 +91,6 @@ SoilIndexPage >> printOn: aStream [
 SoilIndexPage >> readFrom: aStream [ 
 	dirty := false.
 	"we do not read the pageCode here as it was read already"
-]
-
-{ #category : #writing }
-SoilIndexPage >> readIndexFrom: aStream [ 
-	self flag: #todo.
-	"index should be determined at read time depending on the stream.
-	we let the dummy read here for compatibility"
-	"index :=" (aStream next: self indexSize) asInteger.
-
 ]
 
 { #category : #writing }


### PR DESCRIPTION
- refactor writeOn:
- no need to store the index for the header page
- make sure #headerSize is in sync with the data written
- remove indexSize and #readIndexFrom: 

This PR touches the BTree only (the removed methods on SoilIndexPage have no user in the SkipList)

Due to the fixed headerSize, some test need slight adapatation as the max capacity is now correct (but different to before)