### PR TITLE
SoilIndexedDictionary: implement size to restore values

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -239,9 +239,7 @@ SoilIndexedDictionaryTest >> testConcurrentIsEmpty [
 	tx3 commit.
 	"invisible: tx2 still has the key"
 	self deny: tx2 root isEmpty.
-	"to fix: size is wrong as it does not restore the value" 
-	self flag: #isRemoved.
-	self assert: tx2 root size equals: 0
+	self assert: tx2 root size equals: 1
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -339,7 +339,12 @@ SoilIndexedDictionary >> second [
 { #category : #accessing }
 SoilIndexedDictionary >> size [ 
 	^ transaction 
-		ifNotNil: [ self index size ]
+		ifNotNil: [ 
+			"We should just call size on index, but the do: here can restore values"
+			| sum |
+			sum := 0.
+			self do: [ :each | sum := sum + 1 ].
+			sum ]
 		ifNil: [ newValues size ]
 ]
 


### PR DESCRIPTION
this uses the #do of the SoilIndexedDictionary in size, this way it is can restore values correctly on the level of the SoilIndexedDictionary.

fixes #527