### PR TITLE
remove nextKeyCloseTo: on the level of  SoilIndexedDictionary

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -533,21 +533,6 @@ SoilIndexedDictionaryTest >> testNextAssociationAfterWithTransaction [
 ]
 
 { #category : #tests }
-SoilIndexedDictionaryTest >> testNextKeyCloseToWithTransaction [
-	| tx tx2 |
-	tx := soil newTransaction.
-	tx root: dict.
-	dict at: 10 put: #one.
-	dict at: 20 put: #two.
-	"self assert: dict last equals: #two."
-	tx commit.
-	"open a second transaction ..."
-	tx2 := soil newTransaction.
-	"and test last"
-	self assert: (tx2 root nextKeyCloseTo: 15) value equals: 20
-]
-
-{ #category : #tests }
 SoilIndexedDictionaryTest >> testNextcloseToWithTransaction [
 	| tx tx2 |
 	tx := soil newTransaction.

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -195,12 +195,6 @@ SoilIndexedDictionary >> nextCloseTo: aKey [
 ]
 
 { #category : #private }
-SoilIndexedDictionary >> nextKeyCloseTo: aKey [
-	"Note: key will be binary key"
-	^ self newIterator nextKeyCloseTo: aKey
-]
-
-{ #category : #private }
 SoilIndexedDictionary >> prepareNewValues [
 	newValues copy keysAndValuesDo: [ :key :object |
 		object isObjectId ifFalse: [


### PR DESCRIPTION
this removes nextKeyCloseTo: from the SoilIndexedDictionary now that we have #nextCloseTo:

This is was last API on SoilIndexedDictionary that exposed indexKeys.

fixes #596