### PR TITLE
remove #nextKeyCloseTo: from SoilIndexedDictionary

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -451,21 +451,6 @@ SoilIndexedDictionaryTest >> testNextAfterWithTransaction [
 ]
 
 { #category : #tests }
-SoilIndexedDictionaryTest >> testNextKeyCloseToWithTransaction [
-	| tx tx2 |
-	tx := soil newTransaction.
-	tx root: dict.
-	dict at: 10 put: #one.
-	dict at: 20 put: #two.
-	"self assert: dict last equals: #two."
-	tx commit.
-	"open a second transaction ..."
-	tx2 := soil newTransaction.
-	"and test last"
-	self assert: (tx2 root nextKeyCloseTo: 15) value equals: 20
-]
-
-{ #category : #tests }
 SoilIndexedDictionaryTest >> testNextcloseToWithTransaction [
 	| tx tx2 |
 	tx := soil newTransaction.

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -166,12 +166,6 @@ SoilIndexedDictionary >> nextCloseTo: aKey [
 ]
 
 { #category : #private }
-SoilIndexedDictionary >> nextKeyCloseTo: aKey [
-	"Note: key will be index key"
-	^ self newIterator nextKeyCloseTo: aKey
-]
-
-{ #category : #private }
 SoilIndexedDictionary >> prepareNewValues [
 	newValues copy keysAndValuesDo: [ :key :object |
 		object isObjectId ifFalse: [


### PR DESCRIPTION
remove #nextKeyCloseTo: from SoilIndexedDictionary, as it returns indedKeys, which is not useful

fixes #596