### PR TITLE
Move #isRemoved for #isEmpty from the pages to the SoilIndexedDictionary

### DIFF
--- a/src/Soil-Core/SoilBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilBTreeDataPage.class.st
@@ -19,11 +19,6 @@ SoilBTreeDataPage >> find: aKey with: aBTree [
 
 ]
 
-{ #category : #testing }
-SoilBTreeDataPage >> hasItems [
-	^ (items reject: [ :each | each value isRemoved ]) notEmpty
-]
-
 { #category : #utilities }
 SoilBTreeDataPage >> headerSize [
 	^ super headerSize  
@@ -85,12 +80,6 @@ SoilBTreeDataPage >> itemBefore: key [
 	| item |
 	item := items at: key ifAbsent: [ ^ nil ].
 	^ items before: item ifAbsent: nil
-]
-
-{ #category : #accessing }
-SoilBTreeDataPage >> lastItem [
-
-	^ items ifEmpty: nil ifNotEmpty: [ :itms | itms last ]
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -49,7 +49,8 @@ SoilBTreePage >> find: aKey with: aBTree [
 
 { #category : #accessing }
 SoilBTreePage >> firstItem [
-	^ items first
+
+	^ items isNotEmpty ifTrue: [ items first ]
 ]
 
 { #category : #testing }
@@ -142,6 +143,12 @@ SoilBTreePage >> keySize [
 { #category : #accessing }
 SoilBTreePage >> keySize: anInteger [ 
 	keySize := anInteger
+]
+
+{ #category : #accessing }
+SoilBTreePage >> lastItem [
+
+	^ items isNotEmpty ifTrue: [ items last ]
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -118,7 +118,7 @@ SoilBasicBTree >> initializeHeaderPage [
 
 { #category : #testing }
 SoilBasicBTree >> isEmpty [
-	^ self store headerPage hasItems not
+	^ self store headerPage isEmpty
 ]
 
 { #category : #testing }

--- a/src/Soil-Core/SoilBasicSkipList.class.st
+++ b/src/Soil-Core/SoilBasicSkipList.class.st
@@ -97,7 +97,7 @@ SoilBasicSkipList >> headerPage [
 
 { #category : #testing }
 SoilBasicSkipList >> isEmpty [
-	^ self store headerPage hasItems not
+	^ self store headerPage isEmpty
 ]
 
 { #category : #testing }

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -209,7 +209,10 @@ SoilIndexedDictionary >> initialize [
 
 { #category : #testing }
 SoilIndexedDictionary >> isEmpty [
-	^ newValues isEmpty and: [ self index isEmpty ]
+	^ newValues isEmpty and: [ self index isEmpty 
+		or: [
+		"all items might be removed"
+		(self index firstPage items allSatisfy: [ :each | each value isRemoved ])]]
 ]
 
 { #category : #testing }
@@ -326,9 +329,8 @@ SoilIndexedDictionary >> removeKey: key ifAbsent: aBlock [
 ]
 
 { #category : #private }
-SoilIndexedDictionary >> restoreValue: value forKey: key iterator: iterator [ 
-	"restore a value that has been removed by a later 
-	transaction"
+SoilIndexedDictionary >> restoreValue: value forKey: key iterator: iterator [
+	"restore a value that has been removed by a later transaction"
 	^ value isRemoved 
 		ifTrue: [
 			self 

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -57,14 +57,8 @@ SoilSkipListPage >> biggestKey [
 
 { #category : #accessing }
 SoilSkipListPage >> firstItem [
-	^ items 
-		ifNotEmpty: [ items first ]
-		ifEmpty: nil
-]
 
-{ #category : #testing }
-SoilSkipListPage >> hasItems [
-	^ (items reject: [ :each | each value isRemoved ]) notEmpty
+	^ items isNotEmpty ifTrue: [ items first ]
 ]
 
 { #category : #testing }
@@ -223,14 +217,13 @@ SoilSkipListPage >> keySize: anInteger [
 { #category : #accessing }
 SoilSkipListPage >> lastItem [
 
-	^ items ifEmpty: nil ifNotEmpty: [ :itms | itms last ]
+	^ items isNotEmpty ifTrue: [ items last ]
 ]
 
 { #category : #accessing }
 SoilSkipListPage >> lastKey [
-	^ items 
-		ifNotEmpty: [ items last key ]
-		ifEmpty: nil
+
+	^ items isNotEmpty ifTrue: [ items last key ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
The test of removed items should not happen at the level of the pages


- remove #hasItems
- use #isEmpty on the level of the SkipList and Btree, not #hasItems
- do the #isRemoved check on the level of the SoilIndexedDictionary

Clean up first/last item to not need a block creation.

This does not restore values yet, it is just a refactoring. But now we can use it in a next step