### PR TITLE
#asIndexKeyOfSize: cleanup

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -291,7 +291,7 @@ SoilBTreeTest >> testPageAddFirst [
 	self assert: index pages size equals: 2.
 	page := index headerPage.
 	self assert: page numberOfItems equals: 1.
-	self assert: page items first key equals: (#foo asIndexKeyOfSize: 8) asInteger.
+	self assert: page items first key equals: (index binaryKey: #foo).
 	"the index page was updated"
 	indexPage := index rootPage.
 	"Index has been updated"
@@ -309,7 +309,7 @@ SoilBTreeTest >> testPageAddFirstAndLoad [
 	self assert: index pages size equals: 2.
 	page := index headerPage.
 	self assert: page numberOfItems equals: 1.
-	self assert: page items first key equals: (#foo asIndexKeyOfSize: 8) asInteger.
+	self assert: page items first key equals: (index binaryKey: #foo).
 	"the index page was updated"
 	indexPage := index rootPage.
 	"Index has been updated"
@@ -323,7 +323,7 @@ SoilBTreeTest >> testPageAddFirstAndLoad [
 		initializeFilesystem;
 		open.
 	
-	self assert: page items first key equals: (#foo asIndexKeyOfSize: 8) asInteger.	
+	self assert: page items first key equals:(index binaryKey: #foo).
 	"load succeeds"
 	self assert: (index at: #foo) equals: #[ 1 2 3 4 5 6 7 8 ].
 

--- a/src/Soil-Core-Tests/SoilSkipListTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListTest.class.st
@@ -137,9 +137,9 @@ SoilSkipListTest >> testAddLastFitting [
 	
 	| page |
 	1 to: 61 do: [ :n | 
-		index at: (n asString asIndexKeyOfSize: 8) put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: (index binaryKey: n asString ) put: #[ 1 2 3 4 5 6 7 8 ] ].
 	self assert: index pages size equals: 1.
-	index at: (63 asString asIndexKeyOfSize: 8) put: #[ 1 2 3 4 5 6 7 8 ].
+	index at: (index binaryKey: 63 asString) put: #[ 1 2 3 4 5 6 7 8 ].
 	self assert: index pages size equals: 1.
 	page := index pageAt: 1.
 	self assert: page numberOfItems equals: 62.
@@ -331,7 +331,7 @@ SoilSkipListTest >> testLastPage [
 { #category : #tests }
 SoilSkipListTest >> testMorePages [
 	1 to: 512 do: [ :n |
-		index at: (n asString asIndexKeyOfSize: 8) put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: (index binaryKey: n asString) put: #[ 1 2 3 4 5 6 7 8 ] ].
 	index writePages.
 	self assert: index pages size equals: 3
 ]
@@ -379,7 +379,7 @@ SoilSkipListTest >> testPageAddFirst [
 	self assert: index pages size equals: 1.
 	page := index firstPage.
 	self assert: page numberOfItems equals: 1.
-	self assert: page items first key equals: (#foo asIndexKeyOfSize: 8) asInteger
+	self assert: page items first key equals: (index binaryKey: #foo)
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/SoilBTreeDictionary.class.st
+++ b/src/Soil-Core/SoilBTreeDictionary.class.st
@@ -30,7 +30,7 @@ SoilBTreeDictionary >> journalEntries [
 			transactionId: transaction writeVersion;
 			segment: segment;
 			id: id;
-			key: (self binaryKey: key);
+			key: (index binaryKey: key);
 			value: value;
 			oldValue: (oldValues at: key ifAbsent: nil)) ].
 	removedValues keysAndValuesDo: [ :key :value |
@@ -39,7 +39,7 @@ SoilBTreeDictionary >> journalEntries [
 			transactionId: transaction writeVersion;
 			segment: segment;
 			id: id;
-			key: (self binaryKey: key); 
+			key: (index binaryKey: key); 
 			oldValue: value) ].
 	^ entries
 ]

--- a/src/Soil-Core/SoilIndex.class.st
+++ b/src/Soil-Core/SoilIndex.class.st
@@ -40,6 +40,11 @@ SoilIndex >> basicAt: key put: anObject [
 		put: anObject 
 ]
 
+{ #category : #accessing }
+SoilIndex >> binaryKey: aString [
+	^ (aString asIndexKeyOfSize: self keySize) asInteger
+]
+
 { #category : #'open/close' }
 SoilIndex >> close [
 	self store close.
@@ -177,7 +182,7 @@ SoilIndex >> removeKey: key ifAbsent: aBlock [
 	page := self newIterator 
 		find: key;
 		currentPage.
-	^ ((index := page indexOfKey: (key asIndexKeyOfSize: self keySize) asInteger) > 0) 
+	^ ((index := page indexOfKey: (self binaryKey: key)) > 0)
 		ifTrue: [ (page itemRemoveIndex: index) value ]
 		ifFalse: [ aBlock value ]
 ]

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -47,10 +47,8 @@ SoilIndexIterator >> at: aKeyObject ifAbsent: aBlock [
 
 { #category : #accessing }
 SoilIndexIterator >> at: aKeyObject put: anObject [
-	| key |
-	key := (aKeyObject asIndexKeyOfSize: index keySize) asInteger.
 	^ self 
-		basicAt: key 
+		basicAt: (index binaryKey: aKeyObject) 
 		put: anObject
 ]
 
@@ -136,7 +134,7 @@ SoilIndexIterator >> find: key [
 
 { #category : #private }
 SoilIndexIterator >> find: key ifAbsent: aBlock [
-	currentKey := (key asIndexKeyOfSize: index keySize) asInteger.
+	currentKey := index binaryKey: key.
 	self findPageFor: currentKey.
 	^ currentPage valueAt: currentKey ifAbsent: aBlock
 ]
@@ -294,7 +292,7 @@ SoilIndexIterator >> nextCloseTo: key [
 SoilIndexIterator >> nextKeyCloseTo: key [
 	"Note: returnrd key will be binary key"
 	| binKey |
-	binKey := (key asIndexKeyOfSize: index keySize) asInteger.
+	binKey := index binaryKey: key.
 	self findPageFor: binKey.
 	nextKey := currentPage keyOrClosestAfter: binKey.
 	^ nextKey

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -64,11 +64,6 @@ SoilIndexedDictionary >> basicAt: aString ifAbsent: aBlock [
 	^ self newIterator at: aString ifAbsent: aBlock
 ]
 
-{ #category : #accessing }
-SoilIndexedDictionary >> binaryKey: aString [
-	^ (aString asIndexKeyOfSize: index keySize) asInteger
-]
-
 { #category : #initialization }
 SoilIndexedDictionary >> createIndex [
 	^ self subclassResponsibility

--- a/src/Soil-Core/SoilSkipListDictionary.class.st
+++ b/src/Soil-Core/SoilSkipListDictionary.class.st
@@ -31,7 +31,7 @@ SoilSkipListDictionary >> journalEntries [
 			transactionId: transaction writeVersion;
 			segment: segment;
 			id: id;
-			key: (self binaryKey: key);
+			key: (index binaryKey: key);
 			value: value;
 			oldValue: (oldValues at: key ifAbsent: nil)) ].
 	removedValues keysAndValuesDo: [ :key :value |
@@ -40,7 +40,7 @@ SoilSkipListDictionary >> journalEntries [
 			transactionId: transaction writeVersion;
 			segment: segment;
 			id: id;
-			key: (self binaryKey: key); 
+			key: (index binaryKey: key); 
 			oldValue: value) ].
 	^ entries
 ]


### PR DESCRIPTION
Instead of having

```
 (aString asIndexKeyOfSize: self keySize) asInteger
```

everywhere, this PR moves #binaryKey: to the index. We can use that to calculate the key with the right length