### PR TITLE
  571-SoilIndexedDictionarynextAfter-should-forward-to-iterator 

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -570,7 +570,7 @@ SoilIndexedDictionaryTest >> testNextAfter [
 	dict at: 1 put: #bar.
 	dict at: 2 put: #bar2.
 
-	self assert:( dict nextAfter: 1) equals: #bar2
+	self assert:( dict nextAfter: 1) equals: 2->#bar2
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -285,6 +285,13 @@ SoilIndexIterator >> nextAssociation [
 ]
 
 { #category : #accessing }
+SoilIndexIterator >> nextAssociationAfter: key [
+
+	self find: key.
+	^ self nextAssociation
+]
+
+{ #category : #accessing }
 SoilIndexIterator >> pageAt: anInteger [
 	^ index store pageAt: anInteger
 ]

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -212,16 +212,13 @@ SoilIndexedDictionary >> newValuesSortedByKeyOrder [
 
 { #category : #accessing }
 SoilIndexedDictionary >> nextAfter: key [  
-	| iterator |
+	"Note: returns the association key->value"
 	transaction ifNil: [ 
 		| newValueSorted |
 		newValueSorted := self newValuesSortedByKeyOrder.
-		^ (newValueSorted after: (newValues associationAt: key)) value  ].
+		^ (newValueSorted after: (newValues associationAt: key))].
 
-	iterator := self newIterator 
-		find: key asInteger;
-		yourself.
-	^ iterator nextAssociation 
+	^ (self newIterator nextAssociationAfter: key)
 		ifNotNil: [ :assoc |
 			assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ]
 ]


### PR DESCRIPTION
- fix testNextAfter, we should return the association for both the case with and without a transaction

- add #nextAssociationAfter:  to SoilIndexIterator

I added a comment to #nextAfter: that it returns the association. Maybe it should be renamed to be nextAssociationAfter:

fixes #571