### PR TITLE
Iterator #do:, use #nextPresent

### DIFF
--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -56,9 +56,8 @@ SoilIndexIterator >> currentPage: anObject [
 { #category : #enumerating }
 SoilIndexIterator >> do: aBlock [
 	| item |
-	[ (item := self next) isNil ] whileFalse: [ 
-		item isRemoved ifFalse: [  
-			aBlock value: item ] ]
+	[ (item := self nextPresent) isNil ] whileFalse: [
+			aBlock value: item ]
 ]
 
 { #category : #private }


### PR DESCRIPTION
Another small refactoring to reduce isRemoved calls.

#do: uses next, but we have #nextPresent that handles removed values

closes #360 (but I added a new issue as  #nextPresent has to restore values)