### PR TITLE
Comments and trivial cleans

### DIFF
--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -1,3 +1,12 @@
+"
+The iterator implements all logic related to iteratoring a low level index.
+
+If ""soil"" and ""readVersion"" is set, the iterator restores values using the transaction log, see SoilIndexIterator>>#journalEntriesFor:startingAt:
+
+There are two main clients
+- the low level index forwards all methods related to iterating here, not setting the read version
+- the SoilIndexedDictionary sets the readVersion (and never uses the index directly)
+"
 Class {
 	#name : #SoilIndexIterator,
 	#superclass : #Object,
@@ -107,6 +116,7 @@ SoilIndexIterator >> currentPage: anObject [
 { #category : #enumerating }
 SoilIndexIterator >> do: aBlock [
 	| item |
+	"We use basicNextAssociation to avoid the creation of intermediate associations of nextAssociation"
 	[ (item := self basicNextAssociation ) notNil ] whileTrue: [ 
  				(self
  					 restoreValue: item value

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -258,18 +258,17 @@ SoilIndexedDictionary >> removeKey: key [
 
 { #category : #removing }
 SoilIndexedDictionary >> removeKey: key ifAbsent: aBlock [
-	| iterator v |
+	
 	^ transaction 
-		ifNotNil: [ 
+		ifNotNil: [ | v |
 			"remove from newValues as there could be a new at:put: on that
 			key but removing the key will remove the value again"
 			newValues removeKey: key ifAbsent: nil.
-			iterator := self newIterator.
 			v := self basicAt: key ifAbsent: [^ aBlock value].
 			removedValues 
 				at: key 
 				put: v asSoilObjectId.
-			iterator removeKey: key ]
+			self newIterator removeKey: key ]
 		ifNil: [ 
 			removedValues 
 				at: key

--- a/src/Soil-Core/SoilNewClusterVersion.class.st
+++ b/src/Soil-Core/SoilNewClusterVersion.class.st
@@ -112,8 +112,9 @@ SoilNewClusterVersion >> initialize [
 SoilNewClusterVersion >> initializeObjectIdsIn: aSOTransaction [ 
 	"assign indexes to all not yet initialized object records"
 	objectId ifNotNil: [ objectId isInitialized ifFalse: [ aSOTransaction initializeObjectId: objectId ] ].
-	((references, (behaviorDescriptions collect: #objectId)) reject: #isInitialized) do: [ :oid |
-		aSOTransaction initializeObjectId: oid ]
+	(references, (behaviorDescriptions collect: #objectId)) 
+		reject: #isInitialized 
+		thenDo: [ :oid | aSOTransaction initializeObjectId: oid].
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilObjectId.class.st
+++ b/src/Soil-Core/SoilObjectId.class.st
@@ -44,7 +44,7 @@ SoilObjectId class >> segment: segmentId index: index [
 
 { #category : #comparing }
 SoilObjectId >> = anObjectId [ 
-	(anObjectId class = self class) ifFalse: [ ^ false ].
+	(anObjectId class == self class) ifFalse: [ ^ false ].
 	"object ids are generated with zero as index because the allocation of the 
 	real index needs to be done on commit time"
 	(index = 0) ifTrue: [ ^ self == anObjectId ].

--- a/src/Soil-Serializer-Tests/SoilObjectTableTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilObjectTableTest.class.st
@@ -1,13 +1,14 @@
 Class {
-	#name : #SoilObjectTableTest,
-	#superclass : #TestCase,
+	#name : 'SoilObjectTableTest',
+	#superclass : 'TestCase',
 	#pools : [
 		'SoilTypeCodes'
 	],
-	#category : #'Soil-Serializer-Tests'
+	#category : 'Soil-Serializer-Tests',
+	#package : 'Soil-Serializer-Tests'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilObjectTableTest >> testAdd [
 	| table |
 	table := SoilObjectTable new.
@@ -18,7 +19,7 @@ SoilObjectTableTest >> testAdd [
 	self assert: table size equals: 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilObjectTableTest >> testIdenityIndexOf [
 	| table |
 	table := SoilObjectTable new.

--- a/src/Soil-Serializer-Tests/SoilPrimitiveSerializationTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilPrimitiveSerializationTest.class.st
@@ -1,18 +1,19 @@
 Class {
-	#name : #SoilPrimitiveSerializationTest,
-	#superclass : #TestCase,
+	#name : 'SoilPrimitiveSerializationTest',
+	#superclass : 'TestCase',
 	#pools : [
 		'SoilTypeCodes'
 	],
-	#category : #'Soil-Serializer-Tests'
+	#category : 'Soil-Serializer-Tests',
+	#package : 'Soil-Serializer-Tests'
 }
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SoilPrimitiveSerializationTest >> newSerializer [ 
 	^ Soil inMemory newSerializer
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SoilPrimitiveSerializationTest >> restoreLocalTimeZoneAfter: aBlock [
 
 	| realTimeZone |
@@ -20,13 +21,13 @@ SoilPrimitiveSerializationTest >> restoreLocalTimeZoneAfter: aBlock [
 	aBlock ensure: [ DateAndTime localTimeZone: realTimeZone ].
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SoilPrimitiveSerializationTest >> setUp [
 	super setUp.
 	SoilTypeCodes initialize
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationArray [
 	| object serialized materialized |
 	object := #(1 2 3 5).
@@ -38,7 +39,7 @@ SoilPrimitiveSerializationTest >> testSerializationArray [
 	self assert: materialized equals: object
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationAssociation [
 	| object serialized materialized |
 	object := 1 -> 2.
@@ -50,7 +51,7 @@ SoilPrimitiveSerializationTest >> testSerializationAssociation [
 	self assert: materialized equals: object
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationBlockClosure [
 	| object serialized  |
 	object := [].
@@ -58,7 +59,7 @@ SoilPrimitiveSerializationTest >> testSerializationBlockClosure [
 	self should: [serialized := SoilSerializer serializeToBytes: object] raise: TestResult error
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationBoxedFloat64 [
 	| float serialized materialized |
 	float := 2.45227231256843e-45.
@@ -74,7 +75,7 @@ SoilPrimitiveSerializationTest >> testSerializationBoxedFloat64 [
 	self assert: materialized equals: 2.45227231256843e-45
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationBoxedFloat64Infinity [
 	| float serialized materialized |
 	float := Float infinity.
@@ -102,7 +103,7 @@ SoilPrimitiveSerializationTest >> testSerializationBoxedFloat64Infinity [
 	self assert: materialized equals: float
 ]
 
-{ #category : #'tests-twice' }
+{ #category : 'tests-twice' }
 SoilPrimitiveSerializationTest >> testSerializationBoxedFloat64Twice [
 	| float object serialized materialized |
 	
@@ -124,7 +125,7 @@ SoilPrimitiveSerializationTest >> testSerializationBoxedFloat64Twice [
 	self assert: materialized equals: object.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationByteArray [
 	| object serialized materialized |
 	object := #[1 2 3 5].
@@ -136,7 +137,7 @@ SoilPrimitiveSerializationTest >> testSerializationByteArray [
 	self assert: materialized equals: object
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationByteCharacter [
 	| object serialized materialized |
 	object := $a.
@@ -148,7 +149,7 @@ SoilPrimitiveSerializationTest >> testSerializationByteCharacter [
 	self assert: materialized equals: object.
 ]
 
-{ #category : #'tests-twice' }
+{ #category : 'tests-twice' }
 SoilPrimitiveSerializationTest >> testSerializationByteCharacterTwice [
 	| object character serialized materialized |
 	character := $a.
@@ -168,7 +169,7 @@ SoilPrimitiveSerializationTest >> testSerializationByteCharacterTwice [
 	self assert: materialized equals: object.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationCharacter [
 	| object serialized materialized |
 	object := 16rF600 asCharacter.
@@ -180,7 +181,7 @@ SoilPrimitiveSerializationTest >> testSerializationCharacter [
 	self assert: materialized equals: object.
 ]
 
-{ #category : #'tests-twice' }
+{ #category : 'tests-twice' }
 SoilPrimitiveSerializationTest >> testSerializationCharacterTwice [
 	| object character serialized materialized |
 
@@ -194,7 +195,7 @@ SoilPrimitiveSerializationTest >> testSerializationCharacterTwice [
 
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationClass [
 	| object serialized materialized |
 	object := Point.
@@ -205,7 +206,7 @@ SoilPrimitiveSerializationTest >> testSerializationClass [
 	self assert: materialized  equals: Point.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationDate [
 	| object serialized materialized |
 	object := Date fromDays: 10.
@@ -217,7 +218,7 @@ SoilPrimitiveSerializationTest >> testSerializationDate [
 	self assert: materialized equals: object
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationDateNegative [
 	| object serialized materialized |
 	object := (DateAndTime year: 1900 month: 1 day: 1 hour: 0 minute: 0 second: 0 offset: 0 hours) asDate.
@@ -229,7 +230,7 @@ SoilPrimitiveSerializationTest >> testSerializationDateNegative [
 	self assert: materialized equals: object
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationDateWithLocalTimeZone [
 	| utc est bst object utc14plus utc545plus utc12minus utc330minus serialized materialized |
 	utc := TimeZone abbreviated: 'UTC'.
@@ -259,7 +260,7 @@ SoilPrimitiveSerializationTest >> testSerializationDateWithLocalTimeZone [
 			self assert: materialized equals: object ] ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationDateWithNegativeOffset [
 	| object serialized materialized |
 	object := (Date fromDays: 10) offset: -5 hours.
@@ -271,7 +272,7 @@ SoilPrimitiveSerializationTest >> testSerializationDateWithNegativeOffset [
 	self assert: (materialized equals: object)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationDictionary [
 	| object serialized materialized |
 	object := { 1->2 . 3->4 } asDictionary.
@@ -283,13 +284,13 @@ SoilPrimitiveSerializationTest >> testSerializationDictionary [
 	self assert: materialized equals: object
 ]
 
-{ #category : #'tests-layouts' }
+{ #category : 'tests-layouts' }
 SoilPrimitiveSerializationTest >> testSerializationEphemeronLayout [
 	"Emphemeron classes are not yet used (no example in Pharo11), thus we do not support them yet"
 	self flag: #TODO
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationFalse [
 	| object serialized materialized |
 	"Check false"
@@ -301,7 +302,7 @@ SoilPrimitiveSerializationTest >> testSerializationFalse [
 	self deny: materialized
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationFraction [
 	| object serialized materialized |
 	object := 1/2.
@@ -314,7 +315,7 @@ SoilPrimitiveSerializationTest >> testSerializationFraction [
 	self assert: materialized equals: object
 ]
 
-{ #category : #'tests-twice' }
+{ #category : 'tests-twice' }
 SoilPrimitiveSerializationTest >> testSerializationFractionTwice [
 	| fraction object serialized materialized |
 	fraction := 1/2.
@@ -335,7 +336,7 @@ SoilPrimitiveSerializationTest >> testSerializationFractionTwice [
 	self assert: materialized equals: object
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationIdentityDictionary [
 	| object serialized materialized |
 	object := IdentityDictionary newFrom: { #test->2 . #now->4 }.
@@ -356,7 +357,7 @@ SoilPrimitiveSerializationTest >> testSerializationIdentityDictionary [
 	self assert: materialized equals: object
 ]
 
-{ #category : #'tests-layouts' }
+{ #category : 'tests-layouts' }
 SoilPrimitiveSerializationTest >> testSerializationImmediateLayout [
 	| object serialized materialized |
 	"All Immediate classes are specially encoded, to have a test for every layout, use Character here"
@@ -371,7 +372,7 @@ SoilPrimitiveSerializationTest >> testSerializationImmediateLayout [
 	self assert: materialized class classLayout class equals: ImmediateLayout.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationLargeInteger [
 	| object serialized materialized |
 	
@@ -413,7 +414,7 @@ SoilPrimitiveSerializationTest >> testSerializationLargeInteger [
 	self assert: materialized equals: object
 ]
 
-{ #category : #'tests-twice' }
+{ #category : 'tests-twice' }
 SoilPrimitiveSerializationTest >> testSerializationLargeIntegerTwice [
 
 	| object integer serialized materialized |
@@ -456,7 +457,7 @@ SoilPrimitiveSerializationTest >> testSerializationLargeIntegerTwice [
 	
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationODBPersistentDictionary [
 	| object serialized materialized |
 	self flag: #todo. 
@@ -472,7 +473,7 @@ SoilPrimitiveSerializationTest >> testSerializationODBPersistentDictionary [
 	self assert: materialized equals: object"
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationOrderedCollection [
 	| object serialized materialized |
 	object := #(1 2 3 5) asOrderedCollection.
@@ -484,7 +485,7 @@ SoilPrimitiveSerializationTest >> testSerializationOrderedCollection [
 	self assert: materialized equals: object
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationProcess [
 	| object serialized |
 	object := Processor activeProcess.
@@ -492,7 +493,7 @@ SoilPrimitiveSerializationTest >> testSerializationProcess [
 	self should: [serialized := SoilSerializer serializeToBytes: object] raise: TestResult error
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationProcessSchedulerCode [
 	| object serialized materialized |
 	object := Processor.
@@ -504,7 +505,7 @@ SoilPrimitiveSerializationTest >> testSerializationProcessSchedulerCode [
 	self assert: materialized equals: Processor
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationScaledDecimal [
 	"ScaledDecimal is a subclass of Fraction, make sure it works"
 
@@ -519,7 +520,7 @@ SoilPrimitiveSerializationTest >> testSerializationScaledDecimal [
 	self assert: materialized equals: object
 ]
 
-{ #category : #'tests-twice' }
+{ #category : 'tests-twice' }
 SoilPrimitiveSerializationTest >> testSerializationScaledDecimalTwice [
 	| scaledDecimal object serialized materialized |
 	
@@ -537,7 +538,7 @@ SoilPrimitiveSerializationTest >> testSerializationScaledDecimalTwice [
 	self assert: materialized equals: object.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationSmallFloat64 [
 	| float serialized materialized |
 	float := 1.11.
@@ -550,7 +551,7 @@ SoilPrimitiveSerializationTest >> testSerializationSmallFloat64 [
 	self assert: materialized identicalTo: float
 ]
 
-{ #category : #'tests-twice' }
+{ #category : 'tests-twice' }
 SoilPrimitiveSerializationTest >> testSerializationSmallFloat64Twice [
 	| object serialized materialized |
 	
@@ -571,7 +572,7 @@ SoilPrimitiveSerializationTest >> testSerializationSmallFloat64Twice [
 	self assert: materialized second identicalTo: object second.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationSmallFloat64ZeroAndOne [
 	| float serialized materialized |
 	
@@ -606,7 +607,7 @@ SoilPrimitiveSerializationTest >> testSerializationSmallFloat64ZeroAndOne [
 	self assert: materialized identicalTo: Float negativeZero.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationString [ 
 	| string serialized materialized |
 	
@@ -641,7 +642,7 @@ SoilPrimitiveSerializationTest >> testSerializationString [
 	self assert: materialized equals: string
 ]
 
-{ #category : #'tests-twice' }
+{ #category : 'tests-twice' }
 SoilPrimitiveSerializationTest >> testSerializationStringTwice [
 	
 	| object serialized materialized |
@@ -694,7 +695,7 @@ SoilPrimitiveSerializationTest >> testSerializationStringTwice [
 	self assert: materialized equals: object.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationSymbol [
 	| object serialized materialized |
 	object := #someSelector.
@@ -706,7 +707,7 @@ SoilPrimitiveSerializationTest >> testSerializationSymbol [
 	self assert: materialized equals: #someSelector
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationSystemDictionary [
 	| object serialized materialized |
 	object := Smalltalk globals.
@@ -719,7 +720,7 @@ SoilPrimitiveSerializationTest >> testSerializationSystemDictionary [
 	self assertCollection: materialized hasSameElements: Smalltalk globals
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationTime [
 	| object serialized materialized |
 	object := Time midnight.
@@ -731,7 +732,7 @@ SoilPrimitiveSerializationTest >> testSerializationTime [
 	self assert: materialized equals: object
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationTrue [
 	| object serialized materialized |
 	object := true.
@@ -743,7 +744,7 @@ SoilPrimitiveSerializationTest >> testSerializationTrue [
 	self assert: materialized.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationUndefindedObject [
 	| object serialized materialized |
 	object := nil.
@@ -755,7 +756,7 @@ SoilPrimitiveSerializationTest >> testSerializationUndefindedObject [
 	self assert: materialized equals: nil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationWideStringUTF16 [
 
 	| string serialized materialized |
@@ -773,9 +774,12 @@ SoilPrimitiveSerializationTest >> testSerializationWideStringUTF16 [
 
 	materialized := SoilMaterializer materializeFromBytes: serialized.
 	self assert: materialized equals: string.
+	
+	"set the encoding back to the default"
+	Soil characterEncoding: #utf8
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationWideStringUTF32 [
 
 	| string serialized materialized |
@@ -793,9 +797,12 @@ SoilPrimitiveSerializationTest >> testSerializationWideStringUTF32 [
 	
 	materialized := SoilMaterializer materializeFromBytes: serialized.
 	self assert: materialized equals: string.
+	
+	"set the encoding back to the default"
+	Soil characterEncoding: #utf8
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationWideStringUTF8 [
 	| string serialized materialized |
 	string := String
@@ -814,7 +821,7 @@ SoilPrimitiveSerializationTest >> testSerializationWideStringUTF8 [
 	self assert: materialized equals: string.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilPrimitiveSerializationTest >> testSerializationWideSymbol [
 	| symbol serialized materialized |
 	symbol := String
@@ -833,7 +840,7 @@ SoilPrimitiveSerializationTest >> testSerializationWideSymbol [
 	self assert: materialized equals: symbol
 ]
 
-{ #category : #helpers }
+{ #category : 'helpers' }
 SoilPrimitiveSerializationTest >> useTimeZoneInstance: aTimeZone during: aBlock [
 
   self restoreLocalTimeZoneAfter: [ 

--- a/src/Soil-Serializer-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilSerializationTest.class.st
@@ -1,6 +1,6 @@
 Class {
-	#name : #SoilSerializationTest,
-	#superclass : #TestCase,
+	#name : 'SoilSerializationTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'soil',
 		'transaction'
@@ -8,27 +8,28 @@ Class {
 	#pools : [
 		'SoilTypeCodes'
 	],
-	#category : #'Soil-Serializer-Tests'
+	#category : 'Soil-Serializer-Tests',
+	#package : 'Soil-Serializer-Tests'
 }
 
-{ #category : #'tests-layouts' }
+{ #category : 'tests-layouts' }
 SoilSerializationTest >> materializeFromBytes: aByteArray [
 	^ (transaction newPersistentClusterVersion 
 		readFrom: aByteArray readStream)
 		materializeObject 
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SoilSerializationTest >> newMaterializer [
 	^ transaction newMaterializer
 ]
 
-{ #category : #'instance creation' }
+{ #category : 'instance creation' }
 SoilSerializationTest >> newSerializer [ 
 	^ transaction newSerializer
 ]
 
-{ #category : #'tests-layouts' }
+{ #category : 'tests-layouts' }
 SoilSerializationTest >> serializeToBytes: object [
 	| bytes record |
 	record := transaction newClusterVersion
@@ -44,7 +45,7 @@ SoilSerializationTest >> serializeToBytes: object [
 	^ bytes
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 SoilSerializationTest >> setUp [
 	super setUp.
 	SoilTypeCodes initialize.
@@ -52,7 +53,7 @@ SoilSerializationTest >> setUp [
 	transaction := soil newTransaction
 ]
 
-{ #category : #'test-blocks' }
+{ #category : 'test-blocks' }
 SoilSerializationTest >> testSerializationCleanBlockClosure [
 	<compilerOptions: #(+ optionCleanBlockClosure)>
 	| object serialized  materialized |
@@ -65,7 +66,7 @@ SoilSerializationTest >> testSerializationCleanBlockClosure [
 	self assert: materialized value equals: 3
 ]
 
-{ #category : #'tests-layouts' }
+{ #category : 'tests-layouts' }
 SoilSerializationTest >> testSerializationCompiledMethodLayout [
 
 	| object serialized materialized |
@@ -86,7 +87,7 @@ SoilSerializationTest >> testSerializationCompiledMethodLayout [
 		equals: CompiledMethodLayout
 ]
 
-{ #category : #'tests-layouts' }
+{ #category : 'tests-layouts' }
 SoilSerializationTest >> testSerializationCompiledMethodLayoutCompiledBlock [
 	| object serialized materialized |
  	"This tests CompiledBlock. we use a clean block for now"
@@ -103,7 +104,7 @@ SoilSerializationTest >> testSerializationCompiledMethodLayoutCompiledBlock [
  	self assert: materialized class classLayout class equals: CompiledMethodLayout
 ]
 
-{ #category : #'test-blocks' }
+{ #category : 'test-blocks' }
 SoilSerializationTest >> testSerializationConstantBlockClosure [
 	| object serialized  materialized |
 	object := [1].
@@ -117,7 +118,7 @@ SoilSerializationTest >> testSerializationConstantBlockClosure [
 	self assert: materialized outerCode isNil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilSerializationTest >> testSerializationObject [
 	| object serialized materialized |
 	object := Object new.
@@ -129,7 +130,7 @@ SoilSerializationTest >> testSerializationObject [
 	self assert: materialized class equals: Object
 ]
 
-{ #category : #'tests-twice' }
+{ #category : 'tests-twice' }
 SoilSerializationTest >> testSerializationObjectEqualTwice [
 	| object array serialized materialized |
 
@@ -153,7 +154,7 @@ SoilSerializationTest >> testSerializationObjectEqualTwice [
 	self deny: materialized first identicalTo: materialized second
 ]
 
-{ #category : #'tests-twice' }
+{ #category : 'tests-twice' }
 SoilSerializationTest >> testSerializationObjectTwice [
 	| object array serialized materialized |
 	
@@ -176,7 +177,7 @@ SoilSerializationTest >> testSerializationObjectTwice [
 	self assert: materialized first identicalTo: materialized second.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilSerializationTest >> testSerializationObjectWithTransient [
 	| object serialized materialized |
 	object := SoilTestClassWithTransient new.
@@ -188,7 +189,7 @@ SoilSerializationTest >> testSerializationObjectWithTransient [
 	self assert: materialized three equals: 3
 ]
 
-{ #category : #'tests-hashed' }
+{ #category : 'tests-hashed' }
 SoilSerializationTest >> testSerializationSet [
 	"Set uses the hash to find elements, this might be identity, which changes"
 
@@ -205,7 +206,7 @@ SoilSerializationTest >> testSerializationSet [
 	self assert: (materialized includes:  materialized anyOne)
 ]
 
-{ #category : #'tests-encoded-subclasses' }
+{ #category : 'tests-encoded-subclasses' }
 SoilSerializationTest >> testSerializationSortedCollection [
 	"SortedCollection is a subclass of OrderedCollection, make sure it works"
 
@@ -220,7 +221,7 @@ SoilSerializationTest >> testSerializationSortedCollection [
 	self assert: materialized equals: object
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilSerializationTest >> testSerializationSortedCollectionWithSortBlock [
 	"SortedCollection ixs a subclass of OrderedCollection, make sure it works"
 	<compilerOptions: #(+ optionCleanBlockClosure)>
@@ -238,7 +239,7 @@ SoilSerializationTest >> testSerializationSortedCollectionWithSortBlock [
 	self assert: materialized sortBlock compiledBlock bytecodes equals: object sortBlock compiledBlock bytecodes.	
 ]
 
-{ #category : #'tests-encoded-subclasses' }
+{ #category : 'tests-encoded-subclasses' }
 SoilSerializationTest >> testSerializationTTLAssociation [
 	"TTLAssociation is a subclass of Association, make sure it works"
 
@@ -255,7 +256,7 @@ SoilSerializationTest >> testSerializationTTLAssociation [
 
 ]
 
-{ #category : #'tests-encoded-subclasses' }
+{ #category : 'tests-encoded-subclasses' }
 SoilSerializationTest >> testSerializationUUID [
 	"UUID is a subclass of ByteArray, make sure it works"
 
@@ -274,7 +275,7 @@ SoilSerializationTest >> testSerializationUUID [
 	self assert: materialized equals: object
 ]
 
-{ #category : #'tests-layouts' }
+{ #category : 'tests-layouts' }
 SoilSerializationTest >> testSerializationVariableLayout [
 	| object serialized materialized |
 	"All Immediate classes are specially encoded, to have a test for every layout"
@@ -289,7 +290,7 @@ SoilSerializationTest >> testSerializationVariableLayout [
 	self assert: materialized class classLayout class equals: VariableLayout.
 ]
 
-{ #category : #'tests-encoded-subclasses' }
+{ #category : 'tests-encoded-subclasses' }
 SoilSerializationTest >> testSerializationWeakArray [
 	"WeakArray is a subclass of Array, make sure it works"
 
@@ -304,7 +305,7 @@ SoilSerializationTest >> testSerializationWeakArray [
 	self assert: materialized equals: object
 ]
 
-{ #category : #'tests-layouts' }
+{ #category : 'tests-layouts' }
 SoilSerializationTest >> testSerializationWeakLayout [
 	| object serialized materialized |
 	"We use WeakArray as an exampe of a class with a WeakLayout"
@@ -319,7 +320,7 @@ SoilSerializationTest >> testSerializationWeakLayout [
 	self assert: materialized class classLayout class equals: WeakLayout.
 ]
 
-{ #category : #'tests-layouts' }
+{ #category : 'tests-layouts' }
 SoilSerializationTest >> testSerializationWordLayout [
 	| object serialized materialized |
 	"We use IntegerArray as an exampe of a class with a WordLayout but not specially encoded"

--- a/src/Soil-Serializer-Tests/SoilStandaloneSerializationTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilStandaloneSerializationTest.class.st
@@ -1,23 +1,24 @@
 Class {
-	#name : #SoilStandaloneSerializationTest,
-	#superclass : #TestCase,
+	#name : 'SoilStandaloneSerializationTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'soil'
 	],
 	#pools : [
 		'SoilTypeCodes'
 	],
-	#category : #'Soil-Serializer-Tests'
+	#category : 'Soil-Serializer-Tests',
+	#package : 'Soil-Serializer-Tests'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 SoilStandaloneSerializationTest >> setUp [
 	super setUp.
 	SoilTypeCodes initialize.
 
 ]
 
-{ #category : #'tests-layouts' }
+{ #category : 'tests-layouts' }
 SoilStandaloneSerializationTest >> testSerializationByteLayout [
 	| object serialized materialized |
 	"We use SocketAddress as an exampe of a class with a ByteLayout but not specially encoded"
@@ -32,7 +33,7 @@ SoilStandaloneSerializationTest >> testSerializationByteLayout [
 	self assert: materialized class classLayout class equals: ByteLayout.
 ]
 
-{ #category : #'test-blocks' }
+{ #category : 'test-blocks' }
 SoilStandaloneSerializationTest >> testSerializationCleanBlockClosure [
 	<compilerOptions: #(+ optionCleanBlockClosure)>
 	| object serialized  materialized |
@@ -45,7 +46,7 @@ SoilStandaloneSerializationTest >> testSerializationCleanBlockClosure [
 	self assert: materialized value equals: 3
 ]
 
-{ #category : #'tests-layouts' }
+{ #category : 'tests-layouts' }
 SoilStandaloneSerializationTest >> testSerializationCompiledMethodLayout [
 
 	| object serialized materialized |
@@ -66,7 +67,7 @@ SoilStandaloneSerializationTest >> testSerializationCompiledMethodLayout [
 		equals: CompiledMethodLayout
 ]
 
-{ #category : #'tests-layouts' }
+{ #category : 'tests-layouts' }
 SoilStandaloneSerializationTest >> testSerializationCompiledMethodLayoutCompiledBlock [
 	| object serialized materialized |
  	"This tests CompiledBlock. we use a clean block for now"
@@ -83,7 +84,7 @@ SoilStandaloneSerializationTest >> testSerializationCompiledMethodLayoutCompiled
  	self assert: materialized class classLayout class equals: CompiledMethodLayout
 ]
 
-{ #category : #'test-blocks' }
+{ #category : 'test-blocks' }
 SoilStandaloneSerializationTest >> testSerializationConstantBlockClosure [
 	| object serialized  materialized |
 	object := [1].
@@ -97,7 +98,7 @@ SoilStandaloneSerializationTest >> testSerializationConstantBlockClosure [
 	self assert: materialized outerCode isNil
 ]
 
-{ #category : #'tests-layouts' }
+{ #category : 'tests-layouts' }
 SoilStandaloneSerializationTest >> testSerializationDoubleByteLayout [
 	| object serialized materialized |
 	"We use DoubleByteArray as an exampe of a class with a DoubleByteLayout but not specially encoded"
@@ -112,7 +113,7 @@ SoilStandaloneSerializationTest >> testSerializationDoubleByteLayout [
 	self assert: materialized class classLayout class equals: DoubleByteLayout.
 ]
 
-{ #category : #'tests-layouts' }
+{ #category : 'tests-layouts' }
 SoilStandaloneSerializationTest >> testSerializationDoubleWordLayout [
 	| object serialized materialized |
 	"We use DoubleWordArray as an exampe of a class with a DoubleWordLayout but not specially encoded"
@@ -127,7 +128,7 @@ SoilStandaloneSerializationTest >> testSerializationDoubleWordLayout [
 	self assert: materialized class classLayout class equals: DoubleWordLayout.
 ]
 
-{ #category : #'tests-layouts' }
+{ #category : 'tests-layouts' }
 SoilStandaloneSerializationTest >> testSerializationFixedLayout [
 	| object serialized materialized |
 	"We use Point as an exampe of a class with a FixedLayout but not specially encoded"
@@ -142,7 +143,7 @@ SoilStandaloneSerializationTest >> testSerializationFixedLayout [
 	self assert: materialized class classLayout class equals: FixedLayout.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilStandaloneSerializationTest >> testSerializationObject [
 	| object serialized materialized |
 	object := Object new.
@@ -154,7 +155,7 @@ SoilStandaloneSerializationTest >> testSerializationObject [
 	self assert: materialized class equals: Object
 ]
 
-{ #category : #'tests-twice' }
+{ #category : 'tests-twice' }
 SoilStandaloneSerializationTest >> testSerializationObjectEqualTwice [
 	| object array serialized materialized |
 
@@ -178,7 +179,7 @@ SoilStandaloneSerializationTest >> testSerializationObjectEqualTwice [
 	self deny: materialized first identicalTo: materialized second
 ]
 
-{ #category : #'tests-twice' }
+{ #category : 'tests-twice' }
 SoilStandaloneSerializationTest >> testSerializationObjectTwice [
 	| object array serialized materialized |
 	
@@ -201,7 +202,7 @@ SoilStandaloneSerializationTest >> testSerializationObjectTwice [
 	self assert: materialized first identicalTo: materialized second.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilStandaloneSerializationTest >> testSerializationObjectWithTransient [
 	| object serialized materialized |
 	object := SoilTestClassWithTransient new.
@@ -213,7 +214,7 @@ SoilStandaloneSerializationTest >> testSerializationObjectWithTransient [
 	self assert: materialized three equals: 3
 ]
 
-{ #category : #'tests-hashed' }
+{ #category : 'tests-hashed' }
 SoilStandaloneSerializationTest >> testSerializationSet [
 	"Set uses the hash to find elements, this might be identity, which changes"
 
@@ -230,7 +231,7 @@ SoilStandaloneSerializationTest >> testSerializationSet [
 	self assert: (materialized includes:  materialized anyOne)
 ]
 
-{ #category : #'tests-encoded-subclasses' }
+{ #category : 'tests-encoded-subclasses' }
 SoilStandaloneSerializationTest >> testSerializationSortedCollection [
 	"SortedCollection is a subclass of OrderedCollection, make sure it works"
 
@@ -245,7 +246,7 @@ SoilStandaloneSerializationTest >> testSerializationSortedCollection [
 	self assert: materialized equals: object
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 SoilStandaloneSerializationTest >> testSerializationSortedCollectionWithSortBlock [
 	"SortedCollection ixs a subclass of OrderedCollection, make sure it works"
 	<compilerOptions: #(+ optionCleanBlockClosure)>
@@ -263,7 +264,7 @@ SoilStandaloneSerializationTest >> testSerializationSortedCollectionWithSortBloc
 	self assert: materialized sortBlock compiledBlock bytecodes equals: object sortBlock compiledBlock bytecodes.	
 ]
 
-{ #category : #'tests-encoded-subclasses' }
+{ #category : 'tests-encoded-subclasses' }
 SoilStandaloneSerializationTest >> testSerializationTTLAssociation [
 	"TTLAssociation is a subclass of Association, make sure it works"
 
@@ -280,7 +281,7 @@ SoilStandaloneSerializationTest >> testSerializationTTLAssociation [
 
 ]
 
-{ #category : #'tests-encoded-subclasses' }
+{ #category : 'tests-encoded-subclasses' }
 SoilStandaloneSerializationTest >> testSerializationUUID [
 	"UUID is a subclass of ByteArray, make sure it works"
 
@@ -299,7 +300,7 @@ SoilStandaloneSerializationTest >> testSerializationUUID [
 	self assert: materialized equals: object
 ]
 
-{ #category : #'tests-layouts' }
+{ #category : 'tests-layouts' }
 SoilStandaloneSerializationTest >> testSerializationVariableLayout [
 	| object serialized materialized |
 	"All Immediate classes are specially encoded, to have a test for every layout"
@@ -314,7 +315,7 @@ SoilStandaloneSerializationTest >> testSerializationVariableLayout [
 	self assert: materialized class classLayout class equals: VariableLayout.
 ]
 
-{ #category : #'tests-encoded-subclasses' }
+{ #category : 'tests-encoded-subclasses' }
 SoilStandaloneSerializationTest >> testSerializationWeakArray [
 	"WeakArray is a subclass of Array, make sure it works"
 
@@ -329,7 +330,7 @@ SoilStandaloneSerializationTest >> testSerializationWeakArray [
 	self assert: materialized equals: object
 ]
 
-{ #category : #'tests-layouts' }
+{ #category : 'tests-layouts' }
 SoilStandaloneSerializationTest >> testSerializationWeakLayout [
 	| object serialized materialized |
 	"We use WeakArray as an exampe of a class with a WeakLayout"
@@ -344,7 +345,7 @@ SoilStandaloneSerializationTest >> testSerializationWeakLayout [
 	self assert: materialized class classLayout class equals: WeakLayout.
 ]
 
-{ #category : #'tests-layouts' }
+{ #category : 'tests-layouts' }
 SoilStandaloneSerializationTest >> testSerializationWordLayout [
 	| object serialized materialized |
 	"We use IntegerArray as an exampe of a class with a WordLayout but not specially encoded"

--- a/src/Soil-Serializer-Tests/package.st
+++ b/src/Soil-Serializer-Tests/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Soil-Serializer-Tests' }
+Package { #name : 'Soil-Serializer-Tests' }


### PR DESCRIPTION
- add comments
- use #== to compare classes in SoilObjectId>>#= (saves one message send)
- simplify SoilIndexedDictionary #removeKey:ifAbsent: