### PR TITLE
Replay journal on open

### DIFF
--- a/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
+++ b/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
@@ -14,6 +14,14 @@ SoilDatabaseJournalTest class >> classUnderTest [
 ]
 
 { #category : #running }
+SoilDatabaseJournalTest >> addDictionaryRoot [ 
+	| tx |
+	tx := soil newTransaction.
+	tx root: Dictionary new.
+	tx commit
+]
+
+{ #category : #running }
 SoilDatabaseJournalTest >> fillDatabase [ 
 	| tx dict |
 	tx := soil newTransaction.
@@ -44,6 +52,24 @@ SoilDatabaseJournalTest >> fillDatabase [
 	
 ]
 
+{ #category : #tests }
+SoilDatabaseJournalTest >> modifyDictionaryRootEntry [
+	| txn record newRecord |
+	txn := soil newTransaction.
+	record := (txn recordWithId: SoilObjectId root)
+		transaction: txn;
+		materializeObject;
+		yourself.
+	record object at: #foo put: #bar.
+	newRecord := record asNewClusterVersion
+		version: 1;
+		serializeObject;
+		yourself.
+	^ newRecord asJournalEntry first
+				transactionId: 1;
+				yourself
+]
+
 { #category : #initialization }
 SoilDatabaseJournalTest >> setUp [ 
 	super setUp.
@@ -66,6 +92,29 @@ SoilDatabaseJournalTest >> testRecoverWithAtEnd [
 	soil close.
 	soil open.
 	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 28) 
+	
+]
+
+{ #category : #tests }
+SoilDatabaseJournalTest >> testRecoverWithIncompleteTransactionJournal [	
+	| newJournal |
+	self addDictionaryRoot.
+	newJournal := SoilTransactionJournal new.
+	newJournal 
+		addEntry: (SoilBeginTransactionEntry new
+			readVersion: 0; 
+			transactionId: 1;
+			createdAt: DateAndTime now);
+		addEntry: self modifyDictionaryRootEntry.
+	soil journal writeTransactionJournal: newJournal.
+	soil journal currentFragmentFile stream 
+		nextPutAll: #( 1 2 3 4 );
+		flush.
+	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 86).
+	soil close.
+	soil open.
+	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 1 offset: 28) 
+	
 	
 ]
 
@@ -101,7 +150,7 @@ SoilDatabaseJournalTest >> testRecoverWithRemainingBytes [
 	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 28).
 	soil close.
 	soil open.
-	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 61) 
+	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 1 offset: 28) 
 	
 	
 ]
@@ -130,22 +179,34 @@ SoilDatabaseJournalTest >> testRecoverWithRemainingJournal [
 
 { #category : #tests }
 SoilDatabaseJournalTest >> testRecoverWithRemainingJournalAndBytes [
-	| newJournal |
-	
+	| newJournal txn |
+	self addDictionaryRoot.
 	newJournal := SoilTransactionJournal new.
-	newJournal addEntry: (SoilBeginTransactionEntry new
-		readVersion: 0; 
-		transactionId: 1;
-		createdAt: DateAndTime now).
-	newJournal addEntry: (SoilCommitTransactionEntry new 
-		transactionId: 1;
-		committedAt: DateAndTime now;
-		yourself).
+	newJournal 
+		addEntry: (SoilBeginTransactionEntry new
+			readVersion: 0; 
+			transactionId: 1;
+			createdAt: DateAndTime now);
+		addEntry: self modifyDictionaryRootEntry;
+		addEntry: (SoilCommitTransactionEntry new 
+			transactionId: 1;
+			committedAt: DateAndTime now;
+			yourself).
 	soil journal writeTransactionJournal: newJournal.
-	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 28).
+	"put bogus bytes after the journal"
+	soil journal currentFragmentFile stream 
+		nextPutAll: #( 1 2 3 4 );
+		flush.
+	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 86).
 	soil close.
 	soil open.
-	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 61) 
+	"the fragment file should have advanced to a new file so the truncated bytes are the rest of
+	the old file which can be skipped in future reads"
+	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 1 offset: 28).
+	"the change of the replayed transaction should be visible now"
+	txn := soil newTransaction. 
+	[ self assert: (txn root at: #foo) equals: #bar  ]
+		ensure: [ txn abort ]
 	
 	
 ]

--- a/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
+++ b/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
@@ -87,12 +87,49 @@ SoilDatabaseJournalTest >> testRecoverWithJournalAndCheckpoint [
 	soil journal writeTransactionJournal: newJournal.
 	soil close.
 	soil open.
+	"we have now two entries checkpoint at the end but that is to be expected"
+	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 72) 
+	
+]
+
+{ #category : #tests }
+SoilDatabaseJournalTest >> testRecoverWithRemainingBytes [
+	
+	soil journal currentFragmentFile stream 
+		nextPutAll: #( 1 2 3 4 );
+		flush.
+	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 28).
+	soil close.
+	soil open.
 	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 61) 
+	
 	
 ]
 
 { #category : #tests }
 SoilDatabaseJournalTest >> testRecoverWithRemainingJournal [
+	| newJournal |
+	
+	newJournal := SoilTransactionJournal new.
+	newJournal addEntry: (SoilBeginTransactionEntry new
+		readVersion: 0; 
+		transactionId: 1;
+		createdAt: DateAndTime now).
+	newJournal addEntry: (SoilCommitTransactionEntry new 
+		transactionId: 1;
+		committedAt: DateAndTime now;
+		yourself).
+	soil journal writeTransactionJournal: newJournal.
+	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 28).
+	soil close.
+	soil open.
+	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 61) 
+	
+	
+]
+
+{ #category : #tests }
+SoilDatabaseJournalTest >> testRecoverWithRemainingJournalAndBytes [
 	| newJournal |
 	
 	newJournal := SoilTransactionJournal new.

--- a/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
+++ b/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
@@ -75,7 +75,9 @@ SoilDatabaseJournalTest >> setUp [
 	super setUp.
 	soil := (Soil path: 'soil-tests')
 		destroy;
-		initializeFilesystem
+		initializeFilesystem;
+		close;
+		open
 ]
 
 { #category : #running }

--- a/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
+++ b/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
@@ -62,6 +62,28 @@ SoilDatabaseJournalTest >> tearDown [
 ]
 
 { #category : #tests }
+SoilDatabaseJournalTest >> testRecoverWithNormalEnd [
+	| newJournal |
+	
+	newJournal := SoilTransactionJournal new.
+	newJournal addEntry: (SoilBeginTransactionEntry new
+		readVersion: 0; 
+		transactionId: 1;
+		createdAt: DateAndTime now).
+	newJournal addEntry: (SoilCommitTransactionEntry new 
+		transactionId: 1;
+		committedAt: DateAndTime now;
+		yourself).
+	newJournal addEntry: (SoilCheckpointEntry new
+		previousCheckpoint: soil control checkpoint).
+	soil journal writeTransactionJournal: newJournal.
+	soil close.
+	soil open.
+	self assert: soil control checkpoint equals: nil 
+	
+]
+
+{ #category : #tests }
 SoilDatabaseJournalTest >> testReplicationToEmptyDatabase [
 	| tx |
 	self fillDatabase. 

--- a/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
+++ b/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
@@ -62,7 +62,15 @@ SoilDatabaseJournalTest >> tearDown [
 ]
 
 { #category : #tests }
-SoilDatabaseJournalTest >> testRecoverWithNormalEnd [
+SoilDatabaseJournalTest >> testRecoverWithAtEnd [
+	soil close.
+	soil open.
+	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 28) 
+	
+]
+
+{ #category : #tests }
+SoilDatabaseJournalTest >> testRecoverWithJournalAndCheckpoint [
 	| newJournal |
 	
 	newJournal := SoilTransactionJournal new.
@@ -79,7 +87,29 @@ SoilDatabaseJournalTest >> testRecoverWithNormalEnd [
 	soil journal writeTransactionJournal: newJournal.
 	soil close.
 	soil open.
-	self assert: soil control checkpoint equals: nil 
+	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 61) 
+	
+]
+
+{ #category : #tests }
+SoilDatabaseJournalTest >> testRecoverWithRemainingJournal [
+	| newJournal |
+	
+	newJournal := SoilTransactionJournal new.
+	newJournal addEntry: (SoilBeginTransactionEntry new
+		readVersion: 0; 
+		transactionId: 1;
+		createdAt: DateAndTime now).
+	newJournal addEntry: (SoilCommitTransactionEntry new 
+		transactionId: 1;
+		committedAt: DateAndTime now;
+		yourself).
+	soil journal writeTransactionJournal: newJournal.
+	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 28).
+	soil close.
+	soil open.
+	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 61) 
+	
 	
 ]
 

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -286,6 +286,7 @@ Soil >> open [
 	journal := SoilPersistentDatabaseJournal new
 		soil: self;
 		open;
+		recover;
 		yourself.
 	notificationHandler := SoilNotificationHandler new
 		soil: self

--- a/src/Soil-Core/SoilBackupVisitor.class.st
+++ b/src/Soil-Core/SoilBackupVisitor.class.st
@@ -81,7 +81,8 @@ SoilBackupVisitor >> visitControl: aSoilControlFile [
 	target control 
 		databaseFormatVersion: aSoilControlFile databaseFormatVersion;
 		databaseVersion: aSoilControlFile databaseVersion;
-		applicationVersion: aSoilControlFile applicationVersion
+		applicationVersion: aSoilControlFile applicationVersion;
+		checkpoint: aSoilControlFile checkpoint
 ]
 
 { #category : #visiting }

--- a/src/Soil-Core/SoilCheckpointEntry.class.st
+++ b/src/Soil-Core/SoilCheckpointEntry.class.st
@@ -63,6 +63,15 @@ SoilCheckpointEntry >> previousCheckpoint: anObject [
 	previousCheckpoint := anObject 
 ]
 
+{ #category : #printing }
+SoilCheckpointEntry >> printOn: aStream [ 
+	aStream 
+		<< 'checkpointed at: ' 
+		<< checkpointedAt printString 
+		<< ', previous: '
+		<< previousCheckpoint printString
+]
+
 { #category : #'instance creation' }
 SoilCheckpointEntry >> readFrom: aStream [ 
 	super readFrom: aStream.

--- a/src/Soil-Core/SoilDatabaseIsInconsistent.class.st
+++ b/src/Soil-Core/SoilDatabaseIsInconsistent.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #SoilDatabaseIsInconsistent,
+	#superclass : #SoilError,
+	#category : #'Soil-Core-Error'
+}

--- a/src/Soil-Core/SoilDatabaseRecovery.class.st
+++ b/src/Soil-Core/SoilDatabaseRecovery.class.st
@@ -4,9 +4,7 @@ Class {
 	#instVars : [
 		'soil',
 		'journal',
-		'lsn',
-		'beginLSN',
-		'postCheckpointLSN'
+		'lsn'
 	],
 	#category : #'Soil-Core'
 }
@@ -24,38 +22,67 @@ SoilDatabaseRecovery >> readEntryFrom: stream [
 ]
 
 { #category : #'as yet unclassified' }
-SoilDatabaseRecovery >> readFileUpToEnd: aSoilJournalFragmentFile [ 
+SoilDatabaseRecovery >> readFragmentFile: aSoilJournalFragmentFile [ 
 	| processed entry transactionJournal |
 	[ aSoilJournalFragmentFile atEnd ] whileFalse: [ 
 		processed := false.
+		"remember the position before reading the next entry"
 		lsn := aSoilJournalFragmentFile currentLogSequenceNumber.
 		entry := self readEntryFrom: aSoilJournalFragmentFile stream.
+		"if we read a begin entry we can read a transaction journal"
 		(entry class = SoilBeginTransactionEntry) ifTrue: [ 
 			processed := true.
-			beginLSN := lsn.
 			transactionJournal :=  SoilTransactionJournal new index: entry transactionId.
+			"transaction journals are written always completely so we can read until we 
+			discover a commit entry. "
 			self readTransactionJournal: transactionJournal from: aSoilJournalFragmentFile stream.
 			transactionJournal commitIn: soil ].
+		"reading a checkpoint entry is unlikely. It should be possible only if there was an 
+		error after writing the checkpoint entry and before marking that position in the control
+		file. But it is possible it happens so we just need to complete it by updating the 
+		checkpoint position in the control file"
 		(entry class = SoilCheckpointEntry) ifTrue: [
 			processed := true.
 			soil control checkpoint: lsn ].
-		processed ifFalse: [self halt]]
+		processed ifFalse: [
+			"it is unlikely we end up here. It means we could read a journal entry from the stream
+			but it none of the expected ones."
+			Error signal: 'unknown journal entry discovered' ] ]
+]
+
+{ #category : #'as yet unclassified' }
+SoilDatabaseRecovery >> readFragmentFileProtected: aSoilFragmentFile [
+	[ self readFragmentFile: aSoilFragmentFile ]
+		on: SoilTruncatedRead 
+		do: [:err | 
+			"a file that has been truncated should be the last fragment file because a database 
+			should not proceed if a truncation happens and the next open would have ended right
+			at the truncated position"
+			(journal lastFileNumber = aSoilFragmentFile fileNumber)
+				ifFalse: [ SoilDatabaseIsInconsistent signal: 'after a truncated file there should not be another one' ].
+			"we currently have no way of reading behind a truncated piece of a fragment. We cycle
+			the fragment file in order to write new entries to a new file. Future reads can just 
+			skip a fragment file on truncated reads"
+			journal 
+				currentFragmentFile: aSoilFragmentFile;
+				cycleFragmentFile ]
 ]
 
 { #category : #'as yet unclassified' }
 SoilDatabaseRecovery >> readTransactionJournal: transactionJournal from: stream [ 
 	| entry |
+	"read the transaction journal until a commit entry is read"
 	[ stream atEnd ] whileFalse: [  
 		entry := self readEntryFrom: stream.
 		transactionJournal addEntry: entry.
 		(entry class = SoilCommitTransactionEntry) 
 			ifTrue: [ ^ transactionJournal ] ].
-	Error signal: 'should not reach here'
+	SoilTruncatedRead signal: 'reading of transaction journal is incomplete'
 ]
 
 { #category : #'as yet unclassified' }
 SoilDatabaseRecovery >> recover [
-	| lastCheckpoint lastFileNumber checkpoint fragmentFile |
+	| lastCheckpoint checkpointEntry fragmentFile |
 	"read the log sequence number of the last successful checkpoint from the control 
 	file. A successful checkpoint includes writing the transaction logs to disk, 
 	commit the contents to the heap, write the checkpoint entry"
@@ -63,26 +90,27 @@ SoilDatabaseRecovery >> recover [
 	fragmentFile := journal openFragmentForLSN: lastCheckpoint.
 	"The log sequence number of a successful checkpoint points to the checkpoint 
 	entry that was last written"
-	checkpoint := SoilJournalEntry readFrom: fragmentFile stream.
+	checkpointEntry := SoilJournalEntry readFrom: fragmentFile stream.
 	"If the last checkpoint was successful we are at the end of the file and 
 	can return because the database is in a sane state"
 	fragmentFile atEnd ifTrue: [ ^ self ].
-	postCheckpointLSN := fragmentFile currentLogSequenceNumber.
-	[ self readFileUpToEnd: fragmentFile ]
-		on: SoilTruncatedRead 
-		do: [:err | 
-			"if a file has been truncated it should be the last fragment file because a database 
-			should not proceed if a truncation happened and the next open would have ended right
-			at the truncated position"
-			(journal lastFileNumber = fragmentFile fileNumber)
-				ifFalse: [ SoilDatabaseIsInconsistent signal: 'after a truncated file there should not be another one' ].
-			journal 
-				currentFragmentFile: fragmentFile;
-				cycleFragmentFile ].
-	lastFileNumber := journal lastFileNumber.
+	
+	"the fragment file contains more entries after the last checkpoint. Read the
+	current fragment file to its end and apply all transaction logs/checkpoints found"
+	self readFragmentFileProtected: fragmentFile.
+	
+	"it is possible there are more fragment files after that of the last checkpoint.
+	This is due to multiple transactions have been written to the journal and there
+	was a size overflow. Or it happens because the prior step did experience a 
+	truncated read and cycled the fragment file"
 	lastCheckpoint fileNumber + 1 to: journal lastFileNumber do: [ :fileNumber |
 		fragmentFile := journal openFragmentFileNumber: fileNumber.
-		self readFileUpToEnd: (journal openFragmentFileNumber: fileNumber) ].
+		fragmentFile setToStart.
+		self readFragmentFileProtected: fragmentFile ].
+	
+	"we end up here because the journal needed to be recovered. We create new checkpoint
+	to mark that we covered about the extra entries or bogus data so future reads can
+	proceed from here"
 	journal checkpoint.
 ]
 

--- a/src/Soil-Core/SoilDatabaseRecovery.class.st
+++ b/src/Soil-Core/SoilDatabaseRecovery.class.st
@@ -1,0 +1,44 @@
+Class {
+	#name : #SoilDatabaseRecovery,
+	#superclass : #Object,
+	#instVars : [
+		'soil',
+		'journal'
+	],
+	#category : #'Soil-Core'
+}
+
+{ #category : #accessing }
+SoilDatabaseRecovery >> journal: aSoilPersistentDatabaseJournal [ 
+	journal := aSoilPersistentDatabaseJournal 
+]
+
+{ #category : #'as yet unclassified' }
+SoilDatabaseRecovery >> recover [
+	| lastCheckpoint fragmentFiles checkpointFilename file lastFileNumber checkpoint tj ch |
+	lastCheckpoint := soil control checkpoint.
+	fragmentFiles := journal fragmentFiles last.
+	checkpointFilename := journal filenameFrom: lastCheckpoint fileNumber.
+	file := journal openFragmentFile: checkpointFilename.
+	(file size > lastCheckpoint fileOffset) 
+		ifTrue: [ 
+			file stream position: lastCheckpoint fileOffset.
+			checkpoint := SoilJournalEntry readFrom: file stream.
+			file atEnd 
+				ifTrue: [ ^ self "can it be that it is at the end of this file but there are more files?"]
+				ifFalse: [  
+					tj := SoilTransactionJournal readFrom: file stream.
+					ch := SoilJournalEntry readFrom: file stream.
+					self halt.] ]
+		ifFalse: [ 
+			lastFileNumber := journal fileNumberFrom: fragmentFiles basename.
+			(lastFileNumber > lastCheckpoint fileNumber) ifTrue: [ 
+				self halt ]  ] .
+	self halt.	
+	
+]
+
+{ #category : #accessing }
+SoilDatabaseRecovery >> soil: aSoil [ 
+	soil := aSoil
+]

--- a/src/Soil-Core/SoilDatabaseRecovery.class.st
+++ b/src/Soil-Core/SoilDatabaseRecovery.class.st
@@ -15,12 +15,19 @@ SoilDatabaseRecovery >> journal: aSoilPersistentDatabaseJournal [
 ]
 
 { #category : #'as yet unclassified' }
+SoilDatabaseRecovery >> readEntryFrom: stream [
+	^ [ SoilJournalEntry readFrom: stream ]
+		on: MessageNotUnderstood
+		do: [ :err | SoilTruncatedRead signal: 'cannot read' ]
+]
+
+{ #category : #'as yet unclassified' }
 SoilDatabaseRecovery >> readFileUpToEnd: aSoilJournalFragmentFile [ 
 	| processed entry transactionJournal lsn |
 	[ aSoilJournalFragmentFile atEnd ] whileFalse: [ 
 		processed := false.
 		lsn := aSoilJournalFragmentFile currentLogSequenceNumber.
-		entry := SoilJournalEntry readFrom: aSoilJournalFragmentFile stream.
+		entry := self readEntryFrom: aSoilJournalFragmentFile stream.
 		(entry class = SoilBeginTransactionEntry) ifTrue: [ 
 			processed := true.
 			transactionJournal :=  SoilTransactionJournal new index: entry transactionId.
@@ -36,7 +43,7 @@ SoilDatabaseRecovery >> readFileUpToEnd: aSoilJournalFragmentFile [
 SoilDatabaseRecovery >> readTransactionJournal: transactionJournal from: stream [ 
 	| entry |
 	[ stream atEnd ] whileFalse: [  
-		entry := SoilJournalEntry readFrom: stream.
+		entry := self readEntryFrom: stream.
 		transactionJournal addEntry: entry.
 		(entry class = SoilCommitTransactionEntry) 
 			ifTrue: [ ^ transactionJournal ] ].
@@ -46,7 +53,7 @@ SoilDatabaseRecovery >> readTransactionJournal: transactionJournal from: stream 
 { #category : #'as yet unclassified' }
 SoilDatabaseRecovery >> recover [
 	| lastCheckpoint lastFileNumber checkpoint |
-
+	self halt.
 	lastCheckpoint := soil control checkpoint.
 	file := journal openFragmentForLSN: lastCheckpoint.
 	checkpoint := SoilJournalEntry readFrom: file stream.

--- a/src/Soil-Core/SoilDatabaseRecovery.class.st
+++ b/src/Soil-Core/SoilDatabaseRecovery.class.st
@@ -4,7 +4,9 @@ Class {
 	#instVars : [
 		'soil',
 		'journal',
-		'file'
+		'lsn',
+		'beginLSN',
+		'postCheckpointLSN'
 	],
 	#category : #'Soil-Core'
 }
@@ -23,13 +25,14 @@ SoilDatabaseRecovery >> readEntryFrom: stream [
 
 { #category : #'as yet unclassified' }
 SoilDatabaseRecovery >> readFileUpToEnd: aSoilJournalFragmentFile [ 
-	| processed entry transactionJournal lsn |
+	| processed entry transactionJournal |
 	[ aSoilJournalFragmentFile atEnd ] whileFalse: [ 
 		processed := false.
 		lsn := aSoilJournalFragmentFile currentLogSequenceNumber.
 		entry := self readEntryFrom: aSoilJournalFragmentFile stream.
 		(entry class = SoilBeginTransactionEntry) ifTrue: [ 
 			processed := true.
+			beginLSN := lsn.
 			transactionJournal :=  SoilTransactionJournal new index: entry transactionId.
 			self readTransactionJournal: transactionJournal from: aSoilJournalFragmentFile stream.
 			transactionJournal commitIn: soil ].
@@ -52,15 +55,33 @@ SoilDatabaseRecovery >> readTransactionJournal: transactionJournal from: stream 
 
 { #category : #'as yet unclassified' }
 SoilDatabaseRecovery >> recover [
-	| lastCheckpoint lastFileNumber checkpoint |
-	self halt.
+	| lastCheckpoint lastFileNumber checkpoint fragmentFile |
+	"read the log sequence number of the last successful checkpoint from the control 
+	file. A successful checkpoint includes writing the transaction logs to disk, 
+	commit the contents to the heap, write the checkpoint entry"
 	lastCheckpoint := soil control checkpoint.
-	file := journal openFragmentForLSN: lastCheckpoint.
-	checkpoint := SoilJournalEntry readFrom: file stream.
-	self readFileUpToEnd: file.
+	fragmentFile := journal openFragmentForLSN: lastCheckpoint.
+	"The log sequence number of a successful checkpoint points to the checkpoint 
+	entry that was last written"
+	checkpoint := SoilJournalEntry readFrom: fragmentFile stream.
+	"If the last checkpoint was successful we are at the end of the file and 
+	can return because the database is in a sane state"
+	fragmentFile atEnd ifTrue: [ ^ self ].
+	postCheckpointLSN := fragmentFile currentLogSequenceNumber.
+	[ self readFileUpToEnd: fragmentFile ]
+		on: SoilTruncatedRead 
+		do: [:err | 
+			"if a file has been truncated it should be the last fragment file because a database 
+			should not proceed if a truncation happened and the next open would have ended right
+			at the truncated position"
+			(journal lastFileNumber = fragmentFile fileNumber)
+				ifFalse: [ SoilDatabaseIsInconsistent signal: 'after a truncated file there should not be another one' ].
+			journal 
+				currentFragmentFile: fragmentFile;
+				cycleFragmentFile ].
 	lastFileNumber := journal lastFileNumber.
 	lastCheckpoint fileNumber + 1 to: journal lastFileNumber do: [ :fileNumber |
-		file := journal openFragmentFileNumber: fileNumber.
+		fragmentFile := journal openFragmentFileNumber: fileNumber.
 		self readFileUpToEnd: (journal openFragmentFileNumber: fileNumber) ].
 	journal checkpoint.
 ]

--- a/src/Soil-Core/SoilDatabaseRecovery.class.st
+++ b/src/Soil-Core/SoilDatabaseRecovery.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'soil',
-		'journal'
+		'journal',
+		'file'
 	],
 	#category : #'Soil-Core'
 }
@@ -14,28 +15,47 @@ SoilDatabaseRecovery >> journal: aSoilPersistentDatabaseJournal [
 ]
 
 { #category : #'as yet unclassified' }
+SoilDatabaseRecovery >> readFileUpToEnd: aSoilJournalFragmentFile [ 
+	| processed entry transactionJournal lsn |
+	[ aSoilJournalFragmentFile atEnd ] whileFalse: [ 
+		processed := false.
+		lsn := aSoilJournalFragmentFile currentLogSequenceNumber.
+		entry := SoilJournalEntry readFrom: aSoilJournalFragmentFile stream.
+		(entry class = SoilBeginTransactionEntry) ifTrue: [ 
+			processed := true.
+			transactionJournal :=  SoilTransactionJournal new index: entry transactionId.
+			self readTransactionJournal: transactionJournal from: aSoilJournalFragmentFile stream.
+			transactionJournal commitIn: soil ].
+		(entry class = SoilCheckpointEntry) ifTrue: [
+			processed := true.
+			soil control checkpoint: lsn ].
+		processed ifFalse: [self halt]]
+]
+
+{ #category : #'as yet unclassified' }
+SoilDatabaseRecovery >> readTransactionJournal: transactionJournal from: stream [ 
+	| entry |
+	[ stream atEnd ] whileFalse: [  
+		entry := SoilJournalEntry readFrom: stream.
+		transactionJournal addEntry: entry.
+		(entry class = SoilCommitTransactionEntry) 
+			ifTrue: [ ^ transactionJournal ] ].
+	Error signal: 'should not reach here'
+]
+
+{ #category : #'as yet unclassified' }
 SoilDatabaseRecovery >> recover [
-	| lastCheckpoint fragmentFiles checkpointFilename file lastFileNumber checkpoint tj ch |
+	| lastCheckpoint lastFileNumber checkpoint |
+
 	lastCheckpoint := soil control checkpoint.
-	fragmentFiles := journal fragmentFiles last.
-	checkpointFilename := journal filenameFrom: lastCheckpoint fileNumber.
-	file := journal openFragmentFile: checkpointFilename.
-	(file size > lastCheckpoint fileOffset) 
-		ifTrue: [ 
-			file stream position: lastCheckpoint fileOffset.
-			checkpoint := SoilJournalEntry readFrom: file stream.
-			file atEnd 
-				ifTrue: [ ^ self "can it be that it is at the end of this file but there are more files?"]
-				ifFalse: [  
-					tj := SoilTransactionJournal readFrom: file stream.
-					ch := SoilJournalEntry readFrom: file stream.
-					self halt.] ]
-		ifFalse: [ 
-			lastFileNumber := journal fileNumberFrom: fragmentFiles basename.
-			(lastFileNumber > lastCheckpoint fileNumber) ifTrue: [ 
-				self halt ]  ] .
-	self halt.	
-	
+	file := journal openFragmentForLSN: lastCheckpoint.
+	checkpoint := SoilJournalEntry readFrom: file stream.
+	self readFileUpToEnd: file.
+	lastFileNumber := journal lastFileNumber.
+	lastCheckpoint fileNumber + 1 to: journal lastFileNumber do: [ :fileNumber |
+		file := journal openFragmentFileNumber: fileNumber.
+		self readFileUpToEnd: (journal openFragmentFileNumber: fileNumber) ].
+	journal checkpoint.
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilJournalFragmentFile.class.st
+++ b/src/Soil-Core/SoilJournalFragmentFile.class.st
@@ -185,6 +185,11 @@ SoilJournalFragmentFile >> path: aFileReference [
 	path := aFileReference 
 ]
 
+{ #category : #accessing }
+SoilJournalFragmentFile >> position: anInteger [ 
+	stream position: anInteger 
+]
+
 { #category : #utilities }
 SoilJournalFragmentFile >> prefix [
 	^ 'SOIL|JOURNAL FRAGMENT' asByteArray
@@ -195,6 +200,11 @@ SoilJournalFragmentFile >> printOn: aStream [
 	aStream 
 		<< 'journal segment file: '
 		<< path asString
+]
+
+{ #category : #initialization }
+SoilJournalFragmentFile >> setToEnd [
+	stream setToEnd
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilJournalFragmentFile.class.st
+++ b/src/Soil-Core/SoilJournalFragmentFile.class.st
@@ -7,6 +7,16 @@ Class {
 	#category : #'Soil-Core-Journal'
 }
 
+{ #category : #'as yet unclassified' }
+SoilJournalFragmentFile class >> filenameFromFilenumber: anInteger [ 
+	^ (anInteger printStringBase: 16 length: 10 padded: true) asLowercase 
+]
+
+{ #category : #'as yet unclassified' }
+SoilJournalFragmentFile class >> filenumberFromFilename: aString [ 
+	^ (ByteArray readHexFrom: aString) asInteger
+]
+
 { #category : #accessing }
 SoilJournalFragmentFile class >> path: aFileReference [ 
 	^ self new 
@@ -87,7 +97,7 @@ SoilJournalFragmentFile >> createdSize [
 { #category : #accessing }
 SoilJournalFragmentFile >> currentLogSequenceNumber [ 
 	^ SoilLogSequenceNumber 
-		fileNumber: (ByteArray readHexFrom: path pathSegments last) asInteger 
+		fileNumber: (self class filenumberFromFilename: path basename) 
 		offset: stream position 
 ]
 
@@ -103,6 +113,11 @@ SoilJournalFragmentFile >> entriesMatching: aBlock [
 ]
 
 { #category : #accessing }
+SoilJournalFragmentFile >> fileNumber [
+	^ self class filenumberFromFilename: path basename
+]
+
+{ #category : #accessing }
 SoilJournalFragmentFile >> filename [ 
 	^ self path basename
 ]
@@ -110,7 +125,10 @@ SoilJournalFragmentFile >> filename [
 { #category : #accessing }
 SoilJournalFragmentFile >> firstTransactionId [
 	self stream position: self dataPosition.
-
+	self flag: #todo.
+	"we skip the "
+	((SoilJournalEntry readFrom: self stream) class = SoilCheckpointEntry) ifFalse: [ 
+		Error signal: 'fragment file should start with a checkpoint entry' ].
 	^ SoilTransactionJournalEntry readTransactionIdFrom: stream
 ]
 

--- a/src/Soil-Core/SoilJournalFragmentFile.class.st
+++ b/src/Soil-Core/SoilJournalFragmentFile.class.st
@@ -44,6 +44,11 @@ SoilJournalFragmentFile >> appendEntry: aSoilJournalEntry [
 ]
 
 { #category : #accessing }
+SoilJournalFragmentFile >> atEnd [
+	^ stream atEnd
+]
+
+{ #category : #accessing }
 SoilJournalFragmentFile >> basename [ 
 	^ path basename
 ]
@@ -190,6 +195,16 @@ SoilJournalFragmentFile >> printOn: aStream [
 	aStream 
 		<< 'journal segment file: '
 		<< path asString
+]
+
+{ #category : #accessing }
+SoilJournalFragmentFile >> setToStart [
+	self stream position: self dataPosition
+]
+
+{ #category : #accessing }
+SoilJournalFragmentFile >> size [ 
+	^ stream size 
 ]
 
 { #category : #journal }

--- a/src/Soil-Core/SoilLogSequenceNumber.class.st
+++ b/src/Soil-Core/SoilLogSequenceNumber.class.st
@@ -25,6 +25,12 @@ SoilLogSequenceNumber class >> value: anInteger [
 		value: anInteger 
 ]
 
+{ #category : #comparing }
+SoilLogSequenceNumber >> = aLogSequenceNumber [ 
+	(aLogSequenceNumber class = self class) ifFalse: [ ^ false ].
+	^ aLogSequenceNumber value = value
+]
+
 { #category : #accessing }
 SoilLogSequenceNumber >> fileNumber [
 	"the high 40 bits are making up the file number"
@@ -40,6 +46,11 @@ SoilLogSequenceNumber >> fileNumber: number offset: offset [
 { #category : #accessing }
 SoilLogSequenceNumber >> fileOffset [ 
 	^ value bitAnd: 16rFFFFFF
+]
+
+{ #category : #comparing }
+SoilLogSequenceNumber >> hash [ 
+	^ value hash
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilPersistentDatabaseJournal.class.st
+++ b/src/Soil-Core/SoilPersistentDatabaseJournal.class.st
@@ -61,6 +61,16 @@ SoilPersistentDatabaseJournal >> currentFragmentFile [
 			ifFalse: [ self openFragmentFile: filename ] ]
 ]
 
+{ #category : #accessing }
+SoilPersistentDatabaseJournal >> currentFragmentFile: aSoilJournalFragmentFile [ 
+	currentFragmentFile := aSoilJournalFragmentFile
+]
+
+{ #category : #'as yet unclassified' }
+SoilPersistentDatabaseJournal >> cycleFragmentFile [
+	currentFragmentFile := self createFragmentFile: (self filenameFrom: currentFragmentFile fileNumber + 1)
+]
+
 { #category : #enumerating }
 SoilPersistentDatabaseJournal >> do: aBlock [ 
 	semaphore critical: [  

--- a/src/Soil-Core/SoilPersistentDatabaseJournal.class.st
+++ b/src/Soil-Core/SoilPersistentDatabaseJournal.class.st
@@ -115,7 +115,13 @@ SoilPersistentDatabaseJournal >> initialize [
 
 { #category : #initialization }
 SoilPersistentDatabaseJournal >> initializeFilesystem [
+	| file lsn |
 	self path ensureCreateDirectory.
+	self path hasChildren ifFalse: [ 
+		file := self currentFragmentFile.
+		lsn := self appendEntry: (SoilCheckpointEntry new
+			previousCheckpoint: soil control checkpoint).
+		soil control checkpoint: lsn ]
 
 ]
 
@@ -162,6 +168,14 @@ SoilPersistentDatabaseJournal >> openFragmentFile: filename [
 { #category : #accessing }
 SoilPersistentDatabaseJournal >> path [
 	^ soil path / #journal
+]
+
+{ #category : #'as yet unclassified' }
+SoilPersistentDatabaseJournal >> recover [
+	SoilDatabaseRecovery new 
+		soil: soil;
+		journal: self;
+		recover 
 ]
 
 { #category : #initialization }

--- a/src/Soil-Core/SoilPersistentDatabaseJournal.class.st
+++ b/src/Soil-Core/SoilPersistentDatabaseJournal.class.st
@@ -125,14 +125,7 @@ SoilPersistentDatabaseJournal >> initialize [
 
 { #category : #initialization }
 SoilPersistentDatabaseJournal >> initializeFilesystem [
-	| file lsn |
-	self path ensureCreateDirectory.
-	self path hasChildren ifFalse: [ 
-		file := self currentFragmentFile.
-		lsn := self appendEntry: (SoilCheckpointEntry new
-			previousCheckpoint: soil control checkpoint).
-		soil control checkpoint: lsn ]
-
+	self path ensureCreateDirectory
 ]
 
 { #category : #inspector }
@@ -170,6 +163,12 @@ SoilPersistentDatabaseJournal >> newTransactionJournalForId: anInteger [
 
 { #category : #'instance creation' }
 SoilPersistentDatabaseJournal >> open [ 
+	| file lsn |
+	self path hasChildren ifFalse: [ 
+		file := self currentFragmentFile.
+		lsn := self appendEntry: (SoilCheckpointEntry new
+			previousCheckpoint: soil control checkpoint).
+		soil control checkpoint: lsn ]
 	
 ]
 

--- a/src/Soil-Core/SoilPersistentDatabaseJournal.class.st
+++ b/src/Soil-Core/SoilPersistentDatabaseJournal.class.st
@@ -157,7 +157,7 @@ SoilPersistentDatabaseJournal >> inspectionContent [
 
 { #category : #accessing }
 SoilPersistentDatabaseJournal >> lastFileNumber [
-	^ self fileNumberFrom: self fragmentFiles last basename.
+	^ self fileNumberFrom: self fragmentFiles first basename.
 ]
 
 { #category : #'instance creation' }

--- a/src/Soil-Core/SoilPersistentDatabaseJournal.class.st
+++ b/src/Soil-Core/SoilPersistentDatabaseJournal.class.st
@@ -145,6 +145,11 @@ SoilPersistentDatabaseJournal >> inspectionContent [
 			width: 50)"
 ]
 
+{ #category : #accessing }
+SoilPersistentDatabaseJournal >> lastFileNumber [
+	^ self fileNumberFrom: self fragmentFiles last basename.
+]
+
 { #category : #'instance creation' }
 SoilPersistentDatabaseJournal >> newTransactionJournalForId: anInteger [ 
 	^ semaphore critical: [  
@@ -163,6 +168,20 @@ SoilPersistentDatabaseJournal >> openFragmentFile: filename [
 	^ (SoilJournalFragmentFile path: self path / filename )
 		open;
 		yourself
+]
+
+{ #category : #'instance creation' }
+SoilPersistentDatabaseJournal >> openFragmentFileNumber: anInteger [ 
+	^ self openFragmentFile: (self filenameFrom: anInteger)
+]
+
+{ #category : #'as yet unclassified' }
+SoilPersistentDatabaseJournal >> openFragmentForLSN: aSoilLogSequenceNumber [ 
+	| file |
+	file := self openFragmentFileNumber: aSoilLogSequenceNumber fileNumber.
+	file position: aSoilLogSequenceNumber fileOffset.
+	^ file
+
 ]
 
 { #category : #accessing }
@@ -202,6 +221,7 @@ SoilPersistentDatabaseJournal >> writeEntry: aSoilNewCheckpointEntry [
 	position of the entry being written"
 	| entryLSN file |
 	file := self currentFragmentFile.
+	file setToEnd.
 	entryLSN := file currentLogSequenceNumber.
 	file appendEntry: aSoilNewCheckpointEntry.
 	^ entryLSN

--- a/src/Soil-Core/SoilTruncatedRead.class.st
+++ b/src/Soil-Core/SoilTruncatedRead.class.st
@@ -1,0 +1,5 @@
+Class {
+	#name : #SoilTruncatedRead,
+	#superclass : #SoilError,
+	#category : #'Soil-Core'
+}


### PR DESCRIPTION
Adds a journal recovery operation which is executed every time a soil instance is opened. This way we should be sure that the heap and/or the journal are in consistent state