### PR TITLE
This PR finishes the hierarchy merge for the BTree and SkipList pages

### DIFF
--- a/src/Soil-Core/SoilBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilBTreeDataPage.class.st
@@ -33,7 +33,7 @@ SoilBTreeDataPage >> initialize [
 	next := 0
 ]
 
-{ #category : #accessing }
+{ #category : #adding }
 SoilBTreeDataPage >> insertItem: anItem for: iterator [
 
 	| newPage pageWithItem return |

--- a/src/Soil-Core/SoilBTreeIndexPage.class.st
+++ b/src/Soil-Core/SoilBTreeIndexPage.class.st
@@ -32,7 +32,7 @@ SoilBTreeIndexPage >> headerSize [
 		+ 2 "items size"
 ]
 
-{ #category : #searching }
+{ #category : #adding }
 SoilBTreeIndexPage >> insertItem: item for: iterator [
 	| foundItem return newPage  |
 	

--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -1,10 +1,6 @@
 Class {
 	#name : #SoilBTreePage,
 	#superclass : #SoilIndexItemsPage,
-	#instVars : [
-		'keySize',
-		'lastTransaction'
-	],
 	#category : #'Soil-Core-Index-BTree'
 }
 
@@ -40,29 +36,9 @@ SoilBTreePage >> initialize [
 	dirty := true
 ]
 
-{ #category : #testing }
-SoilBTreePage >> isOlderThan: aVersionNumber [ 
-	^ lastTransaction <= aVersionNumber 
-]
-
-{ #category : #accessing }
-SoilBTreePage >> keySize [
-	^ keySize
-]
-
-{ #category : #accessing }
-SoilBTreePage >> keySize: anInteger [ 
-	keySize := anInteger
-]
-
-{ #category : #accessing }
-SoilBTreePage >> lastTransaction [
-	^ lastTransaction
-]
-
-{ #category : #accessing }
-SoilBTreePage >> lastTransaction: anInteger [ 
-	lastTransaction := anInteger
+{ #category : #adding }
+SoilBTreePage >> insertItem: anItem for: iterator [ 
+	^ self subclassResponsibility
 ]
 
 { #category : #accessing }
@@ -84,11 +60,6 @@ SoilBTreePage >> readItemsFrom: aStream [
 	items := SortedCollection new: numberOfItems.
 	numberOfItems timesRepeat: [ 
 		items add: (aStream next: self keySize) asInteger -> (aStream next: self valueSize) ]
-]
-
-{ #category : #writing }
-SoilBTreePage >> readLastTransactionFrom: aStream [ 
-	lastTransaction := (aStream next: 8) asInteger.
 ]
 
 { #category : #private }
@@ -113,10 +84,7 @@ SoilBTreePage >> writeHeaderOn: aStream [
 SoilBTreePage >> writeItemsOn: aStream [ 
 	aStream
 		nextPutAll: (items size asByteArrayOfSize: self itemsSizeSize).
-	items do: [ :assoc |
-		aStream 
-			nextPutAll: (assoc key asByteArrayOfSize: self keySize);
-			nextPutAll: (assoc value asByteArrayOfSize: self valueSize)]
+	super writeItemsOn: aStream
 ]
 
 { #category : #writing }

--- a/src/Soil-Core/SoilIndexItemsPage.class.st
+++ b/src/Soil-Core/SoilIndexItemsPage.class.st
@@ -2,7 +2,9 @@ Class {
 	#name : #SoilIndexItemsPage,
 	#superclass : #SoilIndexPage,
 	#instVars : [
-		'items'
+		'items',
+		'lastTransaction',
+		'keySize'
 	],
 	#category : #'Soil-Core-Index-Common'
 }
@@ -66,6 +68,11 @@ SoilIndexItemsPage >> initialize [
 { #category : #testing }
 SoilIndexItemsPage >> isEmpty [
 	^ items isEmpty 
+]
+
+{ #category : #testing }
+SoilIndexItemsPage >> isOlderThan: aVersionNumber [ 
+	^ lastTransaction <= aVersionNumber 
 ]
 
 { #category : #accessing }
@@ -154,6 +161,17 @@ SoilIndexItemsPage >> keyOrClosestAfter: key [
 ]
 
 { #category : #accessing }
+SoilIndexItemsPage >> keySize [
+	^ keySize
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> keySize: anInteger [ 
+	(anInteger = 0) ifTrue: [ Error signal: 'cannot use key size 0' ].
+	keySize := anInteger
+]
+
+{ #category : #accessing }
 SoilIndexItemsPage >> lastItem [
 
 	^ items isNotEmpty ifTrue: [ items last ] ifFalse: [ nil ]
@@ -166,6 +184,16 @@ SoilIndexItemsPage >> lastKey [
 ]
 
 { #category : #accessing }
+SoilIndexItemsPage >> lastTransaction [
+	^ lastTransaction
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> lastTransaction: anInteger [ 
+	lastTransaction := anInteger
+]
+
+{ #category : #accessing }
 SoilIndexItemsPage >> numberOfItems [
 	^ items size
 ]
@@ -174,6 +202,21 @@ SoilIndexItemsPage >> numberOfItems [
 SoilIndexItemsPage >> postCopy [ 
 	super postCopy.
 	items := items copy.
+]
+
+{ #category : #reading }
+SoilIndexItemsPage >> readItemsFrom: aStream [ 
+	| numberOfItems |
+	numberOfItems := (aStream next: self itemsSizeSize) asInteger.
+	items := SortedCollection new: numberOfItems.
+	numberOfItems timesRepeat: [ 
+		items add: ((aStream next: self keySize) asInteger -> (aStream next: self valueSize) asSoilObjectId) ]
+]
+
+{ #category : #writing }
+SoilIndexItemsPage >> readLastTransactionFrom: aStream [ 
+	lastTransaction := (aStream next: 8) asInteger.
+
 ]
 
 { #category : #accessing }
@@ -203,4 +246,18 @@ SoilIndexItemsPage >> valueAt: anInteger ifAbsent: aBlock [
 { #category : #accessing }
 SoilIndexItemsPage >> valueSize [
 	^ self subclassResponsibility
+]
+
+{ #category : #accessing }
+SoilIndexItemsPage >> valueSize: anInteger [ 
+	^ self subclassResponsibility
+]
+
+{ #category : #writing }
+SoilIndexItemsPage >> writeItemsOn: aStream [ 
+	items do: [ :assoc |
+		aStream 
+			nextPutAll: (assoc key asByteArrayOfSize: self keySize);
+			nextPutAll: (assoc value asByteArrayOfSize: self valueSize)].
+
 ]

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -3,9 +3,7 @@ Class {
 	#superclass : #SoilIndexItemsPage,
 	#instVars : [
 		'right',
-		'keySize',
-		'valueSize',
-		'lastTransaction'
+		'valueSize'
 	],
 	#category : #'Soil-Core-Index-SkipList'
 }
@@ -59,32 +57,6 @@ SoilSkipListPage >> isLastPage [
 	^ (right at: 1) = 0
 ]
 
-{ #category : #testing }
-SoilSkipListPage >> isOlderThan: aVersionNumber [ 
-	^ lastTransaction <= aVersionNumber 
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> keySize [ 
-	^ keySize
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> keySize: anInteger [ 
-	(anInteger = 0) ifTrue: [ Error signal: 'cannot use key size 0' ].
-	keySize := anInteger.
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> lastTransaction [
-	^ lastTransaction
-]
-
-{ #category : #accessing }
-SoilSkipListPage >> lastTransaction: anInteger [ 
-	lastTransaction := anInteger
-]
-
 { #category : #accessing }
 SoilSkipListPage >> level [ 
 	^ right size
@@ -105,21 +77,6 @@ SoilSkipListPage >> postCopy [
 SoilSkipListPage >> readFrom: aStream [ 
 	super readFrom: aStream.
 	self readLastTransactionFrom: aStream
-]
-
-{ #category : #writing }
-SoilSkipListPage >> readItemsFrom: aStream [ 
-	| numberOfItems |
-	numberOfItems := (aStream next: self itemsSizeSize) asInteger.
-	items := SortedCollection new: numberOfItems.
-	numberOfItems timesRepeat: [ 
-		items add: ((aStream next: self keySize) asInteger -> (aStream next: self valueSize) asSoilObjectId) ]
-]
-
-{ #category : #writing }
-SoilSkipListPage >> readLastTransactionFrom: aStream [ 
-	lastTransaction := (aStream next: 8) asInteger.
-
 ]
 
 { #category : #writing }
@@ -185,15 +142,6 @@ SoilSkipListPage >> valueSize: anInteger [
 SoilSkipListPage >> writeHeaderOn: aStream [ 
 	super writeHeaderOn: aStream.
 	aStream nextPutAll: (lastTransaction asByteArrayOfSize: 8)
-
-]
-
-{ #category : #writing }
-SoilSkipListPage >> writeItemsOn: aStream [ 
-	items do: [ :assoc |
-		aStream 
-			nextPutAll: (assoc key asByteArrayOfSize: self keySize);
-			nextPutAll: (assoc value asByteArrayOfSize: self valueSize)].
 
 ]
 


### PR DESCRIPTION
-> move up ivars  'keySize lastTransaction' to the abstract superclass
-> this allows us to share more code

fixes #274