### PR TITLE
 cleanup-firstAssociation-lastAssociation

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -270,14 +270,13 @@ SoilIndexedDictionaryTest >> testFirstAssociationWithTransaction [
 	| tx tx2 |
 	tx := soil newTransaction.
 	tx root: dict.
-	dict at: 1 put: #one.
-	dict at: 2 put: #two.
-	"self assert: dict last equals: #two."
+	dict at: #one put: #onevalue.
+	dict at: #two put: #twovalue.
 	tx commit.
 	"open a second transaction ..."
 	tx2 := soil newTransaction.
 	"and test last"
-	self assert: tx2 root firstAssociation equals: 1->#one.
+	self assert: tx2 root firstAssociation value equals: #onevalue.
 
 ]
 
@@ -286,18 +285,17 @@ SoilIndexedDictionaryTest >> testFirstAssociationWithTransactionRemoved [
 	| tx tx1 tx2 |
 	tx := soil newTransaction.
 	tx root: dict.
-	dict at: 1 put: #one.
-	dict at: 2 put: #two.
-	"self assert: dict last equals: #two."
+	dict at: #one put: #onevalue.
+	dict at: #two put: #twovalue.
 	tx commit.
 	
 	"open a two transactions ..."
 	tx1 := soil newTransaction.
 	tx2 := soil newTransaction.
-	tx2 root removeKey: 1.
+	tx2 root removeKey: #one.
 	tx2 commit.
 	"in tx1 the removed one is not removed"
-	self assert: tx1 root firstAssociation equals: 1->#one.
+	self assert: tx1 root firstAssociation value equals: #onevalue.
 
 ]
 
@@ -315,6 +313,25 @@ SoilIndexedDictionaryTest >> testFirstWithTransaction [
 	"and test first"
 	self assert: tx2 root first equals: #one. 
 	self assert: (tx2 root first: 2) second equals: #two
+
+]
+
+{ #category : #tests }
+SoilIndexedDictionaryTest >> testFirstWithTransactionRemoved [
+	| tx tx1 tx2 |
+	tx := soil newTransaction.
+	tx root: dict.
+	dict at: #one put: #onevalue.
+	dict at: #two put: #twovalue.
+	tx commit.
+	
+	"open a two transactions ..."
+	tx1 := soil newTransaction.
+	tx2 := soil newTransaction.
+	tx2 root removeKey: #one.
+	tx2 commit.
+	"in tx1 the removed one is not removed"
+	self assert: tx1 root first equals: #onevalue.
 
 ]
 
@@ -407,15 +424,14 @@ SoilIndexedDictionaryTest >> testLastAssociationWithTransaction [
 	| tx tx2 |
 	tx := soil newTransaction.
 	tx root: dict.
-	dict at: 2 put: #two.
-	dict at: 1 put: #one.
+	dict at: #two put: #twovalue.
+	dict at: #one put: #onevalue.
 	
-	"self assert: dict last equals: #two."
 	tx commit.
 	"open a second transaction ..."
 	tx2 := soil newTransaction.
 	"and test last, not: key order"
-	self assert: tx2 root lastAssociation equals: 2->#two
+	self assert: tx2 root lastAssociation value equals: #twovalue
 ]
 
 { #category : #tests }
@@ -423,18 +439,17 @@ SoilIndexedDictionaryTest >> testLastAssociationWithTransactionRemoved [
 	| tx tx1 tx2 |
 	tx := soil newTransaction.
 	tx root: dict.
-	dict at: 1 put: #one.
-	dict at: 2 put: #two.
-	"self assert: dict last equals: #two."
+	dict at: #one put: #onevalue.
+	dict at: #two put: #twovalue.
 	tx commit.
 	
 	"open a two transactions ..."
 	tx1 := soil newTransaction.
 	tx2 := soil newTransaction.
-	tx2 root removeKey: 2.
+	tx2 root removeKey: #two.
 	tx2 commit.
 	"in tx1 the removed one is not removed"
-	self assert: tx1 root lastAssociation equals: 2->#two.
+	self assert: tx1 root lastAssociation value equals: #twovalue.
 
 ]
 
@@ -468,6 +483,39 @@ SoilIndexedDictionaryTest >> testLastWithTransactionRemoveLast [
 	tx2 root removeKey: #two.
 	"and test last"
 	self assert: tx2 root last equals: #onevalue
+]
+
+{ #category : #tests }
+SoilIndexedDictionaryTest >> testLastWithTransactionRemoved [
+	| tx tx1 tx2 |
+	tx := soil newTransaction.
+	tx root: dict.
+	dict at: #one put: #onevalue.
+	dict at: #two put: #twovalue.
+	tx commit.
+	
+	"open a two transactions ..."
+	tx1 := soil newTransaction.
+	tx2 := soil newTransaction.
+	tx2 root removeKey: #two.
+	tx2 commit.
+	"in tx1 the removed one is not removed"
+	self assert: tx1 root last equals: #twovalue.
+
+]
+
+{ #category : #tests }
+SoilIndexedDictionaryTest >> testNextAfterWithTransaction [
+	| tx tx2 |
+	tx := soil newTransaction.
+	tx root: dict.
+	dict at: #one put: #onevalue.
+	dict at: #two put: #twovalue.
+	tx commit.
+	"open a second transaction ..."
+	tx2 := soil newTransaction.
+	"and test last"
+	self assert: (tx2 root nextAfter: #one) value equals: #twovalue
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/SoilBTreeIterator.class.st
+++ b/src/Soil-Core/SoilBTreeIterator.class.st
@@ -5,9 +5,9 @@ Class {
 }
 
 { #category : #accessing }
-SoilBTreeIterator >> basicAt: key put: anObject [
+SoilBTreeIterator >> basicAt: binKey put: anObject [
 	| posiblePrioValue |
-	posiblePrioValue := index rootPage insertItem: (key -> anObject) for: self.
+	posiblePrioValue := index rootPage insertItem: (binKey -> anObject) for: self.
 	"as an optimization we return the prior value stored in the list. If there was none we return nil"
 	^ posiblePrioValue returnValue
 ]

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -164,6 +164,7 @@ SoilIndexIterator >> first: anInteger [
 
 { #category : #accessing }
 SoilIndexIterator >> firstAssociation [ 
+	"Note: key will be binary key"
 	| item |
 	currentPage := index store headerPage.
 	item := self nextAssociation.
@@ -235,6 +236,7 @@ SoilIndexIterator >> last [
 
 { #category : #accessing }
 SoilIndexIterator >> lastAssociation [
+	"Note: key will be binary key"
 	| lastAssociation lastValue key |
 	lastAssociation := self priorAssociation ifNil: [ ^nil ].
 	lastValue := (self
@@ -266,7 +268,7 @@ SoilIndexIterator >> next: anInteger [
 
 { #category : #accessing }
 SoilIndexIterator >> nextAssociation [
-
+	"Note: key will be binary key"
 	| nextAssociation nextValue key |
 	nextAssociation := self basicNextAssociation ifNil: [ ^nil ].
 	nextValue := (self
@@ -277,14 +279,14 @@ SoilIndexIterator >> nextAssociation [
 
 { #category : #accessing }
 SoilIndexIterator >> nextAssociationAfter: key [
-
+	"Note: key will be binary key"
 	self find: key.
 	^ self nextAssociation
 ]
 
 { #category : #private }
 SoilIndexIterator >> nextKeyCloseTo: key [
-
+	"Note: returnrd key will be binary key"
 	| binKey |
 	binKey := (key asIndexKeyOfSize: index keySize) asInteger.
 	self findPageFor: binKey.

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -71,7 +71,7 @@ SoilIndexIterator >> basicAssociationsDo: aBlock [
 ]
 
 { #category : #accessing }
-SoilIndexIterator >> basicAt: key put: anObject [
+SoilIndexIterator >> basicAt: binKey put: anObject [
 	self subclassResponsibility
 ]
 

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -94,7 +94,7 @@ SoilIndexedDictionary >> first: anInteger [
 
 { #category : #accessing }
 SoilIndexedDictionary >> firstAssociation [
-
+	"Note: key will be binary key"
 	^ self newIterator firstAssociation ifNotNil: [ :assoc |
 			assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ]
 ]
@@ -148,7 +148,7 @@ SoilIndexedDictionary >> last [
 
 { #category : #accessing }
 SoilIndexedDictionary >> lastAssociation [
-
+	"Note: key will be binary key"
 	^ self newIterator lastAssociation ifNotNil: [ :assoc |
 				 assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ] 
 
@@ -183,14 +183,15 @@ SoilIndexedDictionary >> nextAfter: key [
 
 { #category : #accessing }
 SoilIndexedDictionary >> nextAssociationAfter: key [  
-
+	"Note: key will be binary key"
 	^ (self newIterator nextAssociationAfter: key)
 		ifNotNil: [ :assoc |
 			assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ]
 ]
 
 { #category : #private }
-SoilIndexedDictionary >> nextKeyCloseTo: aKey [ 
+SoilIndexedDictionary >> nextKeyCloseTo: aKey [
+	"Note: key will be binary key"
 	^ self newIterator nextKeyCloseTo: aKey
 ]
 

--- a/src/Soil-Core/SoilSkipListIterator.class.st
+++ b/src/Soil-Core/SoilSkipListIterator.class.st
@@ -13,22 +13,22 @@ SoilSkipListIterator >> atLevel: key put: anObject [
 ]
 
 { #category : #accessing }
-SoilSkipListIterator >> basicAt: key put: anObject [
+SoilSkipListIterator >> basicAt: binKey put: anObject [
 
 	|itemIndex |
-	self findPageFor: key.
-	itemIndex := currentPage indexOfKey: key.
+	self findPageFor: binKey.
+	itemIndex := currentPage indexOfKey: binKey.
 	"as an optimization we return the prior value stored in the list. If
 	there was none we return nil"
 	^ itemIndex > 0
-		  ifTrue: [ currentPage itemAt: key put: anObject ]
+		  ifTrue: [ currentPage itemAt: binKey put: anObject ]
 		  ifFalse: [
 			  currentPage hasRoom ifFalse: [  | newPage |
-				  newPage := index splitPage: self forKey: key.
-				  currentPage := currentPage biggestKey < key
+				  newPage := index splitPage: self forKey: binKey.
+				  currentPage := currentPage biggestKey < binKey
 					                 ifTrue: [ newPage ]
 					                 ifFalse: [ currentPage ] ].
-			  currentPage addItem: key -> anObject.
+			  currentPage addItem: binKey -> anObject.
 			  nil ]
 ]
 


### PR DESCRIPTION
This PR adds comments to all the methods returning associations to make clear that we return the *binary* key.

Users that just use the SoilIndexedDictionary might think that the keys are the keys they use.

The PR fixes all remaining tests that where using integers to test SoilIndexedDictionary