### PR TITLE
523-Index-Iterator-firstAssociation--need-to-restore-values 

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -357,6 +357,26 @@ SoilIndexedDictionaryTest >> testFirstAssociationWithTransaction [
 ]
 
 { #category : #tests }
+SoilIndexedDictionaryTest >> testFirstAssociationWithTransactionRemoved [
+	| tx tx1 tx2 |
+	tx := soil newTransaction.
+	tx root: dict.
+	dict at: 1 put: #one.
+	dict at: 2 put: #two.
+	"self assert: dict last equals: #two."
+	tx commit.
+	
+	"open a two transactions ..."
+	tx1 := soil newTransaction.
+	tx2 := soil newTransaction.
+	tx2 root removeKey: 1.
+	tx2 commit.
+	"in tx1 the removed one is not removed"
+	self assert: tx1 root firstAssociation equals: 1->#one.
+
+]
+
+{ #category : #tests }
 SoilIndexedDictionaryTest >> testFirstWithSingleRemovedItem [ 
 	
 	dict at: #foo put: #bar.

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -167,12 +167,7 @@ SoilIndexIterator >> first: anInteger [
 SoilIndexIterator >> firstAssociation [ 
 	| item |
 	currentPage := index store headerPage.
-	item := currentPage firstItem.
-	"if we get back a key that has been marked removed 
-	we iterate until we find one that hasn't been 
-	removed"
-	[ item notNil and: [ item value isRemoved ] ] whileTrue: [ 
-		item := self nextAssociation ].
+	item := self nextAssociation.
 	currentKey := item 
 		ifNotNil: [ item key ].
 	^ item


### PR DESCRIPTION
This PR
- adds testFirstAssociationWithTransactionRemoved which tests restoring if removed values for #firstAssociation
- implement #firstAssociation in terms of #nextAssociation without the need to check #isRemoved here

fixes #523