### PR TITLE
362-Revisit-creation-of-index-dictionaries-with-conditions-index-presentabsent-transaction-presentabsent

### DIFF
--- a/src/Soil-Core-Tests/SoilBackupTest.class.st
+++ b/src/Soil-Core-Tests/SoilBackupTest.class.st
@@ -36,14 +36,16 @@ SoilBackupTest >> tearDown [
 { #category : #tests }
 SoilBackupTest >> testBackupWithIndex [ 
 	| tx backup tx2 dict object |
+	tx := soil newTransaction.
+	
 	dict := SoilSkipListDictionary new 
 		keySize: 8;
 		maxLevel: 16.
+	tx root: dict.
 	dict at: #foo put: (SoilTestNestedObject new label: #indexed).
 	object := SoilTestClusterRoot new 
 		nested: dict.
-	tx := soil newTransaction.
-	tx root: dict.
+
 	tx commit.
 	soil backupTo: self backupPath.
 	backup := Soil new 
@@ -60,15 +62,15 @@ SoilBackupTest >> testBackupWithIndexRemoval [
 	| tx backup tx2 dict object |
 	"removed keys in indexes get objectId 0:0. On backup time we only
 	need to copy the non-removed"
+	tx := soil newTransaction.
 	dict := SoilSkipListDictionary new 
 		keySize: 8;
 		maxLevel: 16.
+		tx root: dict.
 	dict at: #foo put: (SoilTestNestedObject new label: #indexed).
 	dict at: #bar put: (SoilTestNestedObject new label: #bar).
 	object := SoilTestClusterRoot new 
-		nested: dict.
-	tx := soil newTransaction.
-	tx root: dict.
+	nested: dict.
 	tx commit.
 	tx2 := soil newTransaction.
 	tx2 root removeKey: #bar.

--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -75,16 +75,6 @@ SoilIndexedDictionaryTest >> testAddAndRemoveExistingList [
 ]
 
 { #category : #tests }
-SoilIndexedDictionaryTest >> testAddAndRemoveOnNewList [
-  	self 
-		shouldnt: [ dict at: #foo put: #bar ]
-		raise: Error.
-	self assert: (dict at: #foo) equals: #bar.
-	dict removeKey: #foo.
-	self assert: dict size equals: 0
-]
-
-{ #category : #tests }
 SoilIndexedDictionaryTest >> testAddToExistingEmptyList [
 	| tx tx2 tx3 tx4 |
 	"create emtpy skip list dictionary ..."
@@ -140,31 +130,6 @@ SoilIndexedDictionaryTest >> testAddToExistingNonEmptyList [
 ]
 
 { #category : #tests }
-SoilIndexedDictionaryTest >> testAddToNewList [
-  	self 
-		shouldnt: [ dict at: #foo put: #bar ]
-		raise: Error.
-	self assert: (dict at: #foo) equals: #bar
-]
-
-{ #category : #tests }
-SoilIndexedDictionaryTest >> testAt [
-	dict at: #foo2 put: #bar2.
-	dict at: #foo put: #bar.
-	
-	self assert: (dict at: #foo2) equals: #bar2.
-	self should: [dict at: #ff] raise: KeyNotFound
-]
-
-{ #category : #tests }
-SoilIndexedDictionaryTest >> testAtIndex [
-	dict at: #foo2 put: #bar2.
-	dict at: #foo put: #bar.
-	
-	self assert: (dict atIndex: 1) equals: #bar2
-]
-
-{ #category : #tests }
 SoilIndexedDictionaryTest >> testAtIndexWithTransaction [
 	| tx tx2 |
 	tx := soil newTransaction.
@@ -183,9 +148,9 @@ SoilIndexedDictionaryTest >> testAtIndexWithTransaction [
 SoilIndexedDictionaryTest >> testConcurrentAddKey [ 
 	| tx1 tx2 tx3 |
 	tx1 := soil newTransaction.
-	tx1 root: (dict
-		at: #one put: #onevalue;
-		yourself).
+	tx1 root: dict.
+	dict
+		at: #one put: #onevalue.
 	tx1 commit.
 	tx2 := soil newTransaction.
 	"After creating tx2 we open a concurrent transaction and add a key to 
@@ -202,12 +167,12 @@ SoilIndexedDictionaryTest >> testConcurrentAddKey [
 SoilIndexedDictionaryTest >> testConcurrentDo [
 	| tx1 tx2 tx3 col |
 	tx1 := soil newTransaction.
-	tx1 root: (dict
+	tx1 root: dict.
+	dict
 		at: #one put: #onevalue;
 		at: #two put: #twovalue;
 		at: #three put: #threevalue;
-		at: #four put: #fourvalue;
-		yourself).
+		at: #four put: #fourvalue.
 	tx1 commit.
 	tx2 := soil newTransaction.
 	"After creating tx2 we open a concurrent transaction and add a key to 
@@ -227,9 +192,9 @@ SoilIndexedDictionaryTest >> testConcurrentDo [
 SoilIndexedDictionaryTest >> testConcurrentIsEmpty [ 
 	| tx1 tx2 tx3 |
 	tx1 := soil newTransaction.
-	tx1 root: (dict
-		at: #one put: #onevalue;
-		yourself).
+	tx1 root: dict.
+	dict
+		at: #one put: #onevalue.
 	tx1 commit.
 	tx2 := soil newTransaction.
 	"After creating tx2 we open a concurrent transaction and add a key to 
@@ -246,9 +211,9 @@ SoilIndexedDictionaryTest >> testConcurrentIsEmpty [
 SoilIndexedDictionaryTest >> testConcurrentRemoveKey [
 	| tx1 tx2 tx3 |
 	tx1 := soil newTransaction.
-	tx1 root: (dict
-		at: #one put: #onevalue;
-		yourself).
+	tx1 root: dict.
+	dict
+		at: #one put: #onevalue.
 	tx1 commit.
 	tx2 := soil newTransaction.
 	"After creating tx2 we open a concurrent transaction and remove a key to 
@@ -260,19 +225,6 @@ SoilIndexedDictionaryTest >> testConcurrentRemoveKey [
 	self assert: (tx2 root at: #one) equals: #onevalue.
 	self deny: tx2 root isEmpty.
 
-]
-
-{ #category : #tests }
-SoilIndexedDictionaryTest >> testDo [
-	| counter |
-	dict at: #foo2 put: #bar2.
-	dict at: #foo put: #bar.
-	
-	counter := 0.
-	dict do: [ :each |
-		self assert: (each beginsWith: 'bar').
-		counter := counter + 1].
-	self assert: counter equals: 2
 ]
 
 { #category : #tests }
@@ -314,33 +266,6 @@ SoilIndexedDictionaryTest >> testDoWithTransAction [
 ]
 
 { #category : #tests }
-SoilIndexedDictionaryTest >> testFirst [
-	dict at: #foo2 put: #bar2.
-	dict at: #foo put: #bar.
-	
-	"first in key order"
-	self assert: dict first equals: #bar.
-	self assert: (dict first: 1) first equals: #bar.
-]
-
-{ #category : #tests }
-SoilIndexedDictionaryTest >> testFirstAssociation [
-	dict at: #foo2 put: #bar2.
-	dict at: #foo put: #bar.
-	
-	"firstAssocation in key order"
-	self assert: dict firstAssociation equals: #foo->#bar.
-]
-
-{ #category : #tests }
-SoilIndexedDictionaryTest >> testFirstAssociationWithSingleRemovedItem [ 
-	
-	dict at: #foo put: #bar.
-	dict removeKey: #foo.
-	self assert: dict firstAssociation equals: nil
-]
-
-{ #category : #tests }
 SoilIndexedDictionaryTest >> testFirstAssociationWithTransaction [
 	| tx tx2 |
 	tx := soil newTransaction.
@@ -374,14 +299,6 @@ SoilIndexedDictionaryTest >> testFirstAssociationWithTransactionRemoved [
 	"in tx1 the removed one is not removed"
 	self assert: tx1 root firstAssociation equals: 1->#one.
 
-]
-
-{ #category : #tests }
-SoilIndexedDictionaryTest >> testFirstWithSingleRemovedItem [ 
-	
-	dict at: #foo put: #bar.
-	dict removeKey: #foo.
-	self assert: dict first equals: nil
 ]
 
 { #category : #tests }
@@ -486,31 +403,6 @@ SoilIndexedDictionaryTest >> testIsEmpty [
 ]
 
 { #category : #tests }
-SoilIndexedDictionaryTest >> testLast [
-	dict at: #foo2 put: #bar2.
-	dict at: #foo put: #bar.
-	
-	"last in key order"
-	self assert: dict last equals: #bar2
-]
-
-{ #category : #tests }
-SoilIndexedDictionaryTest >> testLastAssociation [
-	dict at: #foo2 put: #bar2.
-	dict at: #foo put: #bar.
-	
-	"last association in key order"
-	self assert: dict lastAssociation equals:  #foo2->#bar2
-]
-
-{ #category : #tests }
-SoilIndexedDictionaryTest >> testLastAssociationWithSingleRemovedItem [ 
-	dict at: #foo put: #bar.
-	dict removeKey: #foo.
-	self assert: dict lastAssociation equals: nil
-]
-
-{ #category : #tests }
 SoilIndexedDictionaryTest >> testLastAssociationWithTransaction [
 	| tx tx2 |
 	tx := soil newTransaction.
@@ -547,13 +439,6 @@ SoilIndexedDictionaryTest >> testLastAssociationWithTransactionRemoved [
 ]
 
 { #category : #tests }
-SoilIndexedDictionaryTest >> testLastWithSingleRemovedItem [ 
-	dict at: #foo put: #bar.
-	dict removeKey: #foo.
-	self assert: dict last equals: nil
-]
-
-{ #category : #tests }
 SoilIndexedDictionaryTest >> testLastWithTransaction [
 	| tx tx2 |
 	tx := soil newTransaction.
@@ -586,14 +471,6 @@ SoilIndexedDictionaryTest >> testLastWithTransactionRemoveLast [
 ]
 
 { #category : #tests }
-SoilIndexedDictionaryTest >> testNextAssociationAfter [
-	dict at: 1 put: #bar.
-	dict at: 2 put: #bar2.
-
-	self assert:( dict nextAssociationAfter: 1) equals: 2->#bar2
-]
-
-{ #category : #tests }
 SoilIndexedDictionaryTest >> testNextAssociationAfterWithTransaction [
 	| tx tx2 |
 	tx := soil newTransaction.
@@ -621,17 +498,6 @@ SoilIndexedDictionaryTest >> testNextKeyCloseToWithTransaction [
 	tx2 := soil newTransaction.
 	"and test last"
 	self assert: (tx2 root nextKeyCloseTo: 15) value equals: 20
-]
-
-{ #category : #tests }
-SoilIndexedDictionaryTest >> testRemoveKey [
-	dict at: #foo put: #bar.
-	dict at: #foo2 put: #bar2.
-	
-	dict removeKey: #foo.
-	self assert: dict size equals: 1.
-	
-	self should: [ dict removeKey: #blah ] raise: KeyNotFound
 ]
 
 { #category : #tests }
@@ -690,14 +556,6 @@ SoilIndexedDictionaryTest >> testRemoveKeyWithTwoTransactions [
 ]
 
 { #category : #tests }
-SoilIndexedDictionaryTest >> testSecond [
-	dict at: #foo put: #bar.
-	dict at: #foo2 put: #bar2.
-
-	self assert: dict second equals: #bar2
-]
-
-{ #category : #tests }
 SoilIndexedDictionaryTest >> testSecondWithTransaction [
 	| tx tx2 |
 	tx := soil newTransaction.
@@ -713,14 +571,6 @@ SoilIndexedDictionaryTest >> testSecondWithTransaction [
 ]
 
 { #category : #tests }
-SoilIndexedDictionaryTest >> testSize [
-	dict at: #foo put: #bar.
-	dict at: #foo2 put: #bar2.
-
-	self assert: dict size equals: 2
-]
-
-{ #category : #tests }
 SoilIndexedDictionaryTest >> testSizeWithTransaction [
 	| tx tx2 |
 	tx := soil newTransaction.
@@ -733,15 +583,6 @@ SoilIndexedDictionaryTest >> testSizeWithTransaction [
 	tx2 := soil newTransaction.
 	"and test last"
 	self assert: tx2 root size equals: 2
-]
-
-{ #category : #tests }
-SoilIndexedDictionaryTest >> testValues [
-	dict at: #foo put: #bar.
-	dict at: #foo2 put: #bar2.
-
-	self assert: (dict values includes: #bar).
-	self assert: (dict values includes: #bar2)
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -276,6 +276,13 @@ SoilIndexIterator >> nextAssociation [
 	^ nextValue ifNil: [ self nextAssociation ] ifNotNil: [ key -> nextValue ]
 ]
 
+{ #category : #accessing }
+SoilIndexIterator >> nextAssociationAfter: key [
+
+	self find: key.
+	^ self nextAssociation
+]
+
 { #category : #private }
 SoilIndexIterator >> nextKeyCloseTo: key [
 
@@ -289,13 +296,6 @@ SoilIndexIterator >> nextKeyCloseTo: key [
 		ifNotNil: [ 
 			"if there is a close key found, we make sure the cursor get properly positioned"
 			currentKey := nextKey ]
-]
-
-{ #category : #accessing }
-SoilIndexIterator >> nextAssociationAfter: key [
-
-	self find: key.
-	^ self nextAssociation
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -279,7 +279,7 @@ SoilIndexIterator >> nextAssociation [
 { #category : #accessing }
 SoilIndexIterator >> nextAssociationAfter: key [
 
-	self find: key.
+	self find: (key asIndexKeyOfSize: index keySize) asInteger.
 	^ self nextAssociation
 ]
 

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -176,6 +176,12 @@ SoilIndexedDictionary >> newIterator [
 ]
 
 { #category : #accessing }
+SoilIndexedDictionary >> nextAfter: key [  
+	^ (self nextAssociationAfter: key) value  
+
+]
+
+{ #category : #accessing }
 SoilIndexedDictionary >> nextAssociationAfter: key [  
 
 	^ (self newIterator nextAssociationAfter: key)

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -33,39 +33,30 @@ SoilIndexedDictionary >> at: key [
 
 { #category : #accessing }
 SoilIndexedDictionary >> at: key ifAbsent: aBlock [
-	| objectId |
-	^ transaction 
-		ifNotNil: [  
-			objectId := (self basicAt: key ifAbsent: [ ^ aBlock value ]) asSoilObjectId.
-			transaction proxyForObjectId: objectId ]
-		ifNil: [ newValues at: key ifAbsent: aBlock ]
+	| found |
+	found := self basicAt: key ifAbsent: [ ^ aBlock value ].
+	^ transaction proxyForObjectId: found asSoilObjectId
 ]
 
 { #category : #accessing }
 SoilIndexedDictionary >> at: key put: anObject [
-	^ transaction 
-		ifNotNil: [ 
-			| objectId iterator |
-			objectId := transaction makeRoot: anObject.
-			iterator := self newIterator.
-			(iterator at: key put: objectId) ifNotNil: [ :value |
-				oldValues 
-					at: key
-					ifAbsentPut: objectId ].
-		"if there has been a prior removal of the key this new addition invalidates it"
-			removedValues removeKey: key ifAbsent: nil.
-			newValues at: key put: objectId. ]
-		ifNil: [ 
-			newValues at: key put: anObject ]
+	| objectId |
+	objectId := transaction makeRoot: anObject.
+	(self newIterator at: key put: objectId) ifNotNil: [ :value |
+		oldValues 
+			at: key
+			ifAbsentPut: objectId ].
+	"if there has been a prior removal of the key this new addition invalidates it"
+	removedValues removeKey: key ifAbsent: nil.
+	^ newValues at: key put: objectId
+
 ]
 
 { #category : #accessing }
 SoilIndexedDictionary >> atIndex: anInteger [
-	^ transaction 
-		ifNotNil: [  
-			(self newIterator atIndex: anInteger)
-				ifNotNil: [ :objectId | transaction proxyForObjectId: objectId ]]
-		ifNil: [ (newValues associations at: anInteger) value ]
+	^ (self newIterator atIndex: anInteger)
+				ifNotNil: [ :objectId | transaction proxyForObjectId: objectId ]
+
 ]
 
 { #category : #accessing }
@@ -85,41 +76,27 @@ SoilIndexedDictionary >> createIndex [
 
 { #category : #enumerating }
 SoilIndexedDictionary >> do: aBlock [
-
-	transaction
-		ifNotNil: [ 
- 			self newIterator do: [ :objectId | 
- 					aBlock value: (transaction proxyForObjectId: objectId) ]]
-		ifNil: [ 
-			newValues valuesDo: [ :each | aBlock value: each ] ]
+ 	self newIterator do: [ :objectId | 
+ 				aBlock value: (transaction proxyForObjectId: objectId) ]
 ]
 
 { #category : #accessing }
 SoilIndexedDictionary >> first [
-	^ transaction 
-		ifNotNil: [ self proxyFromByteArray: self newIterator first ]
-		ifNil: [ 
-			self newValuesSortedByKeyOrder ifNotEmpty: [:nv | nv first value ] ifEmpty: nil]
+	^ self proxyFromByteArray: self newIterator first
 ]
 
 { #category : #accessing }
-SoilIndexedDictionary >> first: anInteger [ 
-	^ transaction 
-		ifNotNil: [ 
-			(self newIterator first: anInteger) 
-				collect: [ :each | self proxyFromByteArray: each ] ]
-		ifNil: [ (self newValuesSortedByKeyOrder first: anInteger) collect: #value ]  
+SoilIndexedDictionary >> first: anInteger [
+
+	^ (self newIterator first: anInteger) collect: [ :each |
+		  self proxyFromByteArray: each ]
 ]
 
 { #category : #accessing }
 SoilIndexedDictionary >> firstAssociation [
 
-	^ transaction
-		  ifNotNil: [
-			  self newIterator firstAssociation ifNotNil: [ :assoc |
-				  assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ] ]
-		  ifNil: [
-			self newValuesSortedByKeyOrder ifNotEmpty: [:nv | nv first ] ifEmpty: nil]
+	^ self newIterator firstAssociation ifNotNil: [ :assoc |
+			assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ]
 ]
 
 { #category : #testing }
@@ -165,21 +142,16 @@ SoilIndexedDictionary >> keySize: anInteger [
 
 { #category : #accessing }
 SoilIndexedDictionary >> last [
-	^ transaction 
-		ifNotNil: [ self proxyFromByteArray: self newIterator last ]
-		ifNil: [ 
-			self newValuesSortedByKeyOrder ifNotEmpty: [:nv | nv last value ] ifEmpty: nil ]
+	^ self proxyFromByteArray: self newIterator last
+	
 ]
 
 { #category : #accessing }
 SoilIndexedDictionary >> lastAssociation [
 
-	^ transaction
-		  ifNotNil: [
-			  self newIterator lastAssociation ifNotNil: [ :assoc |
-				  assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ] ]
-		  ifNil: [ 
-			self newValuesSortedByKeyOrder ifNotEmpty: [:nv | nv last ] ifEmpty: nil ]
+	^ self newIterator lastAssociation ifNotNil: [ :assoc |
+				 assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ] 
+
 ]
 
 { #category : #private }
@@ -204,18 +176,7 @@ SoilIndexedDictionary >> newIterator [
 ]
 
 { #category : #accessing }
-SoilIndexedDictionary >> newValuesSortedByKeyOrder [
-
-	^ newValues associations sort: [ :a :b |
-		(self binaryKey: a key) < (self binaryKey: b key)  ]
-]
-
-{ #category : #accessing }
 SoilIndexedDictionary >> nextAssociationAfter: key [  
-	transaction ifNil: [ 
-		| newValueSorted |
-		newValueSorted := self newValuesSortedByKeyOrder.
-		^ (newValueSorted after: (newValues associationAt: key))].
 
 	^ (self newIterator nextAssociationAfter: key)
 		ifNotNil: [ :assoc |
@@ -255,35 +216,26 @@ SoilIndexedDictionary >> removeKey: key [
 
 { #category : #removing }
 SoilIndexedDictionary >> removeKey: key ifAbsent: aBlock [
-	
-	^ transaction 
-		ifNotNil: [ | v |
-			"remove from newValues as there could be a new at:put: on that
-			key but removing the key will remove the value again"
-			newValues removeKey: key ifAbsent: nil.
-			v := self basicAt: key ifAbsent: [^ aBlock value].
-			removedValues 
-				at: key 
-				put: v asSoilObjectId.
-			self newIterator removeKey: key ]
-		ifNil: [ 
-			removedValues 
-				at: key
-				put: (newValues removeKey: key ifAbsent: [ ^ aBlock value ]) ]
+	 | v |
+	"remove from newValues as there could be a new at:put: on that
+	key but removing the key will remove the value again"
+	newValues removeKey: key ifAbsent: nil.
+	v := self basicAt: key ifAbsent: [^ aBlock value].
+	removedValues 
+			at: key 
+			put: v asSoilObjectId.
+	^ self newIterator removeKey: key
 ]
 
 { #category : #accessing }
 SoilIndexedDictionary >> second [
-	^ transaction 
-		ifNotNil: [ self proxyFromByteArray: (self newIterator first; next) ]
-		ifNil: [ self newValuesSortedByKeyOrder second value ]
+	^ self proxyFromByteArray: (self newIterator first; next)
 ]
 
 { #category : #accessing }
 SoilIndexedDictionary >> size [ 
-	^ transaction 
-		ifNotNil: [ self newIterator size ]
-		ifNil: [ newValues size ]
+	^ self newIterator size
+
 ]
 
 { #category : #serializing }
@@ -329,7 +281,5 @@ SoilIndexedDictionary >> soilMaterialized: aMaterializer [
 
 { #category : #accessing }
 SoilIndexedDictionary >> values [
-	^ transaction 
-		ifNotNil: [ self newIterator values collect: [ :each | self proxyFromByteArray: each ]]
-		ifNil: [ self newValuesSortedByKeyOrder collect: [ :each | each value ] ]
+	^ self newIterator values collect: [ :each | self proxyFromByteArray: each ]
 ]


### PR DESCRIPTION
redo the PR that removes support of SoilIndexedDictionary without a transaction

fixes #362