### PR TITLE
626-SoilBTreeHeaderPagereadFrom--should-call-super

### DIFF
--- a/src/Soil-Core/SoilAbstractBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilAbstractBTreeDataPage.class.st
@@ -27,6 +27,13 @@ SoilAbstractBTreeDataPage >> find: aKey with: aBTree [
 
 ]
 
+{ #category : #utilities }
+SoilAbstractBTreeDataPage >> headerSize [
+	^ super headerSize  
+		+ self pointerSize "next"
+		+ 2 "items size"
+]
+
 { #category : #initialization }
 SoilAbstractBTreeDataPage >> initialize [ 
 	super initialize.

--- a/src/Soil-Core/SoilAbstractBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilAbstractBTreeDataPage.class.st
@@ -1,0 +1,97 @@
+"
+As a B+Tree, the SoilBTree has data only in the leaves, which are all instances of SoilBTreeDataPage.
+
+The data pages form a linked list and can be traversed fast in the direction of the next page. 
+
+There are two subclasses: one for the hearder, one for the following data pages
+"
+Class {
+	#name : #SoilAbstractBTreeDataPage,
+	#superclass : #SoilBTreePage,
+	#instVars : [
+		'next',
+		'valueSize'
+	],
+	#category : #'Soil-Core-Index-BTree'
+}
+
+{ #category : #testing }
+SoilAbstractBTreeDataPage class >> isAbstract [
+
+	^ self == SoilAbstractBTreeDataPage
+]
+
+{ #category : #private }
+SoilAbstractBTreeDataPage >> find: aKey with: aBTree [
+	^ self
+
+]
+
+{ #category : #initialization }
+SoilAbstractBTreeDataPage >> initialize [ 
+	super initialize.
+	"0 means this is the last page"
+	next := 0
+]
+
+{ #category : #adding }
+SoilAbstractBTreeDataPage >> insertItem: anItem for: iterator [
+
+	| newPage pageWithItem return |
+
+	return := SoilBTreeReturnWrapper new returnValue: ((self associationAt: anItem key ifAbsent: nil) ifNotNil: [:item | item value]).
+	self addItem: anItem.
+	self hasRoom ifTrue: [  iterator currentPage: self. ^ return ].
+	"We have to split"
+	newPage := iterator index splitPage: self.
+	"newPage is the one with the small values"
+	pageWithItem := ((self smallestKey > anItem key)
+						ifTrue: [ newPage ]
+						ifFalse: [ self ]).
+	iterator currentPage: pageWithItem.
+	"we need to add the new page to the index above"
+	^ return indexEntry: (newPage smallestKey -> newPage index)
+]
+
+{ #category : #testing }
+SoilAbstractBTreeDataPage >> isLastPage [
+	^ next == 0
+]
+
+{ #category : #accessing }
+SoilAbstractBTreeDataPage >> next [
+	^next
+]
+
+{ #category : #accessing }
+SoilAbstractBTreeDataPage >> next: anInteger [
+	next := anInteger
+]
+
+{ #category : #accessing }
+SoilAbstractBTreeDataPage >> nextPageIn: btree [
+	^btree pageAt: next
+]
+
+{ #category : #reading }
+SoilAbstractBTreeDataPage >> readFrom: aStream [
+	super readFrom: aStream.
+	next := (aStream next: self pointerSize) asInteger
+]
+
+{ #category : #accessing }
+SoilAbstractBTreeDataPage >> valueSize [ 
+	^ valueSize
+]
+
+{ #category : #accessing }
+SoilAbstractBTreeDataPage >> valueSize: anInteger [ 
+	valueSize := anInteger 
+]
+
+{ #category : #writing }
+SoilAbstractBTreeDataPage >> writeHeaderOn: aStream [ 
+	super writeHeaderOn: aStream.
+	aStream
+		nextPutAll: (next asByteArrayOfSize: self pointerSize)
+]

--- a/src/Soil-Core/SoilBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilBTreeDataPage.class.st
@@ -12,13 +12,6 @@ SoilBTreeDataPage class >> pageCode [
 	^ 4
 ]
 
-{ #category : #utilities }
-SoilBTreeDataPage >> headerSize [
-	^ super headerSize  
-		+ self pointerSize "next"
-		+ 2 "items size"
-]
-
 { #category : #reading }
 SoilBTreeDataPage >> readFrom: aStream [ 
 	super readFrom: aStream.

--- a/src/Soil-Core/SoilBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilBTreeDataPage.class.st
@@ -1,31 +1,15 @@
 "
-As a B+Tree, the SoilBTree has data only in the leaves, which are all instances of SoilBTreeDataPage.
-
-The data pages form a linked list and can be traversed fast in the direction of the next page. 
-
-There is a special subclass for the first page (the header).
-
-
+This is a special subclass for all data pages but the first. See superclass comment for more infos
 "
 Class {
 	#name : #SoilBTreeDataPage,
-	#superclass : #SoilBTreePage,
-	#instVars : [
-		'next',
-		'valueSize'
-	],
+	#superclass : #SoilAbstractBTreeDataPage,
 	#category : #'Soil-Core-Index-BTree'
 }
 
 { #category : #accessing }
 SoilBTreeDataPage class >> pageCode [ 
 	^ 4
-]
-
-{ #category : #private }
-SoilBTreeDataPage >> find: aKey with: aBTree [
-	^ self
-
 ]
 
 { #category : #utilities }
@@ -35,79 +19,9 @@ SoilBTreeDataPage >> headerSize [
 		+ 2 "items size"
 ]
 
-{ #category : #initialization }
-SoilBTreeDataPage >> initialize [ 
-	super initialize.
-	"0 means this is the last page"
-	next := 0
-]
-
-{ #category : #adding }
-SoilBTreeDataPage >> insertItem: anItem for: iterator [
-
-	| newPage pageWithItem return |
-
-	return := SoilBTreeReturnWrapper new returnValue: ((self associationAt: anItem key ifAbsent: nil) ifNotNil: [:item | item value]).
-	self addItem: anItem.
-	self hasRoom ifTrue: [  iterator currentPage: self. ^ return ].
-	"We have to split"
-	newPage := iterator index splitPage: self.
-	"newPage is the one with the small values"
-	pageWithItem := ((self smallestKey > anItem key)
-						ifTrue: [ newPage ]
-						ifFalse: [ self ]).
-	iterator currentPage: pageWithItem.
-	"we need to add the new page to the index above"
-	^ return indexEntry: (newPage smallestKey -> newPage index)
-]
-
-{ #category : #testing }
-SoilBTreeDataPage >> isLastPage [
-	^ next == 0
-]
-
-{ #category : #accessing }
-SoilBTreeDataPage >> next [
-	^next
-]
-
-{ #category : #accessing }
-SoilBTreeDataPage >> next: anInteger [
-	next := anInteger
-]
-
-{ #category : #accessing }
-SoilBTreeDataPage >> nextPageIn: btree [
-	^btree pageAt: next
-]
-
-{ #category : #'reading-writing' }
+{ #category : #reading }
 SoilBTreeDataPage >> readFrom: aStream [ 
 	super readFrom: aStream.
-	self 
-		readNextFrom: aStream;
+	self
 		readItemsFrom: aStream
-]
-
-{ #category : #'reading-writing' }
-SoilBTreeDataPage >> readNextFrom: aStream [
-	
-	next := (aStream next: self pointerSize) asInteger.
-]
-
-{ #category : #accessing }
-SoilBTreeDataPage >> valueSize [ 
-	^ valueSize
-]
-
-{ #category : #accessing }
-SoilBTreeDataPage >> valueSize: anInteger [ 
-	valueSize := anInteger 
-]
-
-{ #category : #'reading-writing' }
-SoilBTreeDataPage >> writeHeaderOn: aStream [ 
-	super writeHeaderOn: aStream.
-	aStream
-		nextPutAll: (next asByteArrayOfSize: self pointerSize)
 ]

--- a/src/Soil-Core/SoilBTreeHeaderPage.class.st
+++ b/src/Soil-Core/SoilBTreeHeaderPage.class.st
@@ -9,7 +9,8 @@ Class {
 	#name : #SoilBTreeHeaderPage,
 	#superclass : #SoilAbstractBTreeDataPage,
 	#instVars : [
-		'lastPageIndex'
+		'lastPageIndex',
+		'lastFreePageIndex'
 	],
 	#category : #'Soil-Core-Index-BTree'
 }
@@ -25,7 +26,19 @@ SoilBTreeHeaderPage >> headerSize [
 		+ 2 "valueSize"
 		+ 2 "keySize"
 		+ self pointerSize "lastPageIndex"
-		
+		+ self pointerSize "lastFreePageIndex"
+]
+
+{ #category : #initialization }
+SoilBTreeHeaderPage >> initialize [ 
+	super initialize.
+	lastFreePageIndex := 0
+]
+
+{ #category : #accessing }
+SoilBTreeHeaderPage >> lastFreePageIndex: anObject [
+
+	lastFreePageIndex := anObject
 ]
 
 { #category : #accessing }
@@ -57,6 +70,7 @@ SoilBTreeHeaderPage >> readFrom: aStream [
 	keySize := (aStream next: 2) asInteger.
 	valueSize := (aStream next: 2) asInteger.
 	lastPageIndex :=(aStream next: self pointerSize) asInteger.
+	lastFreePageIndex :=(aStream next: 4) asInteger.
 	self readItemsFrom: aStream
 ]
 
@@ -66,5 +80,6 @@ SoilBTreeHeaderPage >> writeHeaderOn: aStream [
 	aStream
 		nextPutAll: (keySize asByteArrayOfSize: 2);
 		nextPutAll: (valueSize asByteArrayOfSize: 2);
-		nextPutAll: (lastPageIndex asByteArrayOfSize: self pointerSize)
+		nextPutAll: (lastPageIndex asByteArrayOfSize: self pointerSize);
+		nextPutAll: (lastFreePageIndex asByteArrayOfSize: 4)
 ]

--- a/src/Soil-Core/SoilBTreeHeaderPage.class.st
+++ b/src/Soil-Core/SoilBTreeHeaderPage.class.st
@@ -7,7 +7,7 @@ It is easily accessible via #headerPage on the BTree index
 "
 Class {
 	#name : #SoilBTreeHeaderPage,
-	#superclass : #SoilBTreeDataPage,
+	#superclass : #SoilAbstractBTreeDataPage,
 	#instVars : [
 		'lastPageIndex'
 	],
@@ -51,13 +51,9 @@ SoilBTreeHeaderPage >> printOn: aStream [
 	aStream << 'header page : #' << index asString
 ]
 
-{ #category : #writing }
+{ #category : #reading }
 SoilBTreeHeaderPage >> readFrom: aStream [ 
-	dirty := false.
-	"we do not read the pageCode, that was done before"
-	version := aStream next.
-	self readLastTransactionFrom: aStream.
-	self readNextFrom: aStream.
+	super readFrom: aStream.
 	keySize := (aStream next: 2) asInteger.
 	valueSize := (aStream next: 2) asInteger.
 	lastPageIndex :=(aStream next: self pointerSize) asInteger.

--- a/src/Soil-Core/SoilBTreeIndexPage.class.st
+++ b/src/Soil-Core/SoilBTreeIndexPage.class.st
@@ -65,13 +65,13 @@ SoilBTreeIndexPage >> printOn: aStream [
 	aStream << 'index page : #' << index asString
 ]
 
-{ #category : #'reading-writing' }
+{ #category : #reading }
 SoilBTreeIndexPage >> readFrom: aStream [ 
 	super readFrom: aStream.
 	self readItemsFrom: aStream
 ]
 
-{ #category : #'reading-writing' }
+{ #category : #reading }
 SoilBTreeIndexPage >> readItemsFrom: aStream [ 
 	| numberOfItems |
 	

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -61,6 +61,7 @@ SoilBasicBTree >> newHeaderPage [
 	^ SoilBTreeHeaderPage new
 		index: 1;
 		lastPageIndex: 2;
+		lastFreePageIndex: 0;
 		pageSize: self pageSize
 ]
 

--- a/src/Soil-Core/SoilIndexPage.class.st
+++ b/src/Soil-Core/SoilIndexPage.class.st
@@ -100,7 +100,7 @@ SoilIndexPage >> printOn: aStream [
 	aStream << 'page : #' << index asString
 ]
 
-{ #category : #writing }
+{ #category : #reading }
 SoilIndexPage >> readFrom: aStream [ 
 	dirty := false.
 	"we do not read the pageCode here as it was read already"

--- a/src/Soil-Core/SoilSkipListDataPage.class.st
+++ b/src/Soil-Core/SoilSkipListDataPage.class.st
@@ -20,7 +20,7 @@ SoilSkipListDataPage >> headerSize [
 		+ 2 "items size"
 ]
 
-{ #category : #'instance creation' }
+{ #category : #reading }
 SoilSkipListDataPage >> readFrom: aStream [ 
 	super readFrom: aStream.
 	self 

--- a/src/Soil-Core/SoilSkipListHeaderPage.class.st
+++ b/src/Soil-Core/SoilSkipListHeaderPage.class.st
@@ -99,7 +99,7 @@ SoilSkipListHeaderPage >> nextPageIndex [
 	^ lastPageIndex 
 ]
 
-{ #category : #'instance creation' }
+{ #category : #reading }
 SoilSkipListHeaderPage >> readFrom: aStream [ 
 	super readFrom: aStream.
 	self 
@@ -108,7 +108,7 @@ SoilSkipListHeaderPage >> readFrom: aStream [
 		readItemsFrom: aStream
 ]
 
-{ #category : #'instance creation' }
+{ #category : #reading }
 SoilSkipListHeaderPage >> readHeaderFrom: aStream [
 	keySize := (aStream next: 2) asInteger.
 	valueSize := (aStream next: 2) asInteger.

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -80,13 +80,13 @@ SoilSkipListPage >> postCopy [
 	right := right copy
 ]
 
-{ #category : #'instance creation' }
+{ #category : #reading }
 SoilSkipListPage >> readFrom: aStream [ 
 	super readFrom: aStream.
 	self readLastTransactionFrom: aStream
 ]
 
-{ #category : #writing }
+{ #category : #reading }
 SoilSkipListPage >> readLevelsFrom: aStream [ 
 	| level |
 	level := aStream next asInteger.


### PR DESCRIPTION
add SoilAbstractBTreeDataPage, this way the two subclasses can implemnent reading/writing in a simpler way (and re-use the code of SoilIndexPage)

fixes #626