### PR TITLE
604-Index-values-ObjectID-vs-ByteArray

### DIFF
--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -53,15 +53,6 @@ SoilBTreePage >> readFrom: aStream [
 	self readLastTransactionFrom: aStream
 ]
 
-{ #category : #reading }
-SoilBTreePage >> readItemsFrom: aStream [ 
-	| numberOfItems |
-	numberOfItems := (aStream next: self itemsSizeSize) asInteger.
-	items := SortedCollection new: numberOfItems.
-	numberOfItems timesRepeat: [ 
-		items add: (aStream next: self keySize) asInteger -> (aStream next: self valueSize) ]
-]
-
 { #category : #private }
 SoilBTreePage >> split: newPage [
 	| middle |

--- a/src/Soil-Core/SoilBackupVisitor.class.st
+++ b/src/Soil-Core/SoilBackupVisitor.class.st
@@ -44,7 +44,7 @@ SoilBackupVisitor >> copyIndexAt: indexId segment: segmentId [
 		assoc value isRemoved ifFalse: [ 
 			targetIndex basicAt: assoc key put: assoc value.
 			"recurse further into the values of the index"
-			self process: assoc value ] ].
+			self process: assoc value asSoilObjectId ] ].
 	targetIndex
 		flush; 
 		close.

--- a/src/Soil-Core/SoilIndexItemsPage.class.st
+++ b/src/Soil-Core/SoilIndexItemsPage.class.st
@@ -210,7 +210,7 @@ SoilIndexItemsPage >> readItemsFrom: aStream [
 	numberOfItems := (aStream next: self itemsSizeSize) asInteger.
 	items := SortedCollection new: numberOfItems.
 	numberOfItems timesRepeat: [ 
-		items add: ((aStream next: self keySize) asInteger -> (aStream next: self valueSize) asSoilObjectId) ]
+		items add: ((aStream next: self keySize) asInteger -> (aStream next: self valueSize) ) ]
 ]
 
 { #category : #writing }


### PR DESCRIPTION
When reading an index page from disk, we do not have to create a Soil ObjectId for every value of the page.

- the index should be usable for values that are *not* IDs (see the tests, they use that all the time)
- We only need to convert the bytearray (that is a serialized ID) into a a real ID when we actually use the index for a SoilIndexedDictionary, and even then we only need the ID if we want to read the value

This PR thus
- makes SkipList usable to store non-ID values
- of the 64 instantiations of an OD, an access just needs one. Thus this should result in less memory used and faster speed

fixes #604