### PR TITLE
Unify the ivar in the tests of the indexes (btree and skiplist)

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -2,7 +2,7 @@ Class {
 	#name : #SoilBTreeTest,
 	#superclass : #TestCase,
 	#instVars : [
-		'btree'
+		'index'
 	],
 	#category : #'Soil-Core-Tests'
 }
@@ -10,7 +10,7 @@ Class {
 { #category : #running }
 SoilBTreeTest >> setUp [ 
 	super setUp.
-	btree := SoilBTree new 
+	index := SoilBTree new 
 		path: 'sunit-btree';
 		destroy;
 		initializeFilesystem;
@@ -21,8 +21,8 @@ SoilBTreeTest >> setUp [
 
 { #category : #running }
 SoilBTreeTest >> tearDown [ 
-	btree ifNotNil: [ 
-		btree close ].
+	index ifNotNil: [ 
+		index close ].
 	super tearDown
 ]
 
@@ -30,26 +30,26 @@ SoilBTreeTest >> tearDown [
 SoilBTreeTest >> testAddFirstOverflow [
 
 	| page capacity |
-	capacity := btree headerPage itemCapacity.
-	1 to: capacity do: [ :n | btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	self assert: btree pages size equals: 3.
-	self assert: (btree pageAt: 1) numberOfItems equals: 127.
+	capacity := index headerPage itemCapacity.
+	1 to: capacity do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	self assert: index pages size equals: 3.
+	self assert: (index pageAt: 1) numberOfItems equals: 127.
 	"if we add a page, the current one is split and half is moved there"
-	btree at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: btree pages size equals: 3.
-	page := btree pageAt: 3.
+	index at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: index pages size equals: 3.
+	page := index pageAt: 3.
 	self assert: page numberOfItems equals: 128.
 	self assert: page items first key equals: 128.
 	self assert: page items last key asByteArray equals: #[ 255 ].
 	"check that the next pointer is correct after split"
-	self assert: (btree pageAt:((btree headerPage) next)) identicalTo: (btree pageAt: 3)
+	self assert: (index pageAt:((index headerPage) next)) identicalTo: (index pageAt: 3)
 ]
 
 { #category : #tests }
 SoilBTreeTest >> testAddRandom [
 	| numEntries entries |
 	"just some random addind and checking that we can find it. tree is configured to create lots of pages"
-	btree := SoilBTree new 
+	index := SoilBTree new 
 		path: 'sunit-btree';
 		destroy;
 		initializeFilesystem;
@@ -64,133 +64,133 @@ SoilBTreeTest >> testAddRandom [
 	numEntries timesRepeat: [ | toAdd |
 		toAdd := (numEntries*20) atRandom.
 		entries add: toAdd.
-		btree at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
 	
 	"can we find all the keys we added?"
-	entries do: [:each | self assert: (btree at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	entries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
 ]
 
 { #category : #tests }
 SoilBTreeTest >> testAddSecondOverflow [
 
 	| page capacity |
-	capacity := btree headerPage itemCapacity.
-	1 to: capacity do: [ :n | btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	self assert: btree pages size equals: 3.
-	self assert: (btree pageAt: 1) numberOfItems equals: 127.
+	capacity := index headerPage itemCapacity.
+	1 to: capacity do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	self assert: index pages size equals: 3.
+	self assert: (index pageAt: 1) numberOfItems equals: 127.
 	"if we add a page, the current one is split and half is moved there"
-	1 to: capacity do: [ :n | btree at: capacity + n put: #[ 1 2 3 4 5 6 7 8 ]].
-	self assert: btree pages size equals: 4.
-	page := btree pageAt: 4.
+	1 to: capacity do: [ :n | index at: capacity + n put: #[ 1 2 3 4 5 6 7 8 ]].
+	self assert: index pages size equals: 4.
+	page := index pageAt: 4.
 	self assert: page numberOfItems equals: 253.
 	self assert: page items first key equals: 256.
 	"check that the next pointer is correct after split"
-	self assert: ((btree headerPage nextPageIn: btree) nextPageIn: btree) identicalTo: (btree pageAt: 4).
-	btree writePages.
+	self assert: ((index headerPage nextPageIn: index) nextPageIn: index) identicalTo: (index pageAt: 4).
+	index writePages.
 ]
 
 { #category : #tests }
 SoilBTreeTest >> testAddSecondOverflowReload [
 	| page capacity |
 
-	capacity := btree headerPage itemCapacity.
-	1 to: capacity do: [ :n | btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	self assert: btree pages size equals: 3.
-	self assert: (btree pageAt: 1) numberOfItems equals: 127.
+	capacity := index headerPage itemCapacity.
+	1 to: capacity do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	self assert: index pages size equals: 3.
+	self assert: (index pageAt: 1) numberOfItems equals: 127.
 	"if we add a page, the current one is split and half is moved there"
-	1 to: capacity do: [ :n | btree at: capacity + n put: #[ 1 2 3 4 5 6 7 8 ]].
-	self assert: btree pages size equals: 4.
-	page := btree pageAt: 4.
+	1 to: capacity do: [ :n | index at: capacity + n put: #[ 1 2 3 4 5 6 7 8 ]].
+	self assert: index pages size equals: 4.
+	page := index pageAt: 4.
 	self assert: page numberOfItems equals: 253.
 	self assert: page items first key equals: 256.
 	"check that the next pointer is correct after split"
-	self assert: ((btree headerPage nextPageIn: btree) nextPageIn: btree) identicalTo: (btree pageAt: 4).
+	self assert: ((index headerPage nextPageIn: index) nextPageIn: index) identicalTo: (index pageAt: 4).
 
-	btree writePages.
-	btree close.
-	btree := SoilBTree new 
+	index writePages.
+	index close.
+	index := SoilBTree new 
 		path: 'sunit-btree';
 		initializeFilesystem;
 		open. 
-	self assert: (btree at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
 ]
 
 { #category : #tests }
 SoilBTreeTest >> testAt [
 
 	| capacity |
-	capacity := btree headerPage itemCapacity.
-	1 to: capacity do: [ :n | btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	self assert: btree pages size equals: 3.
-	self assert: (btree pageAt: 1) numberOfItems equals: 127.
+	capacity := index headerPage itemCapacity.
+	1 to: capacity do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	self assert: index pages size equals: 3.
+	self assert: (index pageAt: 1) numberOfItems equals: 127.
 	"if we add a page, the current one is split and half is moved there"
-	btree at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: btree pages size equals: 3.
+	index at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: index pages size equals: 3.
 	
-	self assert: (btree at: 1) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (btree at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (btree at: capacity + 1) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self should: [ btree at: capacity + 2  ] raise: KeyNotFound
+	self assert: (index at: 1) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: capacity + 1) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self should: [ index at: capacity + 2  ] raise: KeyNotFound
 ]
 
 { #category : #tests }
 SoilBTreeTest >> testAtSecondOverflow [
 
 	| capacity |
-	capacity := btree headerPage itemCapacity.
-	1 to: capacity*2 do: [ :n | btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	self assert: btree pages size equals: 4.
-	self assert: (btree pageAt: 1) numberOfItems equals: 127.
+	capacity := index headerPage itemCapacity.
+	1 to: capacity*2 do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	self assert: index pages size equals: 4.
+	self assert: (index pageAt: 1) numberOfItems equals: 127.
 	"if we add a page, the current one is split and half is moved there"
-	1 to: capacity do: [ :n | btree at: capacity + n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	self assert: btree pages size equals: 4.
+	1 to: capacity do: [ :n | index at: capacity + n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	self assert: index pages size equals: 4.
 	
-	self assert: (btree at: 1) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (btree at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (btree at: capacity + 1) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (btree at: capacity + capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self should: [ btree at: capacity * 2 + 1  ] raise: KeyNotFound
+	self assert: (index at: 1) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: capacity + 1) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: capacity + capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self should: [ index at: capacity * 2 + 1  ] raise: KeyNotFound
 ]
 
 { #category : #tests }
 SoilBTreeTest >> testCreation [
 	"we alwaus create one data page and the root index"
-	self assert: btree pages size equals: 2.
+	self assert: index pages size equals: 2.
 	"both pages start as dirty"
-	self assert: (btree pages at: 1) isDirty.
-	self assert: (btree pages at: 2) isDirty
+	self assert: (index pages at: 1) isDirty.
+	self assert: (index pages at: 2) isDirty
 ]
 
 { #category : #tests }
 SoilBTreeTest >> testFirst [
 	
 	| capacity |
-	capacity := btree headerPage itemCapacity * 2.
+	capacity := index headerPage itemCapacity * 2.
 
 	2 to: capacity do: [ :n |
-		btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	btree at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
-	self assert: btree pages size equals: 4.
-	self assert: btree first equals: #[ 8 7 6 5 4 3 2 1 ].
-	self assert: (btree first: 2) second equals: #[ 1 2 3 4 5 6 7 8 ].
+		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	index at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: index pages size equals: 4.
+	self assert: index first equals: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: (index first: 2) second equals: #[ 1 2 3 4 5 6 7 8 ].
 ]
 
 { #category : #tests }
 SoilBTreeTest >> testIsEmpty [
-	self assert: btree isEmpty.
-	btree at: 1 put: #[1 2].
-	self deny: btree isEmpty
+	self assert: index isEmpty.
+	index at: 1 put: #[1 2].
+	self deny: index isEmpty
 ]
 
 { #category : #tests }
 SoilBTreeTest >> testIteratorFindAndNext [
 	
 	| capacity iterator value |
-	capacity := btree headerPage itemCapacity * 2.
+	capacity := index headerPage itemCapacity * 2.
 	1 to: capacity do: [ :n |
-		btree at: n put: (n asByteArrayOfSize: 8) ].
-	self assert: btree pages size equals: 4.
-	iterator := btree newIterator.
+		index at: n put: (n asByteArrayOfSize: 8) ].
+	self assert: index pages size equals: 4.
+	iterator := index newIterator.
 	value := iterator
 		find: 222;
 		next.
@@ -201,11 +201,11 @@ SoilBTreeTest >> testIteratorFindAndNext [
 SoilBTreeTest >> testIteratorFindAndNext2 [
 	
 	| capacity iterator values |
-	capacity := btree headerPage itemCapacity * 2.
+	capacity := index headerPage itemCapacity * 2.
 	1 to: capacity do: [ :n |
-		btree at: n put: (n asByteArrayOfSize: 8) ].
-	self assert: btree pages size equals: 4.
-	iterator := btree newIterator.
+		index at: n put: (n asByteArrayOfSize: 8) ].
+	self assert: index pages size equals: 4.
+	iterator := index newIterator.
 	values := iterator
 		find: 222;
 		next: 3.
@@ -227,12 +227,12 @@ SoilBTreeTest >> testIteratorFindAndNext2 [
 SoilBTreeTest >> testIteratorFirst [
 	
 	| capacity first |
-	capacity := btree headerPage itemCapacity * 2.
-	btree at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
+	capacity := index headerPage itemCapacity * 2.
+	index at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
 	2 to: capacity do: [ :n |
-		btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	self assert: btree pages size equals: 4.
-	first := btree newIterator first.
+		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	self assert: index pages size equals: 4.
+	first := index newIterator first.
 	self assert: first equals: #[ 8 7 6 5 4 3 2 1 ]
 ]
 
@@ -240,29 +240,29 @@ SoilBTreeTest >> testIteratorFirst [
 SoilBTreeTest >> testLast [
 	
 	| capacity |
-	capacity := btree headerPage itemCapacity * 2.
+	capacity := index headerPage itemCapacity * 2.
 
 	1 to: capacity - 1 do: [ :n |
-		btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	btree at: capacity put: #[ 8 7 6 5 4 3 2 1 ].
-	self assert: btree pages size equals: 4.
-	self assert: btree last equals: #[ 8 7 6 5 4 3 2 1 ]
+		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	index at: capacity put: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: index pages size equals: 4.
+	self assert: index last equals: #[ 8 7 6 5 4 3 2 1 ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 SoilBTreeTest >> testLastPage [
 	
 	| capacity lastItem |
-	btree maxLevel: 8.
-	capacity := btree firstPage itemCapacity * 100.
+	index maxLevel: 8.
+	capacity := index firstPage itemCapacity * 100.
 
 	1 to: capacity - 1 do: [ :n |
-		btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	btree at: capacity put: #[ 8 7 6 5 4 3 2 1 ].
-	self assert: btree pages size equals: 199.
-	self assert: btree lastPage index equals: 199.
-	self assert: btree lastPage isLastPage.
-	lastItem := btree lastPage itemAt: capacity ifAbsent: [nil].
+		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	index at: capacity put: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: index pages size equals: 199.
+	self assert: index lastPage index equals: 199.
+	self assert: index lastPage isLastPage.
+	lastItem := index lastPage itemAt: capacity ifAbsent: [nil].
 	self assert: lastItem value equals: #[ 8 7 6 5 4 3 2 1 ].
 ]
 
@@ -270,7 +270,7 @@ SoilBTreeTest >> testLastPage [
 SoilBTreeTest >> testOverflowCopyOnWriteSplitting [
 	
 	| page capacity copyOnWrite |
-	copyOnWrite := btree asCopyOnWrite.
+	copyOnWrite := index asCopyOnWrite.
 	capacity := copyOnWrite headerPage itemCapacity.
 	1 to: capacity * 2 by: 2 do: [ :n | 
 		copyOnWrite at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
@@ -286,14 +286,14 @@ SoilBTreeTest >> testOverflowCopyOnWriteSplitting [
 SoilBTreeTest >> testPageAddFirst [
 	
 	| page indexPage |
-	btree at: #foo put: #[ 1 2 3 4 5 6 7 8 ].
-	btree writePages.
-	self assert: btree pages size equals: 2.
-	page := btree headerPage.
+	index at: #foo put: #[ 1 2 3 4 5 6 7 8 ].
+	index writePages.
+	self assert: index pages size equals: 2.
+	page := index headerPage.
 	self assert: page numberOfItems equals: 1.
 	self assert: page items first key equals: (#foo asSkipListKeyOfSize: 8) asInteger.
 	"the index page was updated"
-	indexPage := btree rootPage.
+	indexPage := index rootPage.
 	"Index has been updated"
 	self assert: indexPage items size equals: 1
 	
@@ -304,28 +304,28 @@ SoilBTreeTest >> testPageAddFirst [
 SoilBTreeTest >> testPageAddFirstAndLoad [
 	
 	| page indexPage |
-	btree at: #foo put: #[ 1 2 3 4 5 6 7 8 ].
-	btree writePages.
-	self assert: btree pages size equals: 2.
-	page := btree headerPage.
+	index at: #foo put: #[ 1 2 3 4 5 6 7 8 ].
+	index writePages.
+	self assert: index pages size equals: 2.
+	page := index headerPage.
 	self assert: page numberOfItems equals: 1.
 	self assert: page items first key equals: (#foo asSkipListKeyOfSize: 8) asInteger.
 	"the index page was updated"
-	indexPage := btree rootPage.
+	indexPage := index rootPage.
 	"Index has been updated"
 	self assert: indexPage items size equals: 1.
 
 	"load back"
 	
-	btree close.
-	btree := SoilBTree new 
+	index close.
+	index := SoilBTree new 
 		path: 'sunit-btree';
 		initializeFilesystem;
 		open.
 	
 	self assert: page items first key equals: (#foo asSkipListKeyOfSize: 8) asInteger.	
 	"load succeeds"
-	self assert: (btree at: #foo) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: #foo) equals: #[ 1 2 3 4 5 6 7 8 ].
 
 ]
 
@@ -333,35 +333,35 @@ SoilBTreeTest >> testPageAddFirstAndLoad [
 SoilBTreeTest >> testRemoveKey [
 
 	| capacity |
-	capacity := btree headerPage itemCapacity.
-	1 to: capacity do: [ :n | btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	capacity := index headerPage itemCapacity.
+	1 to: capacity do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
 	
-	btree removeKey: 20.
+	index removeKey: 20.
 	
-	self assert: (btree at: 1) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (btree at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self should: [ btree at: 20 ] raise: KeyNotFound.
-	self should: [ btree removeKey: 20  ] raise: KeyNotFound.
+	self assert: (index at: 1) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self should: [ index at: 20 ] raise: KeyNotFound.
+	self should: [ index removeKey: 20  ] raise: KeyNotFound.
 ]
 
 { #category : #tests }
 SoilBTreeTest >> testSize [
 	
 	| capacity |
-	capacity := btree headerPage itemCapacity.
-	btree at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
+	capacity := index headerPage itemCapacity.
+	index at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
 	2 to: capacity do: [ :n |
-		btree at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	btree at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: btree pages size equals: 3.
-	self assert: btree size equals: capacity + 1.
+		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	index at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: index pages size equals: 3.
+	self assert: index size equals: capacity + 1.
 ]
 
 { #category : #tests }
 SoilBTreeTest >> testSplitIndexPage [
 	| entries |
 	"this test leads to a split of a non-root index page"
-	btree := SoilBTree new 
+	index := SoilBTree new 
 		path: 'sunit-btree';
 		destroy;
 		initializeFilesystem;
@@ -373,17 +373,17 @@ SoilBTreeTest >> testSplitIndexPage [
 	
 	
 	entries do: [:toAdd |
-		btree at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
 	
 	"can we find all the keys we added?"
-	entries do: [:each | self assert: (btree at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	entries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
 ]
 
 { #category : #tests }
 SoilBTreeTest >> testSplitIndexPageReleoad [
 	| entries |
 	"this test leads to a split of a non-root index page"
-	btree := SoilBTree new 
+	index := SoilBTree new 
 		path: 'sunit-btree';
 		destroy;
 		initializeFilesystem;
@@ -395,19 +395,19 @@ SoilBTreeTest >> testSplitIndexPageReleoad [
 	
 	
 	entries do: [:toAdd |
-		btree at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
 	
 	"can we find all the keys we added?"
-	entries do: [:each | self assert: (btree at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	entries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
 	
 	"write and reload"
-	btree writePages.
-	btree close.
-	btree := SoilBTree new 
+	index writePages.
+	index close.
+	index := SoilBTree new 
 		path: 'sunit-btree';
 		initializeFilesystem;
 		open. 
 	
 	"can we find all the keys we added?"
-	entries do: [:each | self assert: (btree at: each ) equals: (#[ 1 2 3 4 5 6 7 8 ] asByteArrayOfSize: 512)].
+	entries do: [:each | self assert: (index at: each ) equals: (#[ 1 2 3 4 5 6 7 8 ] asByteArrayOfSize: 512)].
 ]

--- a/src/Soil-Core-Tests/SoilSkipListTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListTest.class.st
@@ -2,7 +2,7 @@ Class {
 	#name : #SoilSkipListTest,
 	#superclass : #TestCase,
 	#instVars : [
-		'skipList'
+		'index'
 	],
 	#category : #'Soil-Core-Tests'
 }
@@ -10,7 +10,7 @@ Class {
 { #category : #running }
 SoilSkipListTest >> setUp [ 
 	super setUp.
-	skipList := SoilSkipList new 
+	index := SoilSkipList new 
 		path: 'sunit-skiplist';
 		destroy;
 		initializeFilesystem;
@@ -22,8 +22,8 @@ SoilSkipListTest >> setUp [
 
 { #category : #running }
 SoilSkipListTest >> tearDown [ 
-	skipList ifNotNil: [ 
-		skipList close ].
+	index ifNotNil: [ 
+		index close ].
 	super tearDown
 ]
 
@@ -31,13 +31,13 @@ SoilSkipListTest >> tearDown [
 SoilSkipListTest >> testAddFirstOverflowAppending [
 	
 	| page capacity |
-	capacity := skipList firstPage itemCapacity.
+	capacity := index firstPage itemCapacity.
 	1 to: capacity do: [ :n | 
-		skipList at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
-	self assert: skipList pages size equals: 1.
-	skipList at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: skipList pages size equals: 2.
-	page := skipList pageAt: 2.
+		index at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+	self assert: index pages size equals: 1.
+	index at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: index pages size equals: 2.
+	page := index pageAt: 2.
 	self assert: page numberOfItems equals: 1.
 	self assert: page items first key equals: 254.
 	self assert: page items last key asByteArray equals: #[ 254 ]
@@ -47,39 +47,39 @@ SoilSkipListTest >> testAddFirstOverflowAppending [
 SoilSkipListTest >> testAddFirstOverflowReload [
 	
 	| page capacity |
-	capacity := skipList firstPage itemCapacity.
+	capacity := index firstPage itemCapacity.
 	1 to: capacity do: [ :n | 
-		skipList at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
-	self assert: skipList pages size equals: 1.
-	skipList at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: skipList pages size equals: 2.
-	page := skipList pageAt: 2.
+		index at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+	self assert: index pages size equals: 1.
+	index at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: index pages size equals: 2.
+	page := index pageAt: 2.
 	self assert: page numberOfItems equals: 1.
 	self assert: page items first key equals: 254.
 	self assert: page items last key asByteArray equals: #[ 254 ].
 	
 	"write it and then read it back with a new SoilSkipList"
-	skipList writePages.
-	skipList close.
-	skipList := SoilSkipList new 
+	index writePages.
+	index close.
+	index := SoilSkipList new 
 		path: 'sunit-skiplist';
 		initializeFilesystem;
 		open.
 	"we should be able to do a lookup"
-	self assert: ((skipList at: capacity) asByteArrayOfSize: 8) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: ((index at: capacity) asByteArrayOfSize: 8) equals: #[ 1 2 3 4 5 6 7 8 ].
 ]
 
 { #category : #tests }
 SoilSkipListTest >> testAddFirstOverflowSplitting [
 	
 	| page capacity |
-	capacity := skipList firstPage itemCapacity.
+	capacity := index firstPage itemCapacity.
 	1 to: capacity * 2 by: 2 do: [ :n | 
-		skipList at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
-	self assert: skipList pages size equals: 1.
-	skipList at: capacity - 1 put: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: skipList pages size equals: 2.
-	page := skipList pageAt: 2.
+		index at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+	self assert: index pages size equals: 1.
+	index at: capacity - 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: index pages size equals: 2.
+	page := index pageAt: 2.
 	self assert: page numberOfItems equals: 126.
 	self assert: page items first key equals: 255.
 	self assert: page items last key asByteArray equals: #[ 1 249 ]
@@ -89,13 +89,13 @@ SoilSkipListTest >> testAddFirstOverflowSplitting [
 SoilSkipListTest >> testAddInBetween [
 	
 	| page capacity |
-	capacity := skipList firstPage itemCapacity.
+	capacity := index firstPage itemCapacity.
 	1 to: capacity do: [ :n |
-		skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	self assert: skipList pages size equals: 1.
-	skipList at: (capacity / 2) floor put: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: skipList pages size equals: 1.
-	page := skipList pageAt: 1.
+		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	self assert: index pages size equals: 1.
+	index at: (capacity / 2) floor put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: index pages size equals: 1.
+	page := index pageAt: 1.
 	self assert: page numberOfItems equals: 253.
 	self assert: (page items at: (capacity / 2) floor) key equals: 126
 ]
@@ -104,30 +104,30 @@ SoilSkipListTest >> testAddInBetween [
 SoilSkipListTest >> testAddInBetweenOverflowing [
 	
 	| page capacity |
-	capacity := skipList firstPage itemCapacity.
+	capacity := index firstPage itemCapacity.
 	1 to: capacity * 2 by: 2 do: [ :n | 
-		skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	self assert: skipList pages size equals: 1.
-	skipList at: 32 put: #[ 8 7 6 5 4 3 2 1 ].
-	self assert: skipList pages size equals: 2.
-	page := skipList pageAt: 2.
+		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	self assert: index pages size equals: 1.
+	index at: 32 put: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: index pages size equals: 2.
+	page := index pageAt: 2.
 	self assert: page numberOfItems equals: 126.
 	self assert: (page items first) key equals: 255.
 	self assert: (page items last) key asByteArray equals: #[ 1 249 ].
-	skipList writePages 
+	index writePages 
 ]
 
 { #category : #tests }
 SoilSkipListTest >> testAddInBetweenOverwriting [
 	
 	| page capacity |
-	capacity := skipList firstPage itemCapacity.
+	capacity := index firstPage itemCapacity.
 	1 to: capacity * 2 by: 2 do: [ :n | 
-		skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	self assert: skipList pages size equals: 1.
-	skipList at: 31 put: #[ 8 7 6 5 4 3 2 1 ].
-	self assert: skipList pages size equals: 1.
-	page := skipList pageAt: 1.
+		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	self assert: index pages size equals: 1.
+	index at: 31 put: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: index pages size equals: 1.
+	page := index pageAt: 1.
 	self assert: page numberOfItems equals: 253.
 	self assert: (page items at: 16) value equals: #[ 8 7 6 5 4 3 2 1 ] 
 ]
@@ -137,11 +137,11 @@ SoilSkipListTest >> testAddLastFitting [
 	
 	| page |
 	1 to: 61 do: [ :n | 
-		skipList at: (n asString asSkipListKeyOfSize: 8) put: #[ 1 2 3 4 5 6 7 8 ] ].
-	self assert: skipList pages size equals: 1.
-	skipList at: (63 asString asSkipListKeyOfSize: 8) put: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: skipList pages size equals: 1.
-	page := skipList pageAt: 1.
+		index at: (n asString asSkipListKeyOfSize: 8) put: #[ 1 2 3 4 5 6 7 8 ] ].
+	self assert: index pages size equals: 1.
+	index at: (63 asString asSkipListKeyOfSize: 8) put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: index pages size equals: 1.
+	page := index pageAt: 1.
 	self assert: page numberOfItems equals: 62.
 	self assert: page items last key asByteArray equals: #[ 54 51 ]
 ]
@@ -150,44 +150,44 @@ SoilSkipListTest >> testAddLastFitting [
 SoilSkipListTest >> testAt [
 	
 	| capacity |
-	capacity := skipList firstPage itemCapacity.
+	capacity := index firstPage itemCapacity.
 	1 to: capacity do: [ :n | 
-		skipList at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
-	self assert: skipList pages size equals: 1.
-	skipList at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: skipList pages size equals: 2.
+		index at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+	self assert: index pages size equals: 1.
+	index at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: index pages size equals: 2.
 	
 	"we should be able to find the key that is on the second page"
-	self assert: (skipList at: capacity + 1) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self should: [ skipList at: capacity + 2  ] raise: KeyNotFound
+	self assert: (index at: capacity + 1) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self should: [ index at: capacity + 2  ] raise: KeyNotFound
 ]
 
 { #category : #tests }
 SoilSkipListTest >> testAtIndex [
 	| value |
 	1 to: 200 do: [ :n |
-		skipList at: n put: n asSoilObjectId ].
-	value := skipList atIndex: 133. 
+		index at: n put: n asSoilObjectId ].
+	value := index atIndex: 133. 
 	self assert: (value isSameObjectId: 133 asSoilObjectId) 
 ]
 
 { #category : #tests }
 SoilSkipListTest >> testCreation [
-	self assert: skipList pages size equals: 1
+	self assert: index pages size equals: 1
 ]
 
 { #category : #tests }
 SoilSkipListTest >> testDo [
 	
 	| capacity col |
-	capacity := skipList firstPage itemCapacity.
-	skipList at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
+	capacity := index firstPage itemCapacity.
+	index at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
 	2 to: capacity do: [ :n |
-		skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	skipList at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: skipList pages size equals: 2.
+		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	index at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: index pages size equals: 2.
 	col := OrderedCollection new.
-	skipList do: [ :item | col add: item ].
+	index do: [ :item | col add: item ].
 	self assert: col first equals: #[ 8 7 6 5 4 3 2 1 ].
 	self assert: col size equals: capacity + 1
 ]
@@ -196,8 +196,8 @@ SoilSkipListTest >> testDo [
 SoilSkipListTest >> testFindKey [
 	| value |
 	1 to: 200 do: [ :n |
-		skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	value := skipList find: 133. 
+		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	value := index find: 133. 
 	self assert: value equals: #[ 1 2 3 4 5 6 7 8 ]
 ]
 
@@ -205,9 +205,9 @@ SoilSkipListTest >> testFindKey [
 SoilSkipListTest >> testFindKeyReverse [
 	| value |
 	200 to: 1 by: -1 do: [ :n |
-		skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
 	"skipList writePages."
-	value := skipList find: 133. 
+	value := index find: 133. 
 	self assert: value equals: #[ 1 2 3 4 5 6 7 8 ]
 ]
 
@@ -215,41 +215,41 @@ SoilSkipListTest >> testFindKeyReverse [
 SoilSkipListTest >> testFirst [
 	
 	| capacity |
-	capacity := skipList firstPage itemCapacity * 2.
+	capacity := index firstPage itemCapacity * 2.
 
 	2 to: capacity do: [ :n |
-		skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	skipList at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
-	self assert: skipList pages size equals: 3.
-	self assert: skipList first equals: #[ 8 7 6 5 4 3 2 1 ].
-	self assert: (skipList first: 2) second equals: #[ 1 2 3 4 5 6 7 8 ].
+		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	index at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: index pages size equals: 3.
+	self assert: index first equals: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: (index first: 2) second equals: #[ 1 2 3 4 5 6 7 8 ].
 ]
 
 { #category : #tests }
 SoilSkipListTest >> testFirstArgLargerThenSize [
 
 	1 to: 4 do: [ :n |
-		skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	self assert: skipList pages size equals: 1.
-	self assert: (skipList first: 5) size equals: 4
+		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	self assert: index pages size equals: 1.
+	self assert: (index first: 5) size equals: 4
 ]
 
 { #category : #tests }
 SoilSkipListTest >> testIsEmpty [
-	self assert: skipList isEmpty.
-	skipList at: 1 put: #[1 2].
-	self deny: skipList isEmpty
+	self assert: index isEmpty.
+	index at: 1 put: #[1 2].
+	self deny: index isEmpty
 ]
 
 { #category : #tests }
 SoilSkipListTest >> testIteratorFindAndNext [
 	
 	| capacity iterator value |
-	capacity := skipList firstPage itemCapacity * 2.
+	capacity := index firstPage itemCapacity * 2.
 	1 to: capacity do: [ :n |
-		skipList at: n put: (n asByteArrayOfSize: 8) ].
-	self assert: skipList pages size equals: 2.
-	iterator := skipList newIterator.
+		index at: n put: (n asByteArrayOfSize: 8) ].
+	self assert: index pages size equals: 2.
+	iterator := index newIterator.
 	value := iterator
 		find: 222;
 		next.
@@ -260,11 +260,11 @@ SoilSkipListTest >> testIteratorFindAndNext [
 SoilSkipListTest >> testIteratorFindAndNext2 [
 	
 	| capacity iterator values |
-	capacity := skipList firstPage itemCapacity * 2.
+	capacity := index firstPage itemCapacity * 2.
 	1 to: capacity do: [ :n |
-		skipList at: n put: (n asByteArrayOfSize: 8) ].
-	self assert: skipList pages size equals: 2.
-	iterator := skipList newIterator.
+		index at: n put: (n asByteArrayOfSize: 8) ].
+	self assert: index pages size equals: 2.
+	iterator := index newIterator.
 	values := iterator
 		find: 222;
 		next: 3.
@@ -283,7 +283,7 @@ SoilSkipListTest >> testIteratorFindAndNext2 [
 { #category : #tests }
 SoilSkipListTest >> testIteratorFirstWithSingleRemovedItem [ 
 	| iterator |
-	iterator := skipList newIterator.
+	iterator := index newIterator.
 	iterator at: #foo put: #bar.
 	iterator removeKey: #foo.
 	self assert: iterator firstAssociation equals: nil
@@ -292,7 +292,7 @@ SoilSkipListTest >> testIteratorFirstWithSingleRemovedItem [
 { #category : #tests }
 SoilSkipListTest >> testIteratorLastWithSingleRemovedItem [ 
 	| iterator |
-	iterator := skipList newIterator.
+	iterator := index newIterator.
 	iterator at: #foo put: #bar.
 	iterator removeKey: #foo.
 	self assert: iterator lastAssociation equals: nil
@@ -302,45 +302,45 @@ SoilSkipListTest >> testIteratorLastWithSingleRemovedItem [
 SoilSkipListTest >> testLast [
 	
 	| capacity |
-	capacity := skipList firstPage itemCapacity * 2.
+	capacity := index firstPage itemCapacity * 2.
 
 	1 to: capacity - 1 do: [ :n |
-		skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	skipList at: capacity put: #[ 8 7 6 5 4 3 2 1 ].
-	self assert: skipList pages size equals: 2.
-	self assert: skipList last equals: #[ 8 7 6 5 4 3 2 1 ]
+		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	index at: capacity put: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: index pages size equals: 2.
+	self assert: index last equals: #[ 8 7 6 5 4 3 2 1 ]
 ]
 
 { #category : #tests }
 SoilSkipListTest >> testLastPage [
 	
 	| capacity lastItem |
-	skipList maxLevel: 8.
-	capacity := skipList firstPage itemCapacity * 100.
+	index maxLevel: 8.
+	capacity := index firstPage itemCapacity * 100.
 
 	1 to: capacity - 1 do: [ :n |
-		skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	skipList at: capacity put: #[ 8 7 6 5 4 3 2 1 ].
-	self assert: skipList pages size equals: 100.
-	self assert: skipList lastPage index equals: 100.
-	self assert: skipList lastPage isLastPage.
-	lastItem := skipList lastPage itemAt: capacity ifAbsent: [nil].
+		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	index at: capacity put: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: index pages size equals: 100.
+	self assert: index lastPage index equals: 100.
+	self assert: index lastPage isLastPage.
+	lastItem := index lastPage itemAt: capacity ifAbsent: [nil].
 	self assert: lastItem value equals: #[ 8 7 6 5 4 3 2 1 ].
 ]
 
 { #category : #tests }
 SoilSkipListTest >> testMorePages [
 	1 to: 512 do: [ :n |
-		skipList at: (n asString asSkipListKeyOfSize: 8) put: #[ 1 2 3 4 5 6 7 8 ] ].
-	skipList writePages.
-	self assert: skipList pages size equals: 3
+		index at: (n asString asSkipListKeyOfSize: 8) put: #[ 1 2 3 4 5 6 7 8 ] ].
+	index writePages.
+	self assert: index pages size equals: 3
 ]
 
 { #category : #tests }
 SoilSkipListTest >> testOverflowCopyOnWriteAppending [
 	
 	| page capacity copyOnWrite |
-	copyOnWrite := skipList asCopyOnWrite.
+	copyOnWrite := index asCopyOnWrite.
 	capacity := copyOnWrite firstPage itemCapacity.
 	1 to: capacity do: [ :n | 
 		copyOnWrite at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
@@ -357,7 +357,7 @@ SoilSkipListTest >> testOverflowCopyOnWriteAppending [
 SoilSkipListTest >> testOverflowCopyOnWriteSplitting [
 	
 	| page capacity copyOnWrite |
-	copyOnWrite := skipList asCopyOnWrite.
+	copyOnWrite := index asCopyOnWrite.
 	capacity := copyOnWrite firstPage itemCapacity.
 	1 to: capacity * 2 by: 2 do: [ :n | 
 		copyOnWrite at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
@@ -374,10 +374,10 @@ SoilSkipListTest >> testOverflowCopyOnWriteSplitting [
 SoilSkipListTest >> testPageAddFirst [
 	
 	| page |
-	skipList at: #foo put: #[ 1 2 3 4 5 6 7 8 ].
-	skipList writePages.
-	self assert: skipList pages size equals: 1.
-	page := skipList firstPage.
+	index at: #foo put: #[ 1 2 3 4 5 6 7 8 ].
+	index writePages.
+	self assert: index pages size equals: 1.
+	page := index firstPage.
 	self assert: page numberOfItems equals: 1.
 	self assert: page items first key equals: (#foo asSkipListKeyOfSize: 8) asInteger
 ]
@@ -386,50 +386,50 @@ SoilSkipListTest >> testPageAddFirst [
 SoilSkipListTest >> testRemoveKey [
 
 	| capacity |
-	capacity := skipList headerPage itemCapacity.
-	1 to: capacity do: [ :n | skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	capacity := index headerPage itemCapacity.
+	1 to: capacity do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
 	
-	skipList removeKey: 20.
+	index removeKey: 20.
 	
-	self assert: (skipList at: 1) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (skipList at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self should: [ skipList at: 20  ] raise: KeyNotFound.
-	skipList at: 20 put: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (skipList at: 20) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 1) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self should: [ index at: 20  ] raise: KeyNotFound.
+	index at: 20 put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 20) equals: #[ 1 2 3 4 5 6 7 8 ].
 	
-	self should: [ skipList removeKey: capacity + 1 ] raise: KeyNotFound
+	self should: [ index removeKey: capacity + 1 ] raise: KeyNotFound
 ]
 
 { #category : #tests }
 SoilSkipListTest >> testSize [
 	
 	| capacity |
-	capacity := skipList firstPage itemCapacity.
-	skipList at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
+	capacity := index firstPage itemCapacity.
+	index at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
 	2 to: capacity do: [ :n |
-		skipList at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	skipList at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: skipList pages size equals: 2.
-	self assert: skipList size equals: capacity + 1.
+		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	index at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: index pages size equals: 2.
+	self assert: index size equals: capacity + 1.
 ]
 
 { #category : #tests }
 SoilSkipListTest >> testSplitLastPage [	
 	| headerCapacity itemCapacity |
 	"fill the header page"
-	headerCapacity := skipList headerPage itemCapacity.
+	headerCapacity := index headerPage itemCapacity.
 	1 to: headerCapacity do: [ :n |
-		skipList at: n put: n ].
-	self assert: skipList pages size equals:  1.
+		index at: n put: n ].
+	self assert: index pages size equals:  1.
 	"trigger page split and check it happened"
-	skipList at: headerCapacity + 1 put: 0.
-	self assert: skipList pages size equals:  2.
+	index at: headerCapacity + 1 put: 0.
+	self assert: index pages size equals:  2.
 	"fill second page til the end"
-	itemCapacity := (skipList pageAt: 2) itemCapacity.
+	itemCapacity := (index pageAt: 2) itemCapacity.
 	headerCapacity + 2 to: headerCapacity + itemCapacity do: [ :n |
-		skipList at: n put: n ].
-	self assert: skipList pages size equals:  2.
+		index at: n put: n ].
+	self assert: index pages size equals:  2.
 	"another page split which should be appending"
-	skipList at: 3000 put: 3000.
+	index at: 3000 put: 3000.
 	
 ]


### PR DESCRIPTION
make sure the two tests use the same ivar.

makes it easier to copy tests over and a fist step of maybe moving some to a matrix tests (not sure if that is needed)