### PR TITLE
Add test and fix #nextKeyCloseTo:

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -589,6 +589,21 @@ SoilIndexedDictionaryTest >> testNextAfterWithTransaction [
 ]
 
 { #category : #tests }
+SoilIndexedDictionaryTest >> testNextKeyCloseToWithTransaction [
+	| tx tx2 |
+	tx := soil newTransaction.
+	tx root: dict.
+	dict at: 10 put: #one.
+	dict at: 20 put: #two.
+	"self assert: dict last equals: #two."
+	tx commit.
+	"open a second transaction ..."
+	tx2 := soil newTransaction.
+	"and test last"
+	self assert: (tx2 root nextKeyCloseTo: 15) value equals: 20
+]
+
+{ #category : #tests }
 SoilIndexedDictionaryTest >> testRemoveKey [
 	dict at: #foo put: #bar.
 	dict at: #foo2 put: #bar2.

--- a/src/Soil-Core/SoilIndexItemsPage.class.st
+++ b/src/Soil-Core/SoilIndexItemsPage.class.st
@@ -140,9 +140,29 @@ SoilIndexItemsPage >> items [
 ]
 
 { #category : #accessing }
+SoilIndexItemsPage >> keyOrClosestAfter: key [ 
+	"find the closest key in this page. This returns the exact key if 
+	present or the key that comes after. Else returns nil. This is useful if we enter the
+	list at an unknown point"
+	items isEmpty ifTrue: [ ^ nil ].
+	self lastKey < key ifTrue: [ ^ nil ].
+	^ items 
+		findBinaryIndex: [ :each | key - each key ] 
+		do: [ :e | (items at: e) key] 
+		ifNone: [ :a :b | 
+			(items at: (b min: items size)) key ]
+]
+
+{ #category : #accessing }
 SoilIndexItemsPage >> lastItem [
 
 	^ items isNotEmpty ifTrue: [ items last ] ifFalse: [ nil ]
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> lastKey [
+
+	^ items isNotEmpty ifTrue: [ items last key ]
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -284,6 +284,21 @@ SoilIndexIterator >> nextAssociation [
 	^ nextValue ifNil: [ self nextAssociation ] ifNotNil: [ key -> nextValue ]
 ]
 
+{ #category : #private }
+SoilIndexIterator >> nextKeyCloseTo: key [
+
+	| binKey |
+	binKey := (key asSkipListKeyOfSize: index keySize) asInteger.
+	self findPageFor: binKey.
+	nextKey := currentPage keyOrClosestAfter: binKey.
+	^ nextKey
+		ifNil: [ "if there is no close key found, we position the cursor at the end, so that asking for the next association will return nil" 
+			currentKey := currentPage lastKey ]
+		ifNotNil: [ 
+			"if there is a close key found, we make sure the cursor get properly positioned"
+			currentKey := nextKey ]
+]
+
 { #category : #accessing }
 SoilIndexIterator >> pageAt: anInteger [
 	^ index store pageAt: anInteger

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -227,6 +227,11 @@ SoilIndexedDictionary >> nextAfter: key [
 ]
 
 { #category : #private }
+SoilIndexedDictionary >> nextKeyCloseTo: aKey [ 
+	^ self newIterator nextKeyCloseTo: aKey
+]
+
+{ #category : #private }
 SoilIndexedDictionary >> prepareNewValues [
 	newValues copy keysAndValuesDo: [ :key :object |
 		object isObjectId ifFalse: [

--- a/src/Soil-Core/SoilSkipListIterator.class.st
+++ b/src/Soil-Core/SoilSkipListIterator.class.st
@@ -80,21 +80,6 @@ SoilSkipListIterator >> levelAt: anInteger [
 	^ levels at: anInteger 
 ]
 
-{ #category : #private }
-SoilSkipListIterator >> nextKeyCloseTo: key [
-
-	| binKey |
-	binKey := (key asSkipListKeyOfSize: index keySize) asInteger.
-	self findPageFor: binKey.
-	nextKey := currentPage keyOrClosestAfter: binKey.
-	nextKey
-		ifNil: [ "if there is no close key found, we position the cursor at the end, so that asking for the next association will return nil" 
-			currentKey := currentPage lastKey ]
-		ifNotNil: [ 
-			"if there is a close key found, we make sure the cursor get properly positioned"
-			currentKey := nextKey ]
-]
-
 { #category : #printing }
 SoilSkipListIterator >> printOn: aStream [ 
 	aStream << 'path: ' << levels asString

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -65,20 +65,6 @@ SoilSkipListPage >> isOlderThan: aVersionNumber [
 ]
 
 { #category : #accessing }
-SoilSkipListPage >> keyOrClosestAfter: key [ 
-	"find the closest key in this page. This returns the exact key if 
-	present or the key that comes after. Else returns nil. This is useful if we enter the
-	list at an unknown point"
-	items isEmpty ifTrue: [ ^ nil ].
-	self lastKey < key ifTrue: [ ^ nil ].
-	^ items 
-		findBinaryIndex: [ :each | key - each key ] 
-		do: [ :e | (items at: e) key] 
-		ifNone: [ :a :b | 
-			(items at: (b min: items size)) key ]
-]
-
-{ #category : #accessing }
 SoilSkipListPage >> keySize [ 
 	^ keySize
 ]
@@ -87,12 +73,6 @@ SoilSkipListPage >> keySize [
 SoilSkipListPage >> keySize: anInteger [ 
 	(anInteger = 0) ifTrue: [ Error signal: 'cannot use key size 0' ].
 	keySize := anInteger.
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> lastKey [
-
-	^ items isNotEmpty ifTrue: [ items last key ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This PR adds a first test for #nextKeyCloseTo: (for now just with a transaction)

- add #testNextKeyCloseToWithTransaction
- fix on the iterator #nextKeyCloseTo: to return a value and move up to be usable for BTree, too
- move some methods up in the page hierachy to make it work for BTree