### PR TITLE
Small cleanup: fix #halt SoilIndexConsistencyVisitor 

### DIFF
--- a/src/Soil-Core/SoilIndexConsistencyVisitor.class.st
+++ b/src/Soil-Core/SoilIndexConsistencyVisitor.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SoilIndexConsistencyVisitor,
 	#superclass : #SoilInstanceVisitor,
-	#category : #'Soil-Core-Model'
+	#category : #'Soil-Core-Visitor'
 }
 
 { #category : #api }
@@ -17,5 +17,5 @@ SoilIndexConsistencyVisitor >> visitPagedFileIndexStore: aSoilPagedFileIndexStor
 	1 to: numberOfPages do: [ :pageIndex | | page |
 		page := aSoilPagedFileIndexStore pageAt: pageIndex.
 		(page right allSatisfy: #isZero) ifTrue: [ 
-			(page index = numberOfPages)  ifFalse: [ self halt ] ] ]
+			(page index = numberOfPages)  ifFalse: [ Error signal: 'Index consistency check failed ' ] ] ]
 ]

--- a/src/Soil-Core/SoilJournalConsistencyVisitor.class.st
+++ b/src/Soil-Core/SoilJournalConsistencyVisitor.class.st
@@ -26,7 +26,7 @@ SoilJournalConsistencyVisitor >> verifyDatabaseVersion: aSoilTransactionJournal 
 	"after initialization the database version should always be 
 	one larger than the one before"
 	(entry value = (databaseVersion + 1)) ifFalse: [ 
-		Error signal: 'nope' ].
+		Error signal: 'Journal consistency check failed: #verifyDatabaseVersion:' ].
 	databaseVersion := entry value
 ]
 
@@ -42,7 +42,7 @@ SoilJournalConsistencyVisitor >> verifyObjectIndexes: aSoilTransactionJournal [
 				at: entry objectId segment 
 				ifAbsentPut: [ entry objectId index - 1].
 			(newIndex >= oldIndex) ifFalse: [ 
-				Error signal: 'nope' ].
+				Error signal: 'Index consistency check failed: #verifyObjectIndexes:' ].
 			segments 
 				at: entry objectId segment
 				put: newIndex ]

--- a/src/Soil-Core/SoilJournalConsistencyVisitor.class.st
+++ b/src/Soil-Core/SoilJournalConsistencyVisitor.class.st
@@ -42,7 +42,7 @@ SoilJournalConsistencyVisitor >> verifyObjectIndexes: aSoilTransactionJournal [
 				at: entry objectId segment 
 				ifAbsentPut: [ entry objectId index - 1].
 			(newIndex >= oldIndex) ifFalse: [ 
-				Error signal: 'Index consistency check failed: #verifyObjectIndexes:' ].
+				Error signal: 'Journal consistency check failed: #verifyObjectIndexes:' ].
 			segments 
 				at: entry objectId segment
 				put: newIndex ]


### PR DESCRIPTION
- SoilIndexConsistencyVisitor better uses Error instead of halt (like SoilJournalConsistencyVisitor)
- make sure to have the error be descriptive

This can be improved furhter later as needed (e.g. at some point we could introduce special errors)