### PR TITLE
 499-Index-removeKey-needs-to-use-restoreValue

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -622,9 +622,11 @@ SoilIndexedDictionaryTest >> testRemoveKeyWithTwoTransactions [
 	tx2 commit.
 	"check that we can still see in the first tr"
 	self assert: (tx root at: 2) equals: #two.
-	"but removeKey: does not see it, to be fixed"
-	self flag: #TODO.
-	"tx root removeKey: 2"
+	"but removeKey: does not see it, we can remove it without error"
+	tx root removeKey: 2 ifAbsent: [ self fail ].
+	self assert: tx root size equals: 1.
+	"but commiting it will fail, as we have commited the remove in t2"
+	self should: [tx commit] raise: SoilObjectHasConcurrentChange
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -314,8 +314,7 @@ SoilIndexedDictionary >> removeKey: key ifAbsent: aBlock [
 			newValues removeKey: key ifAbsent: nil.
 			transaction markDirty: self.
 			iterator := self index newIterator.
-			v := iterator at: key ifAbsent: [^ aBlock value ].
-			v isRemoved ifTrue: [ ^ aBlock value ].
+			v := self basicAt: key ifAbsent: [^ aBlock value].
 			removedValues 
 				at: key 
 				put: v asSoilObjectId.


### PR DESCRIPTION
When removing a key from an Indexed Dictionary, use #basicAt:ifAbsent:  as this correctly restores the value

fixes #499