### PR TITLE
Trivial: categories in tests and add tests for two methods

### DIFF
--- a/src/Soil-Core-Tests/SoilBackupTest.class.st
+++ b/src/Soil-Core-Tests/SoilBackupTest.class.st
@@ -7,7 +7,7 @@ Class {
 	#category : #'Soil-Core-Tests'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SoilBackupTest >> backupPath [
 	^ 'soil-backup'
 ]

--- a/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
+++ b/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
@@ -13,7 +13,7 @@ SoilDatabaseJournalTest class >> classUnderTest [
 	^ SoilPersistentDatabaseJournal 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #running }
 SoilDatabaseJournalTest >> fillDatabase [ 
 	| tx dict |
 	tx := soil newTransaction.

--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -447,7 +447,9 @@ SoilIndexedDictionaryTest >> testNextAfterWithTransaction [
 	"open a second transaction ..."
 	tx2 := soil newTransaction.
 	"and test last"
-	self assert: (tx2 root nextAfter: #one) value equals: #twovalue
+	self assert: (tx2 root nextAfter: #one) equals: #twovalue.
+	"test #nextAssociationAfter: on the iterator here, too"
+	self assert: (tx2 proxyForObjectId: (tx2 root newIterator nextAssociationAfter: #one) value) equals: #twovalue
 ]
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilObjectSegmentTest.class.st
+++ b/src/Soil-Core-Tests/SoilObjectSegmentTest.class.st
@@ -1,10 +1,6 @@
 Class {
 	#name : #SoilObjectSegmentTest,
 	#superclass : #TestCase,
-	#instVars : [
-		'reference',
-		'label'
-	],
 	#category : #'Soil-Core-Tests'
 }
 

--- a/src/Soil-Core/SoilFindRecordsVisitor.class.st
+++ b/src/Soil-Core/SoilFindRecordsVisitor.class.st
@@ -36,7 +36,7 @@ SoilFindRecordsVisitor >> records [
 	^ records
 ]
 
-{ #category : #accessing }
+{ #category : #api }
 SoilFindRecordsVisitor >> returnFirst [
 
 	numberOfRecords := 1

--- a/src/Soil-Core/SoilObjectSegment.class.st
+++ b/src/Soil-Core/SoilObjectSegment.class.st
@@ -110,10 +110,11 @@ SoilObjectSegment >> id: anObject [
 ]
 
 { #category : #accessing }
-SoilObjectSegment >> indexAt: indexId [ 
-	^ self indexManager 
-		at: indexId 
-		ifAbsent: [ SoilIndexNotFound signal: 'index not found' ] 
+SoilObjectSegment >> indexAt: indexId [
+
+	^ self
+		  indexAt: indexId
+		  ifAbsent: [ SoilIndexNotFound signal: 'index not found' ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- some recategorization
- use the (now usused) #indexAt:ifAbsent: in SoilObjectSegment>>#indexAt:
- add test for #nextAssociationAfter: on the index level now that #nextAfter: does not use it