### PR TITLE
testAfterReopen and a proposed fix

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -130,6 +130,24 @@ SoilIndexedDictionaryTest >> testAddToExistingNonEmptyList [
 ]
 
 { #category : #tests }
+SoilIndexedDictionaryTest >> testAfterReopen [
+	"test that we can close and re-open the database"
+ 	| tx |
+ 	tx := soil newTransaction.
+ 	tx root: dict.
+ 	tx commit.
+ 	"Open a fresh Soil instance, so index structures are not cached"
+ 	soil close. soil open.
+ 	tx := soil newTransaction.
+ 	"Getting the values, before doing #at:put: yielded index pages with nil pageSize"
+ 	tx root values.
+ 	tx root at: 'abc' asByteArray put: #one.
+ 	self
+ 		shouldnt: [ tx commit ]
+ 		raise: Error
+]
+
+{ #category : #tests }
 SoilIndexedDictionaryTest >> testAtIndexWithTransaction [
 	| tx tx2 |
 	tx := soil newTransaction.

--- a/src/Soil-Core/SoilPagedFileIndexStore.class.st
+++ b/src/Soil-Core/SoilPagedFileIndexStore.class.st
@@ -102,7 +102,10 @@ SoilPagedFileIndexStore >> pageFaultAt: anInteger [
 	self ensureStreamIsOpen.
 	streamSemaphore critical: [  
 		stream position: (self positionOfPageIndex: anInteger).
-		page := (index readPageFrom: stream) index: anInteger ].
+		page := (index readPageFrom: stream) 
+			index: anInteger;
+			pageSize:  self filePageSize
+			yourself ].
 	pagesMutex critical: [  
 		pages at: anInteger put: page ].
 	^ page


### PR DESCRIPTION
Fix for the test in #658

This PR includes the test, but with re-open inlined (this replaces the other PR)