### PR TITLE
Add testIndexAfterReopen which fails in the scenario because header page has pageSize nil

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -34,6 +34,13 @@ SoilIndexedDictionaryTest >> path [
 	^ 'soil-tests'
 ]
 
+{ #category : #tests }
+SoilIndexedDictionaryTest >> reopen [ 
+	soil ifNotNil: [ 
+		soil close ].
+	soil open
+]
+
 { #category : #running }
 SoilIndexedDictionaryTest >> setUp [ 
 	super setUp.
@@ -127,6 +134,23 @@ SoilIndexedDictionaryTest >> testAddToExistingNonEmptyList [
 	tx3 abort.	
 	tx4 := soil newTransaction.
 	self assert: (tx4 root at: #foo) equals: #bar.	
+]
+
+{ #category : #tests }
+SoilIndexedDictionaryTest >> testAfterReopen [
+	| tx |
+	tx := soil newTransaction.
+	tx root: dict.
+	tx commit.
+	"Open a fresh Soil instance, so index structures are not cached"
+	self reopen.
+	tx := soil newTransaction.
+	"Getting the values, before doing #at:put: yielded index pages with nil pageSize"
+	tx root values.
+	tx root at: 'abc' asByteArray put: #one.
+	self
+		shouldnt: [ tx commit ]
+		raise: Error
 ]
 
 { #category : #tests }


### PR DESCRIPTION
When a previously committed BTree or SkipList is accessed in the test scenario, the header page object has a pageSize of nil. The scenario uses a freshly opened Soil, then requests all the dictionary values, before using #at:put:. The commit then triggers a DNU where the pageSize is nil in the #hasRoom method.

==== stack trace ====
UndefinedObject(Object)>>doesNotUnderstand: #-
UndefinedObject>>doesNotUnderstand: #-
SoilSkipListHeaderPage(SoilIndexItemsPage)>>hasRoom
SoilSkipListIterator>>basicAt:put:
SoilSkipListIterator(SoilIndexIterator)>>at:put:
SoilSkipListDictionary(SoilIndexedDictionary)>>at:put:
SoilIndexedDictionaryTest>>testAfterReopen