### PR TITLE
537-asSkipListKeyOfSize-is-confusing-as-we-use-it-for-BTree-too 

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -291,7 +291,7 @@ SoilBTreeTest >> testPageAddFirst [
 	self assert: index pages size equals: 2.
 	page := index headerPage.
 	self assert: page numberOfItems equals: 1.
-	self assert: page items first key equals: (#foo asSkipListKeyOfSize: 8) asInteger.
+	self assert: page items first key equals: (#foo asIndexKeyOfSize: 8) asInteger.
 	"the index page was updated"
 	indexPage := index rootPage.
 	"Index has been updated"
@@ -309,7 +309,7 @@ SoilBTreeTest >> testPageAddFirstAndLoad [
 	self assert: index pages size equals: 2.
 	page := index headerPage.
 	self assert: page numberOfItems equals: 1.
-	self assert: page items first key equals: (#foo asSkipListKeyOfSize: 8) asInteger.
+	self assert: page items first key equals: (#foo asIndexKeyOfSize: 8) asInteger.
 	"the index page was updated"
 	indexPage := index rootPage.
 	"Index has been updated"
@@ -323,7 +323,7 @@ SoilBTreeTest >> testPageAddFirstAndLoad [
 		initializeFilesystem;
 		open.
 	
-	self assert: page items first key equals: (#foo asSkipListKeyOfSize: 8) asInteger.	
+	self assert: page items first key equals: (#foo asIndexKeyOfSize: 8) asInteger.	
 	"load succeeds"
 	self assert: (index at: #foo) equals: #[ 1 2 3 4 5 6 7 8 ].
 

--- a/src/Soil-Core-Tests/SoilSkipListTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListTest.class.st
@@ -137,9 +137,9 @@ SoilSkipListTest >> testAddLastFitting [
 	
 	| page |
 	1 to: 61 do: [ :n | 
-		index at: (n asString asSkipListKeyOfSize: 8) put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: (n asString asIndexKeyOfSize: 8) put: #[ 1 2 3 4 5 6 7 8 ] ].
 	self assert: index pages size equals: 1.
-	index at: (63 asString asSkipListKeyOfSize: 8) put: #[ 1 2 3 4 5 6 7 8 ].
+	index at: (63 asString asIndexKeyOfSize: 8) put: #[ 1 2 3 4 5 6 7 8 ].
 	self assert: index pages size equals: 1.
 	page := index pageAt: 1.
 	self assert: page numberOfItems equals: 62.
@@ -331,7 +331,7 @@ SoilSkipListTest >> testLastPage [
 { #category : #tests }
 SoilSkipListTest >> testMorePages [
 	1 to: 512 do: [ :n |
-		index at: (n asString asSkipListKeyOfSize: 8) put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: (n asString asIndexKeyOfSize: 8) put: #[ 1 2 3 4 5 6 7 8 ] ].
 	index writePages.
 	self assert: index pages size equals: 3
 ]
@@ -379,7 +379,7 @@ SoilSkipListTest >> testPageAddFirst [
 	self assert: index pages size equals: 1.
 	page := index firstPage.
 	self assert: page numberOfItems equals: 1.
-	self assert: page items first key equals: (#foo asSkipListKeyOfSize: 8) asInteger
+	self assert: page items first key equals: (#foo asIndexKeyOfSize: 8) asInteger
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/ByteArray.extension.st
+++ b/src/Soil-Core/ByteArray.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : #ByteArray }
 
 { #category : #'*Soil-Core' }
-ByteArray >> asSkipListKeyOfSize: anInteger [ 
+ByteArray >> asIndexKeyOfSize: anInteger [ 
 	^ self asByteArrayOfSize: anInteger 
 ]
 

--- a/src/Soil-Core/Integer.extension.st
+++ b/src/Soil-Core/Integer.extension.st
@@ -1,13 +1,13 @@
 Extension { #name : #Integer }
 
 { #category : #'*Soil-Core' }
-Integer >> asLogSequenceNumber [ 
-	^ SoilLogSequenceNumber value: self
+Integer >> asIndexKeyOfSize: keySize [ 
+	^ self asByteArrayOfSize: keySize 
 ]
 
 { #category : #'*Soil-Core' }
-Integer >> asSkipListKeyOfSize: keySize [ 
-	^ self asByteArrayOfSize: keySize 
+Integer >> asLogSequenceNumber [ 
+	^ SoilLogSequenceNumber value: self
 ]
 
 { #category : #'*soil-core' }

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -118,7 +118,7 @@ SoilBasicBTree >> readPageFrom: aStream [
 { #category : #removing }
 SoilBasicBTree >> removeKey: aString ifAbsent: aBlock [
 	| page index key |
-	key := (aString asSkipListKeyOfSize: self keySize) asInteger.
+	key := (aString asIndexKeyOfSize: self keySize) asInteger.
 	page := self newIterator 
 		find: key;
 		currentPage.

--- a/src/Soil-Core/SoilBasicSkipList.class.st
+++ b/src/Soil-Core/SoilBasicSkipList.class.st
@@ -30,7 +30,7 @@ SoilBasicSkipList >> newIterator [
 { #category : #removing }
 SoilBasicSkipList >> removeKey: aString ifAbsent: aBlock [
 	| page index key |
-	key := (aString asSkipListKeyOfSize: self keySize) asInteger.
+	key := (aString asIndexKeyOfSize: self keySize) asInteger.
 	page := self newIterator 
 		find: key;
 		currentPage.

--- a/src/Soil-Core/SoilIndex.class.st
+++ b/src/Soil-Core/SoilIndex.class.st
@@ -54,7 +54,7 @@ SoilIndex >> do: aBlock [
 { #category : #private }
 SoilIndex >> find: aString [ 
 	^ self newIterator 
-		find: (aString asSkipListKeyOfSize: self keySize) asInteger
+		find: (aString asIndexKeyOfSize: self keySize) asInteger
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -41,7 +41,7 @@ SoilIndexIterator >> at: aKeyObject [
 { #category : #accessing }
 SoilIndexIterator >> at: aKeyObject ifAbsent: aBlock [
 	| foundValue |
-	currentKey := (aKeyObject asSkipListKeyOfSize: index keySize) asInteger.
+	currentKey := (aKeyObject asIndexKeyOfSize: index keySize) asInteger.
 	foundValue := self find: currentKey ifAbsent: aBlock.
  	^(self restoreValue: foundValue forKey: currentKey) ifNil: [ aBlock value ]
 ]
@@ -49,7 +49,7 @@ SoilIndexIterator >> at: aKeyObject ifAbsent: aBlock [
 { #category : #accessing }
 SoilIndexIterator >> at: aKeyObject put: anObject [
 	| key |
-	key := (aKeyObject asSkipListKeyOfSize: index keySize) asInteger.
+	key := (aKeyObject asIndexKeyOfSize: index keySize) asInteger.
 	^ self 
 		basicAt: key 
 		put: anObject
@@ -276,11 +276,18 @@ SoilIndexIterator >> nextAssociation [
 	^ nextValue ifNil: [ self nextAssociation ] ifNotNil: [ key -> nextValue ]
 ]
 
+{ #category : #accessing }
+SoilIndexIterator >> nextAssociationAfter: key [
+
+	self find: key.
+	^ self nextAssociation
+]
+
 { #category : #private }
 SoilIndexIterator >> nextKeyCloseTo: key [
 
 	| binKey |
-	binKey := (key asSkipListKeyOfSize: index keySize) asInteger.
+	binKey := (key asIndexKeyOfSize: index keySize) asInteger.
 	self findPageFor: binKey.
 	nextKey := currentPage keyOrClosestAfter: binKey.
 	^ nextKey
@@ -289,13 +296,6 @@ SoilIndexIterator >> nextKeyCloseTo: key [
 		ifNotNil: [ 
 			"if there is a close key found, we make sure the cursor get properly positioned"
 			currentKey := nextKey ]
-]
-
-{ #category : #accessing }
-SoilIndexIterator >> nextAssociationAfter: key [
-
-	self find: key.
-	^ self nextAssociation
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -75,7 +75,7 @@ SoilIndexedDictionary >> basicAt: aString ifAbsent: aBlock [
 
 { #category : #accessing }
 SoilIndexedDictionary >> binaryKey: aString [
-	^ (aString asSkipListKeyOfSize: index keySize) asInteger
+	^ (aString asIndexKeyOfSize: index keySize) asInteger
 ]
 
 { #category : #initialization }

--- a/src/Soil-Core/String.extension.st
+++ b/src/Soil-Core/String.extension.st
@@ -1,6 +1,6 @@
 Extension { #name : #String }
 
 { #category : #'*Soil-Core' }
-String >> asSkipListKeyOfSize: anInteger [ 
-	^ self asByteArray asSkipListKeyOfSize: anInteger 
+String >> asIndexKeyOfSize: anInteger [ 
+	^ self asByteArray asIndexKeyOfSize: anInteger 
 ]


### PR DESCRIPTION
this PR renames #asSkipListKeyOfSize: to #asIndexKeyOfSize:

Do we need some form of backward compatibility support for this?

fixes #537

