### PR TITLE
595-SoilIndexedDictionary-should-it-have-the-Association-methods

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -266,40 +266,6 @@ SoilIndexedDictionaryTest >> testDoWithTransAction [
 ]
 
 { #category : #tests }
-SoilIndexedDictionaryTest >> testFirstAssociationWithTransaction [
-	| tx tx2 |
-	tx := soil newTransaction.
-	tx root: dict.
-	dict at: #one put: #onevalue.
-	dict at: #two put: #twovalue.
-	tx commit.
-	"open a second transaction ..."
-	tx2 := soil newTransaction.
-	"and test last"
-	self assert: tx2 root firstAssociation value equals: #onevalue.
-
-]
-
-{ #category : #tests }
-SoilIndexedDictionaryTest >> testFirstAssociationWithTransactionRemoved [
-	| tx tx1 tx2 |
-	tx := soil newTransaction.
-	tx root: dict.
-	dict at: #one put: #onevalue.
-	dict at: #two put: #twovalue.
-	tx commit.
-	
-	"open a two transactions ..."
-	tx1 := soil newTransaction.
-	tx2 := soil newTransaction.
-	tx2 root removeKey: #one.
-	tx2 commit.
-	"in tx1 the removed one is not removed"
-	self assert: tx1 root firstAssociation value equals: #onevalue.
-
-]
-
-{ #category : #tests }
 SoilIndexedDictionaryTest >> testFirstWithTransaction [
 	| tx tx2 |
 	tx := soil newTransaction.
@@ -420,40 +386,6 @@ SoilIndexedDictionaryTest >> testIsEmpty [
 ]
 
 { #category : #tests }
-SoilIndexedDictionaryTest >> testLastAssociationWithTransaction [
-	| tx tx2 |
-	tx := soil newTransaction.
-	tx root: dict.
-	dict at: #two put: #twovalue.
-	dict at: #one put: #onevalue.
-	
-	tx commit.
-	"open a second transaction ..."
-	tx2 := soil newTransaction.
-	"and test last, not: key order"
-	self assert: tx2 root lastAssociation value equals: #twovalue
-]
-
-{ #category : #tests }
-SoilIndexedDictionaryTest >> testLastAssociationWithTransactionRemoved [
-	| tx tx1 tx2 |
-	tx := soil newTransaction.
-	tx root: dict.
-	dict at: #one put: #onevalue.
-	dict at: #two put: #twovalue.
-	tx commit.
-	
-	"open a two transactions ..."
-	tx1 := soil newTransaction.
-	tx2 := soil newTransaction.
-	tx2 root removeKey: #two.
-	tx2 commit.
-	"in tx1 the removed one is not removed"
-	self assert: tx1 root lastAssociation value equals: #twovalue.
-
-]
-
-{ #category : #tests }
 SoilIndexedDictionaryTest >> testLastWithTransaction [
 	| tx tx2 |
 	tx := soil newTransaction.
@@ -516,20 +448,6 @@ SoilIndexedDictionaryTest >> testNextAfterWithTransaction [
 	tx2 := soil newTransaction.
 	"and test last"
 	self assert: (tx2 root nextAfter: #one) value equals: #twovalue
-]
-
-{ #category : #tests }
-SoilIndexedDictionaryTest >> testNextAssociationAfterWithTransaction [
-	| tx tx2 |
-	tx := soil newTransaction.
-	tx root: dict.
-	dict at: #one put: #onevalue.
-	dict at: #two put: #twovalue.
-	tx commit.
-	"open a second transaction ..."
-	tx2 := soil newTransaction.
-	"and test last"
-	self assert: (tx2 root nextAssociationAfter: #one) value equals: #twovalue
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -267,6 +267,11 @@ SoilIndexIterator >> next: anInteger [
 ]
 
 { #category : #accessing }
+SoilIndexIterator >> nextAfter: key [
+	^ (self nextAssociationAfter: key) value
+]
+
+{ #category : #accessing }
 SoilIndexIterator >> nextAssociation [
 	"Note: key will be binary key"
 	| nextAssociation nextValue key |

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -92,13 +92,6 @@ SoilIndexedDictionary >> first: anInteger [
 		  self proxyFromByteArray: each ]
 ]
 
-{ #category : #accessing }
-SoilIndexedDictionary >> firstAssociation [
-	"Note: key will be binary key"
-	^ self newIterator firstAssociation ifNotNil: [ :assoc |
-			assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ]
-]
-
 { #category : #testing }
 SoilIndexedDictionary >> hasIndexUpdates [
 	self isRegistered ifFalse: [ ^ true ].
@@ -146,14 +139,6 @@ SoilIndexedDictionary >> last [
 	
 ]
 
-{ #category : #accessing }
-SoilIndexedDictionary >> lastAssociation [
-	"Note: key will be binary key"
-	^ self newIterator lastAssociation ifNotNil: [ :assoc |
-				 assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ] 
-
-]
-
 { #category : #private }
 SoilIndexedDictionary >> loadFrom: aFileReference [ 
 	^ SoilSkipList new 
@@ -177,16 +162,7 @@ SoilIndexedDictionary >> newIterator [
 
 { #category : #accessing }
 SoilIndexedDictionary >> nextAfter: key [  
-	^ (self nextAssociationAfter: key) value  
-
-]
-
-{ #category : #accessing }
-SoilIndexedDictionary >> nextAssociationAfter: key [  
-	"Note: key will be binary key"
-	^ (self newIterator nextAssociationAfter: key)
-		ifNotNil: [ :assoc |
-			assoc key -> (transaction objectWithId: assoc value asSoilObjectId) ]
+	^  self proxyFromByteArray: (self newIterator nextAfter: key) value
 ]
 
 { #category : #private }


### PR DESCRIPTION
As there is never the need to get the index key (and if, we can use the iterator), this PR removes the association based API on the level of the SoilIndexedDictionary:

- remove #firstAssociation, #lastAssociation, #nextAssociationAfter: on the SoilIndexedDictionary
- add #nextAfter: SoilIndexIterator and use it

fixes #595