### PR TITLE
 551-Add-abstract-superclass-for-SoilBasicSkipList-and-SoilBasicBTree 

### DIFF
--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -18,11 +18,6 @@ SoilBasicBTree >> asCopyOnWrite [
 ]
 
 { #category : #accessing }
-SoilBasicBTree >> firstPage [
-	^ self headerPage
-]
-
-{ #category : #accessing }
 SoilBasicBTree >> flush [
 	self store flush
 ]
@@ -44,14 +39,9 @@ SoilBasicBTree >> initializeHeaderPage [
 
 { #category : #accessing }
 SoilBasicBTree >> keySize: anInteger [
-	self headerPage keySize: anInteger.
+	super keySize: anInteger.
 	"we have to set the keySize of the rootPage, too, as the page gets created before the keySize is known"
 	self rootPage keySize: anInteger
-]
-
-{ #category : #accessing }
-SoilBasicBTree >> maxLevel: anIntegeer [
-	"ignored, this allows to switch SkiList and BTree easily"
 ]
 
 { #category : #'instance creation' }
@@ -118,11 +108,6 @@ SoilBasicBTree >> open [
 { #category : #initialization }
 SoilBasicBTree >> pageClass [
 	^ SoilBTreeDataPage
-]
-
-{ #category : #accessing }
-SoilBasicBTree >> pages [
-	^ self store pages
 ]
 
 { #category : #'instance creation' }

--- a/src/Soil-Core/SoilBasicSkipList.class.st
+++ b/src/Soil-Core/SoilBasicSkipList.class.st
@@ -11,17 +11,6 @@ SoilBasicSkipList class >> isAbstract [
 ]
 
 { #category : #accessing }
-SoilBasicSkipList >> firstPage [
-	^ self store pageAt: 1
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> keySize: anInteger [
-	anInteger isZero ifTrue: [ Error signal: 'keySize cannot be zero yet' ].
-	self headerPage keySize: anInteger
-]
-
-{ #category : #accessing }
 SoilBasicSkipList >> maxLevel [
 
 	^ self headerPage maxLevel
@@ -36,11 +25,6 @@ SoilBasicSkipList >> maxLevel: anInteger [
 { #category : #'instance creation' }
 SoilBasicSkipList >> newIterator [ 
 	^ SoilSkipListIterator on: self 
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> pages [
-	^ self store pages
 ]
 
 { #category : #removing }

--- a/src/Soil-Core/SoilIndex.class.st
+++ b/src/Soil-Core/SoilIndex.class.st
@@ -67,6 +67,11 @@ SoilIndex >> first: anInteger [
 ]
 
 { #category : #accessing }
+SoilIndex >> firstPage [
+	^ self headerPage
+]
+
+{ #category : #accessing }
 SoilIndex >> flushCachedPages [
 	store flushCachedPages
 ]
@@ -92,6 +97,12 @@ SoilIndex >> keySize [
 ]
 
 { #category : #accessing }
+SoilIndex >> keySize: anInteger [
+	anInteger isZero ifTrue: [ Error signal: 'keySize cannot be zero yet' ].
+	self headerPage keySize: anInteger
+]
+
+{ #category : #accessing }
 SoilIndex >> last [
 	^ self newIterator last
 ]
@@ -99,6 +110,11 @@ SoilIndex >> last [
 { #category : #accessing }
 SoilIndex >> lastPage [
 	^ self newIterator lastPage
+]
+
+{ #category : #accessing }
+SoilIndex >> maxLevel: anIntegeer [
+	"ignored, this allows to switch SkiList and BTree easily"
 ]
 
 { #category : #'instance creation' }
@@ -124,6 +140,11 @@ SoilIndex >> pageAt: anInteger [
 { #category : #accessing }
 SoilIndex >> pageSize [
 	^ 4 * 1024
+]
+
+{ #category : #accessing }
+SoilIndex >> pages [
+	^ self store pages
 ]
 
 { #category : #removing }


### PR DESCRIPTION
This finishes moving shared code to SoilIndex

fixes #551