### PR TITLE
568-Index-Iterator-lastAssociation-need-to-restore-values

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -527,6 +527,26 @@ SoilIndexedDictionaryTest >> testLastAssociationWithTransaction [
 ]
 
 { #category : #tests }
+SoilIndexedDictionaryTest >> testLastAssociationWithTransactionRemoved [
+	| tx tx1 tx2 |
+	tx := soil newTransaction.
+	tx root: dict.
+	dict at: 1 put: #one.
+	dict at: 2 put: #two.
+	"self assert: dict last equals: #two."
+	tx commit.
+	
+	"open a two transactions ..."
+	tx1 := soil newTransaction.
+	tx2 := soil newTransaction.
+	tx2 root removeKey: 2.
+	tx2 commit.
+	"in tx1 the removed one is not removed"
+	self assert: tx1 root lastAssociation equals: 2->#two.
+
+]
+
+{ #category : #tests }
 SoilIndexedDictionaryTest >> testLastWithSingleRemovedItem [ 
 	dict at: #foo put: #bar.
 	dict removeKey: #foo.

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -236,20 +236,12 @@ SoilIndexIterator >> last [
 
 { #category : #accessing }
 SoilIndexIterator >> lastAssociation [
-	| lastPage item |
-	lastPage := self lastPage.
-	item := lastPage lastItem.  "sets currentPage"
-	
-	"if the last value is removed, take the one before"
-	[item notNil and: [ item value isRemoved ]] whileTrue: [  
-		item := lastPage itemBefore: item key].
-	
-	self flag: #TODO.
-	"if we did not find it in the last page, we need to check the page before"
-	item ifNil: [ ^nil ].	
-	currentKey := item key.
-	^ item 
-	
+	| lastAssociation lastValue key |
+	lastAssociation := self priorAssociation ifNil: [ ^nil ].
+	lastValue := (self
+ 			restoreValue: lastAssociation value
+ 			forKey: (key := lastAssociation key)).
+	^ lastValue ifNil: [ self priorAssociation ] ifNotNil: [ key -> lastValue ]
 ]
 
 { #category : #accessing }
@@ -287,6 +279,30 @@ SoilIndexIterator >> nextAssociation [
 { #category : #accessing }
 SoilIndexIterator >> pageAt: anInteger [
 	^ index store pageAt: anInteger
+]
+
+{ #category : #private }
+SoilIndexIterator >> priorAssociation [
+	| item |
+	"Find the association before, if currentPage is not set we return the last association"
+	currentPage ifNil: [ 
+		currentPage := index lastPage.
+		currentKey := nil ].
+	[ currentPage isNil ] whileFalse: [  
+		item := currentKey 
+			ifNotNil: [  
+				(currentPage itemBefore: currentKey)
+					ifNotNil: [ :i | 
+						currentKey := i key. 
+						^ i ]
+					ifNil: [ 
+						(currentPage next = 0) ifTrue: [ ^ nil ].
+						currentPage := index store pageAt: currentPage priorPage.
+						currentKey := nil ] ]
+			ifNil: [
+				currentPage isEmpty ifTrue: [ ^ nil ].
+				^ currentPage lastItem ifNotNil: [ :item2 | currentKey := item2 key. item2 ] ] ].
+	Error signal: 'shouldnt happen'
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilPagedIndexStore.class.st
+++ b/src/Soil-Core/SoilPagedIndexStore.class.st
@@ -98,3 +98,9 @@ SoilPagedIndexStore >> pageFaultAt: anInteger [
 SoilPagedIndexStore >> pages [
 	^ pages
 ]
+
+{ #category : #accessing }
+SoilPagedIndexStore >> priorPage [
+	"this is slow as it checks all pages"
+	^ pages detect: [: page | page next == self ]
+]


### PR DESCRIPTION
This PR fixes #lastAssociation


- restore the value correctly if it was removed in another transaction
- implement and use #priorAssociation, which will iterate backwards and correctly go to the prior page if needed 

fixes #568 and #478