### PR TITLE
Add SoilIndexedDictionary>>#nextCloseTo:

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -500,6 +500,26 @@ SoilIndexedDictionaryTest >> testNextKeyCloseToWithTransaction [
 ]
 
 { #category : #tests }
+SoilIndexedDictionaryTest >> testNextcloseToWithTransaction [
+	| tx tx2 |
+	tx := soil newTransaction.
+	tx root: dict.
+	dict at: #'10' put: #one.
+	dict at: #'20' put: #two.
+	tx commit.
+	"open a second transaction ..."
+	tx2 := soil newTransaction.
+	"and test"
+	self assert: (tx2 root nextCloseTo: #'5') equals: #one.
+	self assert: (tx2 root nextCloseTo: #'10') equals: #one.
+	self assert: (tx2 root nextCloseTo: #'11') equals: #two.
+	self assert: (tx2 root nextCloseTo: #'15 ') equals: #two.
+	self assert: (tx2 root nextCloseTo: #'20') equals: #two.
+	"this is a bit odd, when looking with larger values we get the last one"
+	self assert: (tx2 root nextCloseTo: #'100') equals: #two
+]
+
+{ #category : #tests }
 SoilIndexedDictionaryTest >> testRemoveKeyIfAbsentWithTransaction [
 
 

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -283,6 +283,12 @@ SoilIndexIterator >> nextAssociationAfter: key [
 ]
 
 { #category : #private }
+SoilIndexIterator >> nextCloseTo: key [
+	"return the next entry after key, even if key itself is not there"
+	^ self at: (self nextKeyCloseTo: key)
+]
+
+{ #category : #private }
 SoilIndexIterator >> nextKeyCloseTo: key [
 
 	| binKey |

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -190,6 +190,11 @@ SoilIndexedDictionary >> nextAssociationAfter: key [
 ]
 
 { #category : #private }
+SoilIndexedDictionary >> nextCloseTo: aKey [ 
+	^ transaction objectWithId: (self newIterator nextCloseTo: aKey) 
+]
+
+{ #category : #private }
 SoilIndexedDictionary >> nextKeyCloseTo: aKey [ 
 	^ self newIterator nextKeyCloseTo: aKey
 ]


### PR DESCRIPTION
- add #nextCloseTo:
- add a test (that does not use integer keys)


This is one part of #596

The PR does NOT yet remove #nextKeyCloseTo: on the level of the SoilIndexedDictionary