### PR TITLE
Simplify SoilIndexedDictionary>>#basicAt:ifAbsent:

### DIFF
--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -81,32 +81,7 @@ SoilIndexedDictionary >> basicAt: aString ifAbsent: aBlock [
 	key := (aString asSkipListKeyOfSize: self index keySize) asInteger.
 	iterator := self index newIterator.
 	value := iterator at: aString ifAbsent: aBlock.
-	value isRemoved ifTrue: [  
-		^ (iterator currentPage isOlderThan: transaction readVersion) 
-			ifTrue: [ aBlock value ] 
-			ifFalse: [
-				(transaction 
-					journalEntriesFor: key 
-					inIndex: index 
-					startingAt: iterator currentPage lastTransaction)
-						ifNotEmpty: [:entries | 
-							entries last oldValue ]
-						ifEmpty: [ self halt. ] ] ].
-	"if the last modifying transaction of the current page is smaller
-	than ours then we don't need to check for visibility as all objects
-	are visible"
-	^ (iterator currentPage isOlderThan: transaction readVersion)
-		ifTrue: [ value ]
-		ifFalse: [ 
-			(transaction 
-				journalEntriesFor: key 
-				inIndex: index 
-				startingAt: iterator currentPage lastTransaction)
-					ifNotEmpty: [:entries | 
-						entries last oldValue ifNil: [ aBlock value ] ]
-					ifEmpty: [ value ].
-			 ]
-	
+	^ (self restoreValue: value forKey: key iterator: iterator) ifNil: [ aBlock value ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
basicAt:ifAbsent: can be written in terms of #restoreValue: forKey: iterator:

-> we always try to restore.
-> restore checks isRemoved
-> SoilIndexedDictionary>>#historicValueAt:iterator:ifAbsent:  does the isOlderThan: check

This way we use the same code for at: that we use for do: