### PR TITLE
Add SoilIndexItemsPage shared superclass

### DIFF
--- a/src/Soil-Core/SoilBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilBTreeDataPage.class.st
@@ -58,14 +58,6 @@ SoilBTreeDataPage >> isLastPage [
 ]
 
 { #category : #accessing }
-SoilBTreeDataPage >> itemAt: anInteger ifAbsent: aBlock [
-	^ items 
-		findBinaryIndex: [ :each |  anInteger - each key ] 
-		do: [:ind | items at: ind ]
-		ifNone: aBlock 
-]
-
-{ #category : #accessing }
 SoilBTreeDataPage >> itemAt: key put: anObject [ 
 	| removedItem |
 	removedItem := self itemRemoveAt: key ifAbsent: [ KeyNotFound signal: 'this method is just for replacing items'].

--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -1,8 +1,7 @@
 Class {
 	#name : #SoilBTreePage,
-	#superclass : #SoilIndexPage,
+	#superclass : #SoilIndexItemsPage,
 	#instVars : [
-		'items',
 		'keySize',
 		'lastTransaction'
 	],
@@ -14,12 +13,6 @@ SoilBTreePage class >> indexClass [
 	^ SoilBTree 
 ]
 
-{ #category : #accessing }
-SoilBTreePage class >> pageCode [
-	"abstract"
-	^0
-]
-
 { #category : #adding }
 SoilBTreePage >> addItem: anAssociation [
 	(items anySatisfy: [ :item | item key = anAssociation key ])
@@ -28,29 +21,9 @@ SoilBTreePage >> addItem: anAssociation [
 	dirty := true
 ]
 
-{ #category : #accessing }
-SoilBTreePage >> associationAt: anInteger [ 
-	^ self
-		associationAt: anInteger 
-		ifAbsent: nil
-]
-
-{ #category : #accessing }
-SoilBTreePage >> associationAt: anInteger ifAbsent: aBlock [
-	^ items 
-		detect: [:each | each key = anInteger ] 
-		ifNone: aBlock
-]
-
 { #category : #private }
 SoilBTreePage >> find: aKey with: aBTree [ 
 	^ self subclassResponsibility
-]
-
-{ #category : #accessing }
-SoilBTreePage >> firstItem [
-
-	^ items isNotEmpty ifTrue: [ items first ]
 ]
 
 { #category : #testing }
@@ -58,29 +31,11 @@ SoilBTreePage >> hasRoom [
 	^ self headerSize + ((items size + 1) * (self keySize + self valueSize)) <= self pageSize
 ]
 
-{ #category : #utilities }
-SoilBTreePage >> headerSize [
-	^ super headerSize + 8 "last transaction number"
-]
-
-{ #category : #accessing }
-SoilBTreePage >> indexOfKey: anInteger [ 
-	items withIndexDo: [ :each :idx |
-		(each key = anInteger) ifTrue: [ ^ idx ] ].
-	^ 0
-]
-
 { #category : #initialization }
 SoilBTreePage >> initialize [ 
 	super initialize.
-	items := SortedCollection new.
 	lastTransaction := 0.
 	dirty := true
-]
-
-{ #category : #testing }
-SoilBTreePage >> isEmpty [
-	^ items isEmpty 
 ]
 
 { #category : #testing }
@@ -104,38 +59,6 @@ SoilBTreePage >> itemCapacity [
 ]
 
 { #category : #accessing }
-SoilBTreePage >> itemRemoveAt: key [ 
-	^ self 
-		itemRemoveAt: key 
-		ifAbsent: [ KeyNotFound signalFor: key in: self ]
-]
-
-{ #category : #accessing }
-SoilBTreePage >> itemRemoveAt: anInteger ifAbsent: aBlock [
-	| item |
-	items 
-		findBinaryIndex: [ :each |  anInteger - each key ] 
-		do: [:ind | item := items removeAt: ind ]
-		ifNone: [ ^ aBlock value ].
-	dirty := true.
-	^ item
-]
-
-{ #category : #accessing }
-SoilBTreePage >> itemRemoveIndex: anInteger [
-	| item |
-	item := items at: anInteger.
-	items removeAt: anInteger.
-	dirty := true.
-	^ item
-]
-
-{ #category : #accessing }
-SoilBTreePage >> items [
-	^ items
-]
-
-{ #category : #accessing }
 SoilBTreePage >> keySize [
 	^ keySize
 ]
@@ -143,12 +66,6 @@ SoilBTreePage >> keySize [
 { #category : #accessing }
 SoilBTreePage >> keySize: anInteger [ 
 	keySize := anInteger
-]
-
-{ #category : #accessing }
-SoilBTreePage >> lastItem [
-
-	^ items isNotEmpty ifTrue: [ items last ]
 ]
 
 { #category : #accessing }
@@ -162,20 +79,9 @@ SoilBTreePage >> lastTransaction: anInteger [
 ]
 
 { #category : #accessing }
-SoilBTreePage >> numberOfItems [
-	^ items size
-]
-
-{ #category : #accessing }
 SoilBTreePage >> pointerSize [
 	"this is the size in bytes used to point to other pages"
 	^ 4
-]
-
-{ #category : #copying }
-SoilBTreePage >> postCopy [ 
-	super postCopy.
-	items := items copy.
 ]
 
 { #category : #reading }
@@ -198,16 +104,6 @@ SoilBTreePage >> readLastTransactionFrom: aStream [
 	lastTransaction := (aStream next: 8) asInteger.
 ]
 
-{ #category : #initialization }
-SoilBTreePage >> setItems: aCollection [ 
-	items := aCollection
-]
-
-{ #category : #accessing }
-SoilBTreePage >> smallestKey [
-	^ items first key
-]
-
 { #category : #private }
 SoilBTreePage >> split: newPage [
 	| middle |
@@ -218,20 +114,6 @@ SoilBTreePage >> split: newPage [
 	newPage setItems: (items copyFrom: middle + 1 to: items size).
 	items removeLast: items size - middle.
 	^ newPage
-]
-
-{ #category : #accessing }
-SoilBTreePage >> valueAt: anInteger [ 
-	^ self 
-		valueAt: anInteger 
-		ifAbsent: nil 
-]
-
-{ #category : #accessing }
-SoilBTreePage >> valueAt: anInteger ifAbsent: aBlock [
-	^ (self 
-		associationAt: anInteger
-		ifAbsent: aBlock) value
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilIndexItemsPage.class.st
+++ b/src/Soil-Core/SoilIndexItemsPage.class.st
@@ -1,0 +1,137 @@
+Class {
+	#name : #SoilIndexItemsPage,
+	#superclass : #SoilIndexPage,
+	#instVars : [
+		'items'
+	],
+	#category : #'Soil-Core-Index-Common'
+}
+
+{ #category : #testing }
+SoilIndexItemsPage class >> isAbstract [
+	<ignoreForCoverage>
+	^ self == SoilIndexItemsPage
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> associationAt: anInteger [ 
+	^ self
+		associationAt: anInteger 
+		ifAbsent: nil
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> associationAt: anInteger ifAbsent: aBlock [
+	^ items 
+		detect: [:each | each key = anInteger ] 
+		ifNone: aBlock
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> firstItem [
+
+	^ items isNotEmpty ifTrue: [ items first ]
+]
+
+{ #category : #utilities }
+SoilIndexItemsPage >> headerSize [
+	^ super headerSize + 8 "last transaction number"
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> indexOfKey: anInteger [ 
+	items withIndexDo: [ :each :idx |
+		(each key = anInteger) ifTrue: [ ^ idx ] ].
+	^ 0
+]
+
+{ #category : #initialization }
+SoilIndexItemsPage >> initialize [
+	items := SortedCollection new
+]
+
+{ #category : #testing }
+SoilIndexItemsPage >> isEmpty [
+	^ items isEmpty 
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> itemAt: anInteger ifAbsent: aBlock [
+	^ items 
+		findBinaryIndex: [ :each |  anInteger - each key ] 
+		do: [:ind | items at: ind ]
+		ifNone: aBlock 
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> itemRemoveAt: key [ 
+	^ self 
+		itemRemoveAt: key 
+		ifAbsent: [ KeyNotFound signalFor: key in: self ]
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> itemRemoveAt: anInteger ifAbsent: aBlock [
+	| item |
+	items 
+		findBinaryIndex: [ :each |  anInteger - each key ] 
+		do: [:ind | item := items removeAt: ind ]
+		ifNone: [ ^ aBlock value ].
+	dirty := true.
+	^ item
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> itemRemoveIndex: anInteger [
+	| item |
+	item := items at: anInteger.
+	items removeAt: anInteger.
+	dirty := true.
+	^ item
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> items [
+	^ items
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> lastItem [
+
+	^ items isNotEmpty ifTrue: [ items last ] ifFalse: [ nil ]
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> numberOfItems [
+	^ items size
+]
+
+{ #category : #copying }
+SoilIndexItemsPage >> postCopy [ 
+	super postCopy.
+	items := items copy.
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> setItems: aCollection [ 
+	items := aCollection
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> smallestKey [
+	^ items first key
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> valueAt: anInteger [ 
+	^ self 
+		valueAt: anInteger 
+		ifAbsent: nil 
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> valueAt: anInteger ifAbsent: aBlock [
+	^ (self 
+		associationAt: anInteger
+		ifAbsent: aBlock) value
+]

--- a/src/Soil-Core/SoilIndexPage.class.st
+++ b/src/Soil-Core/SoilIndexPage.class.st
@@ -19,8 +19,9 @@ SoilIndexPage class >> isAbstract [
 ]
 
 { #category : #accessing }
-SoilIndexPage class >> pageCode [ 
-	self subclassResponsibility 
+SoilIndexPage class >> pageCode [
+	"abstract"
+	^ 0 
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilJournalConverter.class.st
+++ b/src/Soil-Core/SoilJournalConverter.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'soil'
 	],
-	#category : #'Soil-Core'
+	#category : #'Soil-Core-Journal'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -1,9 +1,8 @@
 Class {
 	#name : #SoilSkipListPage,
-	#superclass : #SoilIndexPage,
+	#superclass : #SoilIndexItemsPage,
 	#instVars : [
 		'right',
-		'items',
 		'keySize',
 		'valueSize',
 		'lastTransaction'
@@ -22,12 +21,6 @@ SoilSkipListPage class >> isAbstract [
 	^ self == SoilSkipListPage 
 ]
 
-{ #category : #accessing }
-SoilSkipListPage class >> pageCode [
-	"abstract"
-	^ 0 
-]
-
 { #category : #adding }
 SoilSkipListPage >> addItem: anAssociation [ 
 	items add: anAssociation.
@@ -35,30 +28,10 @@ SoilSkipListPage >> addItem: anAssociation [
 ]
 
 { #category : #accessing }
-SoilSkipListPage >> associationAt: anInteger [ 
-	^ self 
-		associationAt: anInteger 
-		ifAbsent: nil
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> associationAt: key ifAbsent: aBlock [
-	^ items 
-		detect: [:each | each key = key ] 
-		ifNone: aBlock
-]
-
-{ #category : #accessing }
 SoilSkipListPage >> biggestKey [
 	^ self isLastPage 
 		ifTrue: [ (2 raisedTo: (keySize * 8)) - 1 ]
 		ifFalse: [ self lastKey ]
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> firstItem [
-
-	^ items isNotEmpty ifTrue: [ items first ]
 ]
 
 { #category : #testing }
@@ -69,24 +42,9 @@ SoilSkipListPage >> hasRoom [
 	^ used <= (self pageSize - itemSize)
 ]
 
-{ #category : #utilities }
-SoilSkipListPage >> headerSize [
-	^ super headerSize + 8 "last transaction number"
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> indexOfKey: anInteger [ 
-	items withIndexDo: [ :each :idx |
-		(each key = anInteger) ifTrue: [ ^ idx ] ].
-	^ 0
-	
-		
-]
-
 { #category : #initialization }
 SoilSkipListPage >> initialize [ 
 	super initialize.
-	items := SortedCollection new.
 	lastTransaction := 0.
 	dirty := true.
 
@@ -101,11 +59,6 @@ SoilSkipListPage >> initializeLevel: maxLevel [
 		level := level + 1.
 		promote := self class random next > 0.5 ].
 	right := Array new: level withAll: 0. 
-]
-
-{ #category : #testing }
-SoilSkipListPage >> isEmpty [
-	^ items isEmpty 
 ]
 
 { #category : #testing }
@@ -128,14 +81,6 @@ SoilSkipListPage >> itemAfter: key [
 ]
 
 { #category : #accessing }
-SoilSkipListPage >> itemAt: anInteger ifAbsent: aBlock [
-	^ items 
-		findBinaryIndex: [ :each |  anInteger - each key ] 
-		do: [:ind | items at: ind ]
-		ifNone: aBlock 
-]
-
-{ #category : #accessing }
 SoilSkipListPage >> itemAt: key put: anObject [ 
 	| removedItem |
 	removedItem := self itemRemoveAt: key ifAbsent: [ KeyNotFound signal: 'this method is just for replacing items'].
@@ -155,38 +100,6 @@ SoilSkipListPage >> itemBefore: key [
 { #category : #accessing }
 SoilSkipListPage >> itemCapacity [
 	^ ((self pageSize - self headerSize) / (self keySize + self valueSize)) floor
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> itemRemoveAt: key [ 
-	^ self 
-		itemRemoveAt: key 
-		ifAbsent: [ KeyNotFound signalFor: key in: self ]
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> itemRemoveAt: anInteger ifAbsent: aBlock [
-	| item |
-	items 
-		findBinaryIndex: [ :each |  anInteger - each key ] 
-		do: [:ind | item := items removeAt: ind ]
-		ifNone: [ ^ aBlock value ].
-	dirty := true.
-	^ item
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> itemRemoveIndex: anInteger [
-	| item |
-	item := items at: anInteger.
-	items removeAt: anInteger.
-	dirty := true.
-	^ item
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> items [
-	^ items
 ]
 
 { #category : #accessing }
@@ -215,12 +128,6 @@ SoilSkipListPage >> keySize: anInteger [
 ]
 
 { #category : #accessing }
-SoilSkipListPage >> lastItem [
-
-	^ items isNotEmpty ifTrue: [ items last ]
-]
-
-{ #category : #accessing }
 SoilSkipListPage >> lastKey [
 
 	^ items isNotEmpty ifTrue: [ items last key ]
@@ -246,15 +153,9 @@ SoilSkipListPage >> next [
 	^ self rightAt: 1
 ]
 
-{ #category : #accessing }
-SoilSkipListPage >> numberOfItems [
-	^ items size 
-]
-
 { #category : #copying }
 SoilSkipListPage >> postCopy [ 
 	super postCopy.
-	items := items copy.
 	right := right copy
 ]
 
@@ -312,19 +213,9 @@ SoilSkipListPage >> rightSize [
 	^ 4
 ]
 
-{ #category : #accessing }
-SoilSkipListPage >> setItems: aCollection [ 
-	items := aCollection
-]
-
 { #category : #private }
 SoilSkipListPage >> sizeInBytes [
 	^ self headerSize + (items size * (self keySize + self valueSize))
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> smallestKey [
-	^ items first key
 ]
 
 { #category : #private }
@@ -336,20 +227,6 @@ SoilSkipListPage >> split: newPage [
 	dirty := true.
 	^ newPage
 	
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> valueAt: anInteger [ 
-	^ self 
-		valueAt: anInteger 
-		ifAbsent: nil
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> valueAt: anInteger ifAbsent: aBlock [
-	^ (self 
-		associationAt: anInteger
-		ifAbsent: aBlock) value
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Add SoilIndexItemsPage, abstract, no pageCode.

This is a superclass of SoilBTreePage and SoilSkipListPage to not have to copy all the code that access the items.

We keep SoilIndexPage as a superclass as there will be more kinds of pages (with different page codes) in the future.

(and it is very easy to undo this and copy the methods down in case if needed )