### PR TITLE
90-Serializing-methods-that-reference-Smalltalk

### DIFF
--- a/src/Soil-Serializer-Tests/SoilPrimitiveSerializationTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilPrimitiveSerializationTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#pools : [
 		'SoilTypeCodes'
 	],
-	#category : 'Soil-Serializer-Tests'
+	#category : #'Soil-Serializer-Tests'
 }
 
 { #category : #'instance creation' }
@@ -604,6 +604,19 @@ SoilPrimitiveSerializationTest >> testSerializationSmallFloat64ZeroAndOne [
 	self assert: materialized class equals: SmallFloat64.
 	self assert: materialized identicalTo: float.
 	self assert: materialized identicalTo: Float negativeZero.
+]
+
+{ #category : #tests }
+SoilPrimitiveSerializationTest >> testSerializationSmalltalkImage [
+
+	| object serialized materialized |
+	object := Smalltalk.
+	serialized := SoilSerializer serializeToBytes: object.
+	self assert: serialized equals: #[ 55 ].
+	self assert: (serialized at: 1) equals: TypeCodeSmalltalkImage.
+
+	materialized := SoilMaterializer materializeFromBytes: serialized.
+	self assert: materialized identicalTo: Smalltalk
 ]
 
 { #category : #tests }

--- a/src/Soil-Serializer/SmalltalkImage.extension.st
+++ b/src/Soil-Serializer/SmalltalkImage.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #SmalltalkImage }
+
+{ #category : #'*Soil-Serializer' }
+SmalltalkImage >> soilBasicSerialize: serializer [
+
+	serializer nextPutSmalltalkImage: self
+]
+
+{ #category : #'*Soil-Serializer' }
+SmalltalkImage >> soilSerialize: serializer [
+	"registration not needed, as we always return the current Smalltalk value on read"
+	self soilBasicSerialize: serializer
+]

--- a/src/Soil-Serializer/SoilSerializer.class.st
+++ b/src/Soil-Serializer/SoilSerializer.class.st
@@ -151,6 +151,11 @@ SoilSerializer >> nextPutProcessorScheduler: aProcessorScheduler [
 ]
 
 { #category : #writing }
+SoilSerializer >> nextPutSmalltalkImage: aCollection [ 
+	self nextPutByte: TypeCodeSmalltalkImage
+]
+
+{ #category : #writing }
 SoilSerializer >> nextPutSystemDictionary: aCollection [ 
 	self nextPutByte: TypeCodeSystemDictionary 
 ]

--- a/src/Soil-Serializer/SoilTypeCodes.class.st
+++ b/src/Soil-Serializer/SoilTypeCodes.class.st
@@ -25,6 +25,7 @@ Class {
 		'TypeCodePositiveInteger',
 		'TypeCodeProcessScheduler',
 		'TypeCodeScaledDecimal',
+		'TypeCodeSmalltalkImage',
 		'TypeCodeString',
 		'TypeCodeSymbol',
 		'TypeCodeSystemDictionary',
@@ -76,6 +77,7 @@ SoilTypeCodes class >> initializeTypeCodeMapping [
 		at: TypeCodeCompiledBlock  			put: CompiledBlock;
 		at: TypeCodeCompiledMethod 			put: CompiledMethod;
 		at: TypeCodeSystemDictionary 		put: Smalltalk globals;
+		at: TypeCodeSmalltalkImage 			put: Smalltalk;
 		at: TypeCodeProcessScheduler  		put: Processor;
 		at: TypeCodeUUID   					put: UUID;
 		at: TypeCodeInternalReference 		put: [ :materializer | materializer nextInternalReference ];
@@ -117,6 +119,7 @@ SoilTypeCodes class >> initializeTypeCodes [
 	TypeCodeSystemDictionary := 52.
 	TypeCodeProcessScheduler := 53.
 	TypeCodeUUID := 54.
+	TypeCodeSmalltalkImage := 55.
 
 	TypeCodeInternalReference := 65.
 	TypeCodeExternalReference := 66.


### PR DESCRIPTION
This PR adds a TypeCode for Smalltalk. This is needed as we can serialize methods, but these can use "Smaltalk", as SmalltalkImage in turn points to a Process, we get an error.

(and the de-serialized Smalltalk image instance makes no sense in the context of the image state).

fixes #90