### PR TITLE
Unify API wrapped indexed

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexTest.class.st
@@ -36,7 +36,7 @@ SoilIndexTest >> testFlushIndexPages [
 	tx commit.
 	txn1 := soil newTransaction.
 	root1 := txn1 root.
-	self assert: root1 index wrappedSkipList pages size equals: 2.
+	self assert: root1 index wrapped pages size equals: 2.
 	root1 index flushCachedPages.
 	self assert: root1 index pages size equals: 0.
 	txn1 abort.
@@ -44,7 +44,7 @@ SoilIndexTest >> testFlushIndexPages [
 	txn2 := soil newTransaction.
 	root2 := txn2 root.
 	self assert: root2 index pages size equals: 0.
-	self assert: root2 index wrappedSkipList pages size equals: 0.
+	self assert: root2 index wrapped pages size equals: 0.
 	self assert: (root2 at: '56') equals: '56'.
 	txn2 abort
  

--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -391,8 +391,8 @@ SoilIndexedDictionaryTest >> testFlushIndexPages [
 	txn1 := soil newTransaction.
 	root1 := txn1 root.
 	(dict index isKindOf: SoilSkipList)
-		ifTrue: [ self assert: root1 index wrappedIndex pages size equals: 2]
-		ifFalse: [self assert: root1 index wrappedIndex pages size equals: 3].
+		ifTrue: [ self assert: root1 index wrapped pages size equals: 2]
+		ifFalse: [self assert: root1 index wrapped pages size equals: 3].
 	root1 index flushCachedPages.
 	self assert: root1 index pages size equals: 0.
 	txn1 abort.
@@ -400,7 +400,7 @@ SoilIndexedDictionaryTest >> testFlushIndexPages [
 	txn2 := soil newTransaction.
 	root2 := txn2 root.
 	self assert: root2 index pages size equals: 0.
-	self assert: root2 index wrappedIndex pages size equals: 0.
+	self assert: root2 index wrapped pages size equals: 0.
 	self assert: (root2 at: '56') equals: '56'.
 	txn2 abort
 ]

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -16,7 +16,7 @@ SoilBasicBTree class >> isAbstract [
 { #category : #converting }
 SoilBasicBTree >> asCopyOnWrite [
 	^ SoilCopyOnWriteBTree new
-		wrappedBTree: self;
+		wrapped: self;
 		yourself 
 ]
 

--- a/src/Soil-Core/SoilCopyOnWriteBTree.class.st
+++ b/src/Soil-Core/SoilCopyOnWriteBTree.class.st
@@ -2,41 +2,35 @@ Class {
 	#name : #SoilCopyOnWriteBTree,
 	#superclass : #SoilBasicBTree,
 	#instVars : [
-		'wrappedBTree'
+		'wrapped'
 	],
 	#category : #'Soil-Core-Index-BTree'
 }
 
 { #category : #testing }
 SoilCopyOnWriteBTree >> isRegistered [
-	^ wrappedBTree isRegistered
+	^ wrapped isRegistered
 ]
 
 { #category : #'instance creation' }
 SoilCopyOnWriteBTree >> newPage [ 
-	^ wrappedBTree newPage
+	^ wrapped newPage
 ]
 
 { #category : #converting }
 SoilCopyOnWriteBTree >> thePersistentInstance [
-	^ wrappedBTree
+	^ wrapped
 ]
 
 { #category : #accessing }
-SoilCopyOnWriteBTree >> wrappedBTree [
+SoilCopyOnWriteBTree >> wrapped [
 
-	^ wrappedBTree
+	^ wrapped
 ]
 
 { #category : #accessing }
-SoilCopyOnWriteBTree >> wrappedBTree: anObject [
+SoilCopyOnWriteBTree >> wrapped: anObject [
 
-	wrappedBTree := anObject.
-	self store: wrappedBTree store asCopyOnWriteStore 
-]
-
-{ #category : #accessing }
-SoilCopyOnWriteBTree >> wrappedIndex [
-
-	^ self wrappedBTree
+	wrapped := anObject.
+	self store: wrapped store asCopyOnWriteStore 
 ]

--- a/src/Soil-Core/SoilCopyOnWriteSkipList.class.st
+++ b/src/Soil-Core/SoilCopyOnWriteSkipList.class.st
@@ -2,40 +2,34 @@ Class {
 	#name : #SoilCopyOnWriteSkipList,
 	#superclass : #SoilBasicSkipList,
 	#instVars : [
-		'wrappedSkipList'
+		'wrapped'
 	],
 	#category : #'Soil-Core-Index-SkipList'
 }
 
 { #category : #testing }
 SoilCopyOnWriteSkipList >> isRegistered [
-	^ wrappedSkipList isRegistered
+	^ wrapped isRegistered
 ]
 
 { #category : #'instance creation' }
 SoilCopyOnWriteSkipList >> newPage [ 
-	^ wrappedSkipList newPage
+	^ wrapped newPage
 ]
 
 { #category : #converting }
 SoilCopyOnWriteSkipList >> thePersistentInstance [
-	^ wrappedSkipList
+	^ wrapped
 ]
 
 { #category : #converting }
-SoilCopyOnWriteSkipList >> wrappedIndex [
-
-	^ self wrappedSkipList
-]
-
-{ #category : #converting }
-SoilCopyOnWriteSkipList >> wrappedSkipList [
-	^ wrappedSkipList
+SoilCopyOnWriteSkipList >> wrapped [
+	^ wrapped
 ]
 
 { #category : #accessing }
-SoilCopyOnWriteSkipList >> wrappedSkipList: anObject [
+SoilCopyOnWriteSkipList >> wrapped: anObject [
 
-	wrappedSkipList := anObject.
-	self store: wrappedSkipList store asCopyOnWriteStore 
+	wrapped := anObject.
+	self store: wrapped store asCopyOnWriteStore 
 ]

--- a/src/Soil-Core/SoilSkipList.class.st
+++ b/src/Soil-Core/SoilSkipList.class.st
@@ -17,7 +17,7 @@ SoilSkipList >> acceptSoil: aSoilVisitor [
 { #category : #converting }
 SoilSkipList >> asCopyOnWrite [
 	^ SoilCopyOnWriteSkipList new
-		wrappedSkipList: self;
+		wrapped: self;
 		yourself 
 ]
 


### PR DESCRIPTION
The copyOnWrite subclasses where using accessors for wrappedSkipList and wrappedBTree

This PR changes the vars to be just "wrapped", this makes it easier to write tests and allows to remove the wrappedIndex forwarder