### PR TITLE
SoilIndexedDictionary: do not use index where the iterator should be used

### DIFF
--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -1,9 +1,6 @@
 Class {
 	#name : #SoilBasicBTree,
-	#superclass : #Object,
-	#instVars : [
-		'store'
-	],
+	#superclass : #SoilIndex,
 	#category : #'Soil-Core-Index-BTree'
 }
 
@@ -21,55 +18,6 @@ SoilBasicBTree >> asCopyOnWrite [
 ]
 
 { #category : #accessing }
-SoilBasicBTree >> at: key [ 
-	^ self 
-		at: key 
-		ifAbsent: [ KeyNotFound signalFor: key in: self  ] 
-]
-
-{ #category : #accessing }
-SoilBasicBTree >> at: anObject ifAbsent: aBlock [
-	^ (self find: anObject) 
-		ifNotNil: [:node | node value ]
-		ifNil: [ aBlock value ] 
-]
-
-{ #category : #accessing }
-SoilBasicBTree >> at: aKeyObject put: anObject [
-
-	self newIterator 
-		at: aKeyObject 
-		put: anObject.
-
-]
-
-{ #category : #accessing }
-SoilBasicBTree >> atIndex: anInteger [
-	^ self newIterator atIndex: anInteger 
-]
-
-{ #category : #'open/close' }
-SoilBasicBTree >> close [
-	self store close
-]
-
-{ #category : #private }
-SoilBasicBTree >> find: aString [ 
-	^ self newIterator 
-		find: (aString asSkipListKeyOfSize: self keySize) asInteger
-]
-
-{ #category : #accessing }
-SoilBasicBTree >> first [
-	^ self newIterator first
-]
-
-{ #category : #accessing }
-SoilBasicBTree >> first: anInteger [
-	^ self newIterator first: anInteger
-]
-
-{ #category : #accessing }
 SoilBasicBTree >> firstPage [
 	^ self headerPage
 ]
@@ -77,16 +25,6 @@ SoilBasicBTree >> firstPage [
 { #category : #accessing }
 SoilBasicBTree >> flush [
 	self store flush
-]
-
-{ #category : #accessing }
-SoilBasicBTree >> flushCachedPages [
-	store flushCachedPages
-]
-
-{ #category : #accessing }
-SoilBasicBTree >> headerPage [
-	^ self store headerPage
 ]
 
 { #category : #initialization }
@@ -104,36 +42,11 @@ SoilBasicBTree >> initializeHeaderPage [
 	self store pageAt: rootIndexPage index put: rootIndexPage
 ]
 
-{ #category : #testing }
-SoilBasicBTree >> isEmpty [
-	^ self store headerPage isEmpty
-]
-
-{ #category : #testing }
-SoilBasicBTree >> isRegistered [
-	^ self subclassResponsibility
-]
-
-{ #category : #accessing }
-SoilBasicBTree >> keySize [
-	^ self headerPage keySize
-]
-
 { #category : #accessing }
 SoilBasicBTree >> keySize: anInteger [
 	self headerPage keySize: anInteger.
 	"we have to set the keySize of the rootPage, too, as the page gets created before the keySize is known"
 	self rootPage keySize: anInteger
-]
-
-{ #category : #accessing }
-SoilBasicBTree >> last [
-	^ self newIterator last
-]
-
-{ #category : #accessing }
-SoilBasicBTree >> lastPage [
-	^ self newIterator lastPage
 ]
 
 { #category : #accessing }
@@ -202,19 +115,9 @@ SoilBasicBTree >> open [
 	self store open
 ]
 
-{ #category : #accessing }
-SoilBasicBTree >> pageAt: anInteger [ 
-	^ self store pageAt: anInteger 
-]
-
 { #category : #initialization }
 SoilBasicBTree >> pageClass [
 	^ SoilBTreeDataPage
-]
-
-{ #category : #accessing }
-SoilBasicBTree >> pageSize [
-	^ 4 * 1024
 ]
 
 { #category : #accessing }
@@ -225,13 +128,6 @@ SoilBasicBTree >> pages [
 { #category : #'instance creation' }
 SoilBasicBTree >> readPageFrom: aStream [
 	^ SoilBTreePage readPageFrom: aStream keySize: self keySize valueSize: self valueSize
-]
-
-{ #category : #removing }
-SoilBasicBTree >> removeKey: key [ 
-	^ self
-		removeKey: key 
-		ifAbsent: [ KeyNotFound signalFor: key in: self ]
 ]
 
 { #category : #removing }
@@ -251,12 +147,6 @@ SoilBasicBTree >> rootPage [
 	^ self store pageAt: 2
 ]
 
-{ #category : #accessing }
-SoilBasicBTree >> size [
-	"We iterate over all elements to get the size. Slow!"
-	^ self newIterator size 
-]
-
 { #category : #splitting }
 SoilBasicBTree >> splitIndexPage: page [ 
 	| newPage |
@@ -274,33 +164,6 @@ SoilBasicBTree >> splitPage: page [
 	page next: newPage index.
 	self store pageAt: newPage index put: newPage.
 	^ newPage 
-]
-
-{ #category : #accessing }
-SoilBasicBTree >> store [
-	^ store ifNil: [ 
-		store := self newFileStore ]
-]
-
-{ #category : #accessing }
-SoilBasicBTree >> store: anObject [
-	anObject index: self.
-	store := anObject
-]
-
-{ #category : #converting }
-SoilBasicBTree >> thePersistentInstance [
-	^ self subclassResponsibility
-]
-
-{ #category : #accessing }
-SoilBasicBTree >> valueSize [
-	^ self headerPage valueSize
-]
-
-{ #category : #accessing }
-SoilBasicBTree >> valueSize: anInteger [
-	self headerPage valueSize: anInteger
 ]
 
 { #category : #writing }

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -73,7 +73,7 @@ SoilBasicBTree >> first [
 SoilBasicBTree >> first: anInteger [ 
 	| iterator col |
 	iterator := self newIterator.
-	col := OrderedCollection new.
+	col := OrderedCollection new: anInteger.
 	anInteger timesRepeat: [ 
 		(iterator nextPresent)
 			ifNotNil: [ :value | col add: value ]

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -45,12 +45,7 @@ SoilBasicBTree >> at: aKeyObject put: anObject [
 
 { #category : #accessing }
 SoilBasicBTree >> atIndex: anInteger [
-	| current iterator |
-	iterator := self newIterator.
-	current := iterator first.
-	2 to: anInteger do: [ :idx |
-		current := iterator next ].
-	^ current value
+	^ self newIterator atIndex: anInteger 
 ]
 
 { #category : #'open/close' }
@@ -70,15 +65,8 @@ SoilBasicBTree >> first [
 ]
 
 { #category : #accessing }
-SoilBasicBTree >> first: anInteger [ 
-	| iterator col |
-	iterator := self newIterator.
-	col := OrderedCollection new: anInteger.
-	anInteger timesRepeat: [ 
-		(iterator nextPresent)
-			ifNotNil: [ :value | col add: value ]
-			ifNil: [ ^ col ]].
-	^ col
+SoilBasicBTree >> first: anInteger [
+	^ self newIterator first: anInteger
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilBasicSkipList.class.st
+++ b/src/Soil-Core/SoilBasicSkipList.class.st
@@ -36,13 +36,8 @@ SoilBasicSkipList >> at: aKeyObject put: anObject [
 ]
 
 { #category : #accessing }
-SoilBasicSkipList >> atIndex: anInteger [ 
-	| current iterator |
-	iterator := self newIterator.
-	current := iterator first.
-	2 to: anInteger do: [ :idx |
-		current := iterator next ].
-	^ current value
+SoilBasicSkipList >> atIndex: anInteger [
+	^ self newIterator atIndex: anInteger 
 ]
 
 { #category : #accessing }
@@ -69,15 +64,8 @@ SoilBasicSkipList >> first [
 ]
 
 { #category : #accessing }
-SoilBasicSkipList >> first: anInteger [ 
-	| iterator col |
-	iterator := self newIterator.
-	col := OrderedCollection new: anInteger.
-	anInteger timesRepeat: [ 
-		(iterator nextPresent)
-			ifNotNil: [ :value | col add: value ]
-			ifNil: [ ^ col ]].
-	^ col
+SoilBasicSkipList >> first: anInteger [
+	^ self newIterator first: anInteger
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilBasicSkipList.class.st
+++ b/src/Soil-Core/SoilBasicSkipList.class.st
@@ -1,9 +1,6 @@
 Class {
 	#name : #SoilBasicSkipList,
-	#superclass : #Object,
-	#instVars : [
-		'store'
-	],
+	#superclass : #SoilIndex,
 	#category : #'Soil-Core-Index-SkipList'
 }
 
@@ -13,105 +10,15 @@ SoilBasicSkipList class >> isAbstract [
 	^ self == SoilBasicSkipList
 ]
 
-{ #category : #private }
-SoilBasicSkipList >> at: key [ 
-	^ self 
-		at: key 
-		ifAbsent: [ KeyNotFound signalFor: key in: self ]
-]
-
-{ #category : #private }
-SoilBasicSkipList >> at: anObject ifAbsent: aBlock [
-	^ (self find: anObject) 
-		ifNotNil: [:node | node value ]
-		ifNil: [ aBlock value ] 
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> at: aKeyObject put: anObject [
-	self newIterator 
-		at: aKeyObject 
-		put: anObject.
-
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> atIndex: anInteger [
-	^ self newIterator atIndex: anInteger 
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> basicAt: key put: anObject [
-	^ self newIterator 
-		basicAt: key 
-		put: anObject 
-]
-
-{ #category : #enumerating }
-SoilBasicSkipList >> do: aBlock [
-	self newIterator do: aBlock
-]
-
-{ #category : #private }
-SoilBasicSkipList >> find: aString [ 
-	^ self newIterator 
-		find: (aString asSkipListKeyOfSize: self keySize) asInteger
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> first [
-	^ self newIterator first
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> first: anInteger [
-	^ self newIterator first: anInteger
-]
-
 { #category : #accessing }
 SoilBasicSkipList >> firstPage [
 	^ self store pageAt: 1
 ]
 
 { #category : #accessing }
-SoilBasicSkipList >> flushCachedPages [
-	store flushCachedPages
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> headerPage [
-	^ self store headerPage
-]
-
-{ #category : #testing }
-SoilBasicSkipList >> isEmpty [
-	^ self store headerPage isEmpty
-]
-
-{ #category : #testing }
-SoilBasicSkipList >> isRegistered [
-	^ self subclassResponsibility
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> keySize [
-	^ self headerPage keySize
-]
-
-{ #category : #accessing }
 SoilBasicSkipList >> keySize: anInteger [
 	anInteger isZero ifTrue: [ Error signal: 'keySize cannot be zero yet' ].
 	self headerPage keySize: anInteger
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> last [
-	^ self newIterator last
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> lastPage [
-	^ self newIterator lastPage
 ]
 
 { #category : #accessing }
@@ -126,36 +33,14 @@ SoilBasicSkipList >> maxLevel: anInteger [
 	self headerPage maxLevel: anInteger 
 ]
 
-{ #category : #'public/accessing' }
+{ #category : #'instance creation' }
 SoilBasicSkipList >> newIterator [ 
 	^ SoilSkipListIterator on: self 
-]
-
-{ #category : #'instance creation' }
-SoilBasicSkipList >> newPage [
-	^ self subclassResponsibility
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> pageAt: anInteger [ 
-	^ self store pageAt: anInteger 
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> pageSize [
-	^ 4 * 1024
 ]
 
 { #category : #accessing }
 SoilBasicSkipList >> pages [
 	^ self store pages
-]
-
-{ #category : #removing }
-SoilBasicSkipList >> removeKey: key [ 
-	^ self
-		removeKey: key 
-		ifAbsent: [ KeyNotFound signalFor: key in: self ]
 ]
 
 { #category : #removing }
@@ -168,12 +53,6 @@ SoilBasicSkipList >> removeKey: aString ifAbsent: aBlock [
 	^ ((index := page indexOfKey: key) > 0) 
 		ifTrue: [ (page itemRemoveIndex: index) value ]
 		ifFalse: [ aBlock value ]
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> size [
-	"We iterate over all elements to get the size. Slow!"
-	^ self newIterator size 
 ]
 
 { #category : #private }
@@ -199,35 +78,6 @@ SoilBasicSkipList >> splitPage: aIterator forKey: aKey [
 				page rightAt: level put: newPage index ]].
 	self store pageAt: newPage index put: newPage.
 	^ newPage 
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> store [
-	^ store ifNil: [ 
-		store := self newFileStore ]
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> store: anObject [
-	anObject index: self.
-	store := anObject
-]
-
-{ #category : #converting }
-SoilBasicSkipList >> thePersistentInstance [
-	^ self subclassResponsibility
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> valueSize [
-	"^ 8"
-	^ self headerPage valueSize
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> valueSize: anInteger [ 
-	"valueSize := anInteger"
-	self headerPage valueSize: anInteger 
 ]
 
 { #category : #enumerating }

--- a/src/Soil-Core/SoilBasicSkipList.class.st
+++ b/src/Soil-Core/SoilBasicSkipList.class.st
@@ -72,7 +72,7 @@ SoilBasicSkipList >> first [
 SoilBasicSkipList >> first: anInteger [ 
 	| iterator col |
 	iterator := self newIterator.
-	col := OrderedCollection new.
+	col := OrderedCollection new: anInteger.
 	anInteger timesRepeat: [ 
 		(iterator nextPresent)
 			ifNotNil: [ :value | col add: value ]

--- a/src/Soil-Core/SoilIndex.class.st
+++ b/src/Soil-Core/SoilIndex.class.st
@@ -1,0 +1,172 @@
+Class {
+	#name : #SoilIndex,
+	#superclass : #Object,
+	#instVars : [
+		'store'
+	],
+	#category : #'Soil-Core-Index-Common'
+}
+
+{ #category : #private }
+SoilIndex >> at: key [ 
+	^ self 
+		at: key 
+		ifAbsent: [ KeyNotFound signalFor: key in: self ]
+]
+
+{ #category : #accessing }
+SoilIndex >> at: anObject ifAbsent: aBlock [
+	^ (self find: anObject) 
+		ifNotNil: [:node | node value ]
+		ifNil: [ aBlock value ] 
+]
+
+{ #category : #accessing }
+SoilIndex >> at: aKeyObject put: anObject [
+	self newIterator 
+		at: aKeyObject 
+		put: anObject
+]
+
+{ #category : #accessing }
+SoilIndex >> atIndex: anInteger [
+	^ self newIterator atIndex: anInteger 
+]
+
+{ #category : #accessing }
+SoilIndex >> basicAt: key put: anObject [
+	^ self newIterator 
+		basicAt: key 
+		put: anObject 
+]
+
+{ #category : #'open/close' }
+SoilIndex >> close [
+	self store close
+]
+
+{ #category : #enumerating }
+SoilIndex >> do: aBlock [
+	self newIterator do: aBlock
+]
+
+{ #category : #private }
+SoilIndex >> find: aString [ 
+	^ self newIterator 
+		find: (aString asSkipListKeyOfSize: self keySize) asInteger
+]
+
+{ #category : #accessing }
+SoilIndex >> first [
+	^ self newIterator first
+]
+
+{ #category : #accessing }
+SoilIndex >> first: anInteger [
+	^ self newIterator first: anInteger
+]
+
+{ #category : #accessing }
+SoilIndex >> flushCachedPages [
+	store flushCachedPages
+]
+
+{ #category : #accessing }
+SoilIndex >> headerPage [
+	^ self store headerPage
+]
+
+{ #category : #testing }
+SoilIndex >> isEmpty [
+	^ self store headerPage isEmpty
+]
+
+{ #category : #testing }
+SoilIndex >> isRegistered [
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+SoilIndex >> keySize [
+	^ self headerPage keySize
+]
+
+{ #category : #accessing }
+SoilIndex >> last [
+	^ self newIterator last
+]
+
+{ #category : #accessing }
+SoilIndex >> lastPage [
+	^ self newIterator lastPage
+]
+
+{ #category : #'instance creation' }
+SoilIndex >> newFileStore [
+	^ self subclassResponsibility
+]
+
+{ #category : #'instance creation' }
+SoilIndex >> newIterator [
+	^ self subclassResponsibility
+]
+
+{ #category : #'instance creation' }
+SoilIndex >> newPage [
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+SoilIndex >> pageAt: anInteger [ 
+	^ self store pageAt: anInteger 
+]
+
+{ #category : #accessing }
+SoilIndex >> pageSize [
+	^ 4 * 1024
+]
+
+{ #category : #removing }
+SoilIndex >> removeKey: key [ 
+	^ self
+		removeKey: key 
+		ifAbsent: [ KeyNotFound signalFor: key in: self ]
+]
+
+{ #category : #'instance creation' }
+SoilIndex >> removeKey: aString ifAbsent: aBlock [
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+SoilIndex >> size [
+	"We iterate over all elements to get the size. Slow!"
+	^ self newIterator size 
+]
+
+{ #category : #accessing }
+SoilIndex >> store [
+	^ store ifNil: [ 
+		store := self newFileStore ]
+]
+
+{ #category : #accessing }
+SoilIndex >> store: anObject [
+	anObject index: self.
+	store := anObject
+]
+
+{ #category : #converting }
+SoilIndex >> thePersistentInstance [
+	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+SoilIndex >> valueSize [
+	^ self headerPage valueSize
+]
+
+{ #category : #accessing }
+SoilIndex >> valueSize: anInteger [
+	self headerPage valueSize: anInteger
+]

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -43,6 +43,15 @@ SoilIndexIterator >> at: aKeyObject put: anObject [
 ]
 
 { #category : #accessing }
+SoilIndexIterator >> atIndex: anInteger [
+	| current |
+	current := self first.
+	2 to: anInteger do: [ :idx |
+		current := self next ].
+	^ current value
+]
+
+{ #category : #accessing }
 SoilIndexIterator >> basicAt: key put: anObject [
 	self subclassResponsibility
 ]

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -47,7 +47,7 @@ SoilIndexIterator >> atIndex: anInteger [
 	| current |
 	current := self first.
 	2 to: anInteger do: [ :idx |
-		current := self next ].
+		current := self nextPresent ].
 	^ current value
 ]
 

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -89,6 +89,17 @@ SoilIndexIterator >> first [
 ]
 
 { #category : #accessing }
+SoilIndexIterator >> first: anInteger [
+	| result |
+	result := OrderedCollection new: anInteger.
+	anInteger timesRepeat: [
+		| next |
+		next := self nextPresent ifNil: [ ^ result].
+		result add: next ].
+	^ result
+]
+
+{ #category : #accessing }
 SoilIndexIterator >> firstAssociation [ 
 	| item |
 	currentPage := index store headerPage.

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -47,7 +47,7 @@ SoilIndexedDictionary >> at: key put: anObject [
 		ifNotNil: [ 
 			| objectId iterator |
 			objectId := transaction makeRoot: anObject.
-			iterator := self index newIterator.
+			iterator := self newIterator.
 			(iterator at: key put: objectId) ifNotNil: [ :value |
 				oldValues 
 					at: key
@@ -63,7 +63,7 @@ SoilIndexedDictionary >> at: key put: anObject [
 SoilIndexedDictionary >> atIndex: anInteger [
 	^ transaction 
 		ifNotNil: [  
-			(self index atIndex: anInteger)
+			(index atIndex: anInteger)
 				ifNotNil: [ :bytes |
 					transaction 
 						objectId: bytes asSoilObjectId
@@ -75,15 +75,15 @@ SoilIndexedDictionary >> atIndex: anInteger [
 { #category : #accessing }
 SoilIndexedDictionary >> basicAt: aString ifAbsent: aBlock [ 
 	| iterator value key |
-	key := (aString asSkipListKeyOfSize: self index keySize) asInteger.
-	iterator := self index newIterator.
+	key := (aString asSkipListKeyOfSize: index keySize) asInteger.
+	iterator := self newIterator.
 	value := iterator at: aString ifAbsent: aBlock.
 	^ (self restoreValue: value forKey: key iterator: iterator) ifNil: [ aBlock value ]
 ]
 
 { #category : #accessing }
 SoilIndexedDictionary >> binaryKey: aString [
-	^ (aString asSkipListKeyOfSize: self index keySize) asInteger
+	^ (aString asSkipListKeyOfSize: index keySize) asInteger
 ]
 
 { #category : #initialization }
@@ -97,7 +97,7 @@ SoilIndexedDictionary >> do: aBlock [
 	transaction
 		ifNotNil: [ 
 			| iterator assoc |
-			iterator := self index newIterator.
+			iterator := self newIterator.
 			[ (assoc := iterator nextAssociation) notNil ] whileTrue: [ 
 				(self
 					 restoreValue: assoc value
@@ -111,7 +111,7 @@ SoilIndexedDictionary >> do: aBlock [
 { #category : #accessing }
 SoilIndexedDictionary >> first [
 	^ transaction 
-		ifNotNil: [ self proxyFromByteArray: self index newIterator first ]
+		ifNotNil: [ self proxyFromByteArray: self newIterator first ]
 		ifNil: [ 
 			self newValuesSortedByKeyOrder ifNotEmpty: [:nv | nv first value ] ifEmpty: nil]
 ]
@@ -120,7 +120,7 @@ SoilIndexedDictionary >> first [
 SoilIndexedDictionary >> first: anInteger [ 
 	^ transaction 
 		ifNotNil: [ 
-			(self index first: anInteger) 
+			(self newIterator first: anInteger) 
 				collect: [ :each | self proxyFromByteArray: each ] ]
 		ifNil: [ (self newValuesSortedByKeyOrder first: anInteger) collect: #value ]  
 ]
@@ -130,7 +130,7 @@ SoilIndexedDictionary >> firstAssociation [
 
 	^ transaction
 		  ifNotNil: [
-			  index newIterator firstAssociation ifNotNil: [ :assoc |
+			  self newIterator firstAssociation ifNotNil: [ :assoc |
 				  assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ] ]
 		  ifNil: [
 			self newValuesSortedByKeyOrder ifNotEmpty: [:nv | nv first ] ifEmpty: nil]
@@ -142,7 +142,7 @@ SoilIndexedDictionary >> hasIndexUpdates [
 	^ newValues notEmpty or: [ removedValues notEmpty ]
 ]
 
-{ #category : #accessing }
+{ #category : #private }
 SoilIndexedDictionary >> historicValueAt: key iterator: iterator ifAbsent: absentBlock [ 
 	"a removed value will return ObjectId 0:0"
 	
@@ -156,9 +156,8 @@ SoilIndexedDictionary >> historicValueAt: key iterator: iterator ifAbsent: absen
 			"we determine all changes between our transaction and the
 			last one modifying the page. if we get back changes for the
 			key the value of the oldes entry has the value it had before"
-			(transaction 
+			(self 
 				journalEntriesFor: key 
-				inIndex: index 
 				startingAt: iterator currentPage lastTransaction)
 					ifNotEmpty: [:entries | entries last oldValue ]
 					ifEmpty: absentBlock ]
@@ -188,12 +187,12 @@ SoilIndexedDictionary >> initialize [
 { #category : #testing }
 SoilIndexedDictionary >> isEmpty [
 	| iterator|
-	iterator := self index newIterator.
-	iterator currentPage: self index firstPage.
-	^ newValues isEmpty and: [ self index isEmpty 
+	iterator := self newIterator.
+	iterator currentPage: index firstPage.
+	^ newValues isEmpty and: [ index isEmpty 
 		or: [
 		"all items might be removed and not restorable" 
-		(self index firstPage items allSatisfy: [ :each | (self
+		(index firstPage items allSatisfy: [ :each | (self
 					 restoreValue: each value
 					 forKey: each key
 					 iterator: iterator)isNil] )]]
@@ -204,6 +203,21 @@ SoilIndexedDictionary >> isRegistered [
 	^ index isRegistered 
 ]
 
+{ #category : #private }
+SoilIndexedDictionary >> journalEntriesFor: key startingAt: anInteger [ 
+	| transactionId entries |
+	entries := OrderedCollection new.
+	transactionId := anInteger.
+	[ transactionId > transaction readVersion ] whileTrue: [  
+		(transaction soil journal transactionJournalAt: transactionId) entries do: [ :each | 
+			((each class = SoilAddKeyEntry) | (each class = SoilRemoveKeyEntry)) ifTrue: [ 
+				(each key = key) ifTrue: [ 
+					entries add: each ] ]  ].
+		transactionId := transactionId - 1.
+	].
+   ^ entries
+]
+
 { #category : #accessing }
 SoilIndexedDictionary >> keySize: anInteger [ 
 	index keySize: anInteger 
@@ -212,7 +226,7 @@ SoilIndexedDictionary >> keySize: anInteger [
 { #category : #accessing }
 SoilIndexedDictionary >> last [
 	^ transaction 
-		ifNotNil: [ self proxyFromByteArray: self index newIterator last ]
+		ifNotNil: [ self proxyFromByteArray: self newIterator last ]
 		ifNil: [ 
 			self newValuesSortedByKeyOrder ifNotEmpty: [:nv | nv last value ] ifEmpty: nil ]
 ]
@@ -222,7 +236,7 @@ SoilIndexedDictionary >> lastAssociation [
 
 	^ transaction
 		  ifNotNil: [
-			  index newIterator lastAssociation ifNotNil: [ :assoc |
+			  self newIterator lastAssociation ifNotNil: [ :assoc |
 				  assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ] ]
 		  ifNil: [ 
 			self newValuesSortedByKeyOrder ifNotEmpty: [:nv | nv last ] ifEmpty: nil ]
@@ -236,17 +250,22 @@ SoilIndexedDictionary >> loadFrom: aFileReference [
 ]
 
 { #category : #accessing }
-SoilIndexedDictionary >> maxLevel: anInteger [ 
-	index maxLevel: anInteger.
+SoilIndexedDictionary >> maxLevel: anInteger [
+	"Implemented here to allow to switch between SkipList and BTree easily in tests"
+	index maxLevel: anInteger
 
+]
+
+{ #category : #private }
+SoilIndexedDictionary >> newIterator [
+	^ index newIterator
 ]
 
 { #category : #accessing }
 SoilIndexedDictionary >> newValuesSortedByKeyOrder [
 
 	^ newValues associations sort: [ :a :b |
-		(a key asSkipListKeyOfSize: self index keySize) asInteger 
-		< (b key asSkipListKeyOfSize: self index keySize) asInteger ]
+		(self binaryKey: a key) < (self binaryKey: b key)  ]
 ]
 
 { #category : #accessing }
@@ -257,7 +276,7 @@ SoilIndexedDictionary >> nextAfter: key [
 		newValueSorted := self newValuesSortedByKeyOrder.
 		^ (newValueSorted after: (newValues associationAt: key)) value  ].
 
-	iterator := self index newIterator 
+	iterator := self newIterator 
 		find: key asInteger;
 		yourself.
 	^ iterator nextPresentAssociation 
@@ -299,7 +318,7 @@ SoilIndexedDictionary >> removeKey: key ifAbsent: aBlock [
 			"remove from newValues as there could be a new at:put: on that
 			key but removing the key will remove the value again"
 			newValues removeKey: key ifAbsent: nil.
-			iterator := self index newIterator.
+			iterator := self newIterator.
 			v := self basicAt: key ifAbsent: [^ aBlock value].
 			removedValues 
 				at: key 
@@ -321,8 +340,7 @@ SoilIndexedDictionary >> restoreValue: value forKey: key iterator: iterator [
 				iterator: iterator 
 				ifAbsent: [ nil ] ]
 		ifFalse: [
-			"restore a value that has been overwritten by a later
-			transaction"   
+			"restore a value that has been overwritten by a later transaction"   
 			self 
 				historicValueAt: key 
 				iterator: iterator 
@@ -332,7 +350,7 @@ SoilIndexedDictionary >> restoreValue: value forKey: key iterator: iterator [
 { #category : #accessing }
 SoilIndexedDictionary >> second [
 	^ transaction 
-		ifNotNil: [ self proxyFromByteArray: (index newIterator first; next) ]
+		ifNotNil: [ self proxyFromByteArray: (self newIterator first; next) ]
 		ifNil: [ self newValuesSortedByKeyOrder second value ]
 ]
 
@@ -368,7 +386,7 @@ SoilIndexedDictionary >> soilClusterRootIn: aTransaction [
 				newValues 
 					at: key 
 					put: (transaction makeRoot: object) ].
-		self index newIterator at: key put: obj ].
+		self newIterator at: key put: obj ].
 	transaction markDirty: self
 ]
 

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -63,7 +63,7 @@ SoilIndexedDictionary >> at: key put: anObject [
 SoilIndexedDictionary >> atIndex: anInteger [
 	^ transaction 
 		ifNotNil: [  
-			(index atIndex: anInteger)
+			(self newIterator atIndex: anInteger)
 				ifNotNil: [ :bytes |
 					transaction 
 						objectId: bytes asSoilObjectId

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -64,12 +64,8 @@ SoilIndexedDictionary >> atIndex: anInteger [
 	^ transaction 
 		ifNotNil: [  
 			(self newIterator atIndex: anInteger)
-				ifNotNil: [ :bytes |
-					transaction 
-						objectId: bytes asSoilObjectId
-						ifVisible: [:objectId | (objectId asSoilObjectProxy) transaction: transaction ]
-						ifHidden: nil ] ]
-		ifNil: [ (newValues associations at: anInteger) value  ]
+				ifNotNil: [ :objectId | transaction proxyForObjectId: objectId ]]
+		ifNil: [ (newValues associations at: anInteger) value ]
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilSkipList.class.st
+++ b/src/Soil-Core/SoilSkipList.class.st
@@ -21,17 +21,12 @@ SoilSkipList >> asCopyOnWrite [
 		yourself 
 ]
 
-{ #category : #'opening/closing' }
-SoilSkipList >> close [
-	self store close
-]
-
 { #category : #deleting }
 SoilSkipList >> destroy [
 	path ensureDelete 
 ]
 
-{ #category : #accessing }
+{ #category : #deleting }
 SoilSkipList >> flush [
 	self store flush
 ]
@@ -54,7 +49,7 @@ SoilSkipList >> initializeParametersFrom: aSoilSkipList [
 		valueSize: aSoilSkipList valueSize
 ]
 
-{ #category : #private }
+{ #category : #testing }
 SoilSkipList >> isPersistent [
 	^ path notNil
 ]
@@ -136,7 +131,6 @@ SoilSkipList >> thePersistentInstance [
 
 { #category : #accessing }
 SoilSkipList >> valueSize [
-	"^ 8"
 	^ valueSize ifNil: [ 
 		valueSize := super valueSize ]
 ]

--- a/src/Soil-Core/SoilTransaction.class.st
+++ b/src/Soil-Core/SoilTransaction.class.st
@@ -377,22 +377,6 @@ SoilTransaction >> journal [
 	^ journal
 ]
 
-{ #category : #accessing }
-SoilTransaction >> journalEntriesFor: key inIndex: aSoilIndex startingAt: anInteger [ 
-	| transactionId entries |
-	entries := OrderedCollection new.
-	transactionId := anInteger.
-	[ transactionId > readVersion ] whileTrue: [  
-		(soil journal transactionJournalAt: transactionId) entries do: [ :each | 
-			((each class = SoilAddKeyEntry) | (each class = SoilRemoveKeyEntry)) ifTrue: [ 
-				(each key = key) ifTrue: [ 
-					entries add: each ] ]  ].
-		transactionId := transactionId - 1.
-	].
-   ^ entries
-	
-]
-
 { #category : #'as yet unclassified' }
 SoilTransaction >> lockObjectId: aSOObjectId [ 
 	^ self objectRepository lockObjectId: aSOObjectId for: self

--- a/src/Soil-Core/SoilTransaction.class.st
+++ b/src/Soil-Core/SoilTransaction.class.st
@@ -364,14 +364,6 @@ SoilTransaction >> isRoot: anObject [
 		ifAbsent: nil) notNil
 ]
 
-{ #category : #testing }
-SoilTransaction >> isVisibleObjectId: aSoilObjectId [ 
-	"not initialized objectIds are private to this transaction
-	and therefor visible"
-	aSoilObjectId isInitialized ifFalse: [ ^ true ].
-	^ (self recordWithId: aSoilObjectId) notNil 
-]
-
 { #category : #accessing }
 SoilTransaction >> journal [
 	^ journal
@@ -465,13 +457,6 @@ SoilTransaction >> objectAt: anObjectId ifAbsent: aBlock [
 		at: anObjectId 
 		ifPresent: [ :record | ^ record object ]
 		ifAbsent: aBlock 
-]
-
-{ #category : #testing }
-SoilTransaction >> objectId: objectId ifVisible: visibleBlock ifHidden: hiddenBlock [ 
-	^ (self isVisibleObjectId: objectId)
-		ifTrue: [ visibleBlock cull: objectId ]
-		ifFalse: [ hiddenBlock cull: objectId ] 
 ]
 
 { #category : #'as yet unclassified' }


### PR DESCRIPTION
- implement #first on the iterator
- never do a self send #index in SoilIndexedDictionary
- all direct accesses of index in SoilIndexedDictionary now are *not* related to accessing/interating
- move journalEntriesFor:inIndex:startingAt: to the SoilIndexedDictionary (was on Transaction), remove unused index arg
- Implement #atIndex: at the level of the Iterator
- Index: delegate atIndex and first: to the iterator
- atIndex: use nextPresent (for now)
- cleanup #objectId:ifVisible:ifHidden: that it used before (this was an early version of the isRemoved check)
- BTree/SkipList: Move all methods using the iterator up to SoilIndex