### PR TITLE
Added complete sync of database files

### DIFF
--- a/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
+++ b/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
@@ -93,7 +93,7 @@ SoilDatabaseJournalTest >> tearDown [
 SoilDatabaseJournalTest >> testRecoverWithAtEnd [
 	soil close.
 	soil open.
-	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 28) 
+	self assert: soil control lastCheckpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 28) 
 	
 ]
 
@@ -112,10 +112,10 @@ SoilDatabaseJournalTest >> testRecoverWithIncompleteTransactionJournal [
 	soil journal currentFragmentFile stream 
 		nextPutAll: #( 1 2 3 4 );
 		flush.
-	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 86).
+	self assert: soil control lastCheckpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 86).
 	soil close.
 	soil open.
-	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 1 offset: 28) 
+	self assert: soil control lastCheckpoint equals: (SoilLogSequenceNumber fileNumber: 1 offset: 28) 
 	
 	
 ]
@@ -134,12 +134,12 @@ SoilDatabaseJournalTest >> testRecoverWithJournalAndCheckpoint [
 		committedAt: DateAndTime now;
 		yourself).
 	newJournal addEntry: (SoilCheckpointEntry new
-		previousCheckpoint: soil control checkpoint).
+		previousCheckpoint: soil control lastCheckpoint).
 	soil journal writeTransactionJournal: newJournal.
 	soil close.
 	soil open.
 	"we have now two entries checkpoint at the end but that is to be expected"
-	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 72) 
+	self assert: soil control lastCheckpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 72) 
 	
 ]
 
@@ -149,10 +149,10 @@ SoilDatabaseJournalTest >> testRecoverWithRemainingBytes [
 	soil journal currentFragmentFile stream 
 		nextPutAll: #( 1 2 3 4 );
 		flush.
-	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 28).
+	self assert: soil control lastCheckpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 28).
 	soil close.
 	soil open.
-	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 1 offset: 28) 
+	self assert: soil control lastCheckpoint equals: (SoilLogSequenceNumber fileNumber: 1 offset: 28) 
 	
 	
 ]
@@ -171,10 +171,10 @@ SoilDatabaseJournalTest >> testRecoverWithRemainingJournal [
 		committedAt: DateAndTime now;
 		yourself).
 	soil journal writeTransactionJournal: newJournal.
-	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 28).
+	self assert: soil control lastCheckpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 28).
 	soil close.
 	soil open.
-	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 61) 
+	self assert: soil control lastCheckpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 61) 
 	
 	
 ]
@@ -199,12 +199,12 @@ SoilDatabaseJournalTest >> testRecoverWithRemainingJournalAndBytes [
 	soil journal currentFragmentFile stream 
 		nextPutAll: #( 1 2 3 4 );
 		flush.
-	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 86).
+	self assert: soil control lastCheckpoint equals: (SoilLogSequenceNumber fileNumber: 0 offset: 86).
 	soil close.
 	soil open.
 	"the fragment file should have advanced to a new file so the truncated bytes are the rest of
 	the old file which can be skipped in future reads"
-	self assert: soil control checkpoint equals: (SoilLogSequenceNumber fileNumber: 1 offset: 28).
+	self assert: soil control lastCheckpoint equals: (SoilLogSequenceNumber fileNumber: 1 offset: 28).
 	"the change of the replayed transaction should be visible now"
 	txn := soil newTransaction. 
 	[ self assert: (txn root at: #foo) equals: #bar  ]

--- a/src/Soil-Core-Tests/SoilTest.class.st
+++ b/src/Soil-Core-Tests/SoilTest.class.st
@@ -88,7 +88,7 @@ SoilTest >> testCheckpointEmptyRecordsToCommit [
 	"N.B. Having the skip list at the root, did not trigger the error"
 	tx makeRoot: root.
 	tx root: root.
-	tx checkpointAndContinue.
+	tx commitAndContinue.
 
 	skipList := SoilSkipListDictionary new keySize: 32; maxLevel: 8; yourself.
 	tx makeRoot: skipList.
@@ -102,7 +102,7 @@ SoilTest >> testCheckpointEmptyRecordsToCommit [
 	tx makeRoot: obj.
 	skipList at: 'bbb' asByteArray put: obj.
 
-	tx checkpointAndContinue.
+	tx commitAndContinue.
 
 	self
 		shouldnt: [
@@ -111,7 +111,7 @@ SoilTest >> testCheckpointEmptyRecordsToCommit [
 				skipList := tx root at: 123.
 				"N.B. Have to actually pull in the proxy object to trigger error"
 				items := skipList values collect: [ :each | each one ].
-				tx checkpointAndContinue ] ]
+				tx commitAndContinue ] ]
 		raise: Error
 ]
 
@@ -284,7 +284,7 @@ SoilTest >> testSerializingRootTwoCluster [
 	graph := self simpleGraph.
 	tx makeRoot: graph nested reference. 
 	tx root: graph. 
-	tx checkpoint.
+	tx basicCommit.
 	tx2 := soil newTransaction.
 	materializedRoot := tx2 root.
 	self assert: materializedRoot nested reference objectIsNotLoaded.

--- a/src/Soil-Core-Tests/SoilTransactionJournalTest.class.st
+++ b/src/Soil-Core-Tests/SoilTransactionJournalTest.class.st
@@ -77,7 +77,7 @@ SoilTransactionJournalTest >> testNewRootObject [
 	| tx journal |
 	tx := soil newTransaction.
 	tx root: SoilTestClusterRoot new.
-	tx checkpoint.
+	tx basicCommit.
 	journal := tx journal.
 	self assert: journal size equals: 7.
 	self assert: ((journal entryAt: 3) objectId isSameObjectId: (SoilObjectId segment: 1 index: 1)).
@@ -98,7 +98,7 @@ SoilTransactionJournalTest >> testNewRootSkipList [
 		keySize: 16;
 		yourself).
 	tx root at: #foo put: #bar.
-	tx checkpoint.
+	tx basicCommit.
 	journal := tx journal.
 	self assert: journal size equals: 11.
 	self assert: (journal anyEntrySatisfy:[:each | (each isKindOf: SoilNewObjectEntry) and: [ each objectId notNil and: [ each objectId isSameObjectId: (SoilObjectId segment: 1 index: 1) ]]]).
@@ -117,7 +117,7 @@ SoilTransactionJournalTest >> testRootObjectUpdate [
 	tx2 := soil newTransaction.
 	tx2 root nested: #teststring.
 	tx2 markDirty: tx2 root.
-	tx2 checkpoint.
+	tx2 basicCommit.
 	journal := tx2 journal.
 	self assert: journal size equals: 4.
 	self assert: ((journal entryAt: 2) objectId isSameObjectId: (SoilObjectId segment: 1 index: 1)).
@@ -137,7 +137,7 @@ SoilTransactionJournalTest >> testRootObjectUpdateClusterObject [
 	tx2 
 		markDirty: tx2 root;
 		makeRoot: object.
-	tx2 checkpoint.
+	tx2 basicCommit.
 	journal := tx2 journal.
 	self assert: journal size equals: 9.
 	self assert: (journal entries anySatisfy: [:entry | (entry isKindOf: SoilNewObjectEntry) and: [ entry objectId notNil and: [entry objectId isSameObjectId: (SoilObjectId segment: 1 index: 1) ] ] ]).
@@ -159,7 +159,7 @@ SoilTransactionJournalTest >> testRootObjectUpdateClusterPrimitive [
 	tx2 
 		markDirty: tx2 root;
 		makeRoot: string.
-	tx2 checkpoint.
+	tx2 basicCommit.
 	journal := tx2 journal.
 	self assert: journal size equals: 6.
 	self assert: (journal entries anySatisfy: [:entry |(entry isKindOf: SoilNewObjectEntry) and: [ entry objectId notNil and: [entry objectId isSameObjectId: (SoilObjectId segment: 1 index: 1)] ] ]).

--- a/src/Soil-Core-Tests/SoilTransactionTest.class.st
+++ b/src/Soil-Core-Tests/SoilTransactionTest.class.st
@@ -43,7 +43,7 @@ SoilTransactionTest >> testCheckpointAndContinue [
 	| tx |
 	tx := soil newTransaction.
 	tx root: Object new.
-	tx checkpointAndContinue.
+	tx commitAndContinue.
 	self deny: tx hasModifications.
 	 
 	
@@ -110,7 +110,7 @@ SoilTransactionTest >> testTwoRootsWithAlwaysRoot [
 	"obj1 is made root but refers to an object that has a class
 	side setting for being root. The second object is being made
 	root when serializing obj1 "
-	tx checkpoint.
+	tx basicCommit.
 	"expect 4 records: 2 instances and 2 classes"
 	self assert: tx records size equals: 4
 ]

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -350,7 +350,13 @@ Soil >> replayJournal: aSoilJournal [
 	databaseVersion := self databaseVersion.
 	journals := aSoilJournal 
 		transactionJournalsStartingAt: databaseVersion + 1
-		do: [:tj | self replayTransactionJournal: tj ]
+		do: [:tj | self replayTransactionJournal: tj ].
+	self behaviorRegistry 
+		flush;
+		writeContentsToDisk.
+	self objectRepository 
+		flush;
+		writeContentsToDisk 
 ]
 
 { #category : #journal }

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -112,6 +112,20 @@ Soil >> behaviorRegistry [
 	^ behaviorRegistry
 ]
 
+{ #category : #accessing }
+Soil >> checkpoint [ 
+	| entry checkpointLSN |
+	entry := SoilCheckpointEntry new
+		previousCheckpoint: self control lastCheckpoint.
+	entry commitIn: self.
+	"write the checkpoint entry in the journal and get 
+	the position of that entry in the file"
+	checkpointLSN := self journal writeEntry: entry.
+	"set the checkpoint position so it can be read back"
+	self control checkpoint: checkpointLSN.
+	^ entry
+]
+
 { #category : #'opening/closing' }
 Soil >> close [
 	objectRepository ifNotNil: [ 

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -391,3 +391,13 @@ Soil >> setup [
 Soil >> transactionClass [
 	^ SoilTransaction 
 ]
+
+{ #category : #writing }
+Soil >> writeEverythingToDisk [ 
+	self behaviorRegistry 
+		flush;
+		writeContentsToDisk.
+	self objectRepository 
+		flush;
+		writeContentsToDisk 
+]

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -365,12 +365,7 @@ Soil >> replayJournal: aSoilJournal [
 	journals := aSoilJournal 
 		transactionJournalsStartingAt: databaseVersion + 1
 		do: [:tj | self replayTransactionJournal: tj ].
-	self behaviorRegistry 
-		flush;
-		writeContentsToDisk.
-	self objectRepository 
-		flush;
-		writeContentsToDisk 
+	self writeEverythingToDisk 
 ]
 
 { #category : #journal }

--- a/src/Soil-Core/SoilBackupVisitor.class.st
+++ b/src/Soil-Core/SoilBackupVisitor.class.st
@@ -82,7 +82,7 @@ SoilBackupVisitor >> visitControl: aSoilControlFile [
 		databaseFormatVersion: aSoilControlFile databaseFormatVersion;
 		databaseVersion: aSoilControlFile databaseVersion;
 		applicationVersion: aSoilControlFile applicationVersion;
-		checkpoint: aSoilControlFile checkpoint
+		checkpoint: aSoilControlFile lastCheckpoint
 ]
 
 { #category : #visiting }

--- a/src/Soil-Core/SoilBehaviorRegistry.class.st
+++ b/src/Soil-Core/SoilBehaviorRegistry.class.st
@@ -150,3 +150,9 @@ SoilBehaviorRegistry >> soil [
 SoilBehaviorRegistry >> soil: aSoil [ 
 	soil := aSoil
 ]
+
+{ #category : #writing }
+SoilBehaviorRegistry >> writeContentsToDisk [
+	soil setup isFsyncEnabled ifTrue: [  
+		self index writeContentsToDisk ]
+]

--- a/src/Soil-Core/SoilBinaryFile.class.st
+++ b/src/Soil-Core/SoilBinaryFile.class.st
@@ -91,3 +91,8 @@ SoilBinaryFile >> stream [
 SoilBinaryFile >> stream: anObject [
 	stream := anObject
 ]
+
+{ #category : #writing }
+SoilBinaryFile >> writeContentsToDisk [
+	stream fileStream fdatasync
+]

--- a/src/Soil-Core/SoilCheckpointEntry.class.st
+++ b/src/Soil-Core/SoilCheckpointEntry.class.st
@@ -25,17 +25,8 @@ SoilCheckpointEntry >> checkpointedAt [
 
 { #category : #committing }
 SoilCheckpointEntry >> commitIn: soil [
-	"make sure behavior registry gets flushed at the end of 
-	a transaction"
-	soil behaviorRegistry 
-		flush;
-		writeContentsToDisk.
-	"as indexes are just created and keys/values being added,
-	we need to flush sometime and the checkpoint time is good
-	for this"
-	soil objectRepository 
-		flush;
-		writeContentsToDisk 
+	"write all values in the heap to disk"
+	soil writeEverythingToDisk 
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilCheckpointEntry.class.st
+++ b/src/Soil-Core/SoilCheckpointEntry.class.st
@@ -27,12 +27,15 @@ SoilCheckpointEntry >> checkpointedAt [
 SoilCheckpointEntry >> commitIn: soil [
 	"make sure behavior registry gets flushed at the end of 
 	a transaction"
-	soil behaviorRegistry flush.
+	soil behaviorRegistry 
+		flush;
+		writeContentsToDisk.
 	"as indexes are just created and keys/values being added,
 	we need to flush sometime and the checkpoint time is good
 	for this"
-	soil objectRepository segments do: [ :segment |
-		segment indexManager flush ]
+	soil objectRepository 
+		flush;
+		writeContentsToDisk 
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilControlFile.class.st
+++ b/src/Soil-Core/SoilControlFile.class.st
@@ -55,14 +55,6 @@ SoilControlFile >> basicDatabaseVersion: anInteger [
 ]
 
 { #category : #accessing }
-SoilControlFile >> checkpoint [
-	^ semaphore critical: [  
-		self stream 
-			position: self checkpointPosition.
-		(stream next: self checkpointPositionSize) asInteger asLogSequenceNumber ]
-]
-
-{ #category : #accessing }
 SoilControlFile >> checkpoint: anInteger [
 	semaphore critical: [  
 		self stream 
@@ -159,6 +151,14 @@ SoilControlFile >> inspectionControl [
 ]
 
 { #category : #accessing }
+SoilControlFile >> lastCheckpoint [
+	^ semaphore critical: [  
+		self stream 
+			position: self checkpointPosition.
+		(stream next: self checkpointPositionSize) asInteger asLogSequenceNumber ]
+]
+
+{ #category : #accessing }
 SoilControlFile >> legacyPath [
 	^ soil path / #settings
 ]
@@ -185,7 +185,7 @@ SoilControlFile >> open [
 
 { #category : #accessing }
 SoilControlFile >> parameterNames [
-	^ #( databaseFormatVersion databaseVersion applicationVersion checkpoint ) 
+	^ #( databaseFormatVersion databaseVersion applicationVersion #lastCheckpoint ) 
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilDatabaseRecovery.class.st
+++ b/src/Soil-Core/SoilDatabaseRecovery.class.st
@@ -111,7 +111,7 @@ SoilDatabaseRecovery >> recover [
 	"we end up here because the journal needed to be recovered. We create new checkpoint
 	to mark that we covered about the extra entries or bogus data so future reads can
 	proceed from here"
-	journal checkpoint.
+	soil checkpoint.
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilDatabaseRecovery.class.st
+++ b/src/Soil-Core/SoilDatabaseRecovery.class.st
@@ -86,7 +86,7 @@ SoilDatabaseRecovery >> recover [
 	"read the log sequence number of the last successful checkpoint from the control 
 	file. A successful checkpoint includes writing the transaction logs to disk, 
 	commit the contents to the heap, write the checkpoint entry"
-	lastCheckpoint := soil control checkpoint.
+	lastCheckpoint := soil control lastCheckpoint.
 	fragmentFile := journal openFragmentForLSN: lastCheckpoint.
 	"The log sequence number of a successful checkpoint points to the checkpoint 
 	entry that was last written"

--- a/src/Soil-Core/SoilIndex.class.st
+++ b/src/Soil-Core/SoilIndex.class.st
@@ -240,3 +240,8 @@ SoilIndex >> valueSize: anInteger [
 SoilIndex >> values [ 
 	^ self newIterator values
 ]
+
+{ #category : #writing }
+SoilIndex >> writeContentsToDisk [
+	self store writeContentsToDisk 
+]

--- a/src/Soil-Core/SoilIndexManager.class.st
+++ b/src/Soil-Core/SoilIndexManager.class.st
@@ -127,3 +127,9 @@ SoilIndexManager >> segment [
 SoilIndexManager >> segment: aSOObjectSegment [ 
 	segment := aSOObjectSegment 
 ]
+
+{ #category : #writing }
+SoilIndexManager >> writeContentsToDisk [
+	segment soil setup isFsyncEnabled ifTrue: [  
+		self indexes do: #writeContentsToDisk ]
+]

--- a/src/Soil-Core/SoilJournalConverter.class.st
+++ b/src/Soil-Core/SoilJournalConverter.class.st
@@ -24,7 +24,7 @@ SoilJournalConverter >> convert [
 		stream close.
 		each delete ].
 	"write a final checkpoint record and about its position in the database"
-	soil journal checkpoint
+	soil checkpoint
 
 
 ]

--- a/src/Soil-Core/SoilJournalFragmentFile.class.st
+++ b/src/Soil-Core/SoilJournalFragmentFile.class.st
@@ -271,8 +271,3 @@ SoilJournalFragmentFile >> versionPosition [
 SoilJournalFragmentFile >> versionSize [
 	^ 1
 ]
-
-{ #category : #'as yet unclassified' }
-SoilJournalFragmentFile >> writeContentsToDisk [
-	stream fileStream fdatasync
-]

--- a/src/Soil-Core/SoilObjectRepository.class.st
+++ b/src/Soil-Core/SoilObjectRepository.class.st
@@ -92,6 +92,11 @@ SoilObjectRepository >> firstSegment [
 ]
 
 { #category : #accessing }
+SoilObjectRepository >> flush [
+	self segmentsDo: #flush
+]
+
+{ #category : #accessing }
 SoilObjectRepository >> heapPositionOf: anObjectId [ 
 	^ (self segmentAt: anObjectId segment)
 		heapPositionAt: anObjectId index  
@@ -207,4 +212,10 @@ SoilObjectRepository >> soil [
 { #category : #accessing }
 SoilObjectRepository >> soil: aSoil [ 
 	soil := aSoil 
+]
+
+{ #category : #writing }
+SoilObjectRepository >> writeContentsToDisk [
+	soil setup isFsyncEnabled ifTrue: [  
+		self segmentsDo: #writeContentsToDisk ]
 ]

--- a/src/Soil-Core/SoilObjectSegment.class.st
+++ b/src/Soil-Core/SoilObjectSegment.class.st
@@ -83,6 +83,11 @@ SoilObjectSegment >> close [
 ]
 
 { #category : #accessing }
+SoilObjectSegment >> flush [
+	self indexManager flush
+]
+
+{ #category : #accessing }
 SoilObjectSegment >> flushCachedObjectRecords [
 	
 ]
@@ -231,4 +236,12 @@ SoilObjectSegment >> soil [
 { #category : #validating }
 SoilObjectSegment >> validateLastObjectIndex: anInteger [ 
 	indexFile validateLastObjectIndex: anInteger
+]
+
+{ #category : #writing }
+SoilObjectSegment >> writeContentsToDisk [
+	self soil setup isFsyncEnabled ifTrue: [  
+		indexFile writeContentsToDisk.
+		objectFile writeContentsToDisk.
+		self indexManager writeContentsToDisk ]
 ]

--- a/src/Soil-Core/SoilPagedFileIndexStore.class.st
+++ b/src/Soil-Core/SoilPagedFileIndexStore.class.st
@@ -145,6 +145,11 @@ SoilPagedFileIndexStore >> stream [
 ]
 
 { #category : #writing }
+SoilPagedFileIndexStore >> writeContentsToDisk [
+	stream fileStream fdatasync  
+]
+
+{ #category : #writing }
 SoilPagedFileIndexStore >> writePage: aPage [ 
 	| pagePosition |
 	self ensureStreamIsOpen.

--- a/src/Soil-Core/SoilPersistentDatabaseJournal.class.st
+++ b/src/Soil-Core/SoilPersistentDatabaseJournal.class.st
@@ -28,20 +28,6 @@ SoilPersistentDatabaseJournal >> appendEntry: aSoilNewCheckpointEntry [
 		
 ]
 
-{ #category : #accessing }
-SoilPersistentDatabaseJournal >> checkpoint [ 
-	| entry checkpointLSN |
-	entry := SoilCheckpointEntry new
-		previousCheckpoint: soil control lastCheckpoint.
-	entry commitIn: soil.
-	"write the checkpoint entry in the journal and get 
-	the position of that entry in the file"
-	checkpointLSN := self writeEntry: entry.
-	"set the checkpoint position so it can be read back"
-	soil control checkpoint: checkpointLSN.
-	^ entry
-]
-
 { #category : #private }
 SoilPersistentDatabaseJournal >> createFragmentFile: filename [
 	(self path / filename) ensureCreateFile.

--- a/src/Soil-Core/SoilPersistentDatabaseJournal.class.st
+++ b/src/Soil-Core/SoilPersistentDatabaseJournal.class.st
@@ -32,7 +32,7 @@ SoilPersistentDatabaseJournal >> appendEntry: aSoilNewCheckpointEntry [
 SoilPersistentDatabaseJournal >> checkpoint [ 
 	| entry checkpointLSN |
 	entry := SoilCheckpointEntry new
-		previousCheckpoint: soil control checkpoint.
+		previousCheckpoint: soil control lastCheckpoint.
 	entry commitIn: soil.
 	"write the checkpoint entry in the journal and get 
 	the position of that entry in the file"
@@ -54,7 +54,7 @@ SoilPersistentDatabaseJournal >> createFragmentFile: filename [
 SoilPersistentDatabaseJournal >> currentFragmentFile [
 	| currentLSN filename |
 	^ currentFragmentFile ifNil: [  
-		currentLSN := soil control checkpoint.
+		currentLSN := soil control lastCheckpoint.
 		filename := self filenameFrom: currentLSN fileNumber.
 		currentFragmentFile := (currentLSN isInitial) 
 			ifTrue: [ self createFragmentFile: filename ]
@@ -176,7 +176,7 @@ SoilPersistentDatabaseJournal >> open [
 	self path hasChildren ifFalse: [ 
 		file := self currentFragmentFile.
 		lsn := self appendEntry: (SoilCheckpointEntry new
-			previousCheckpoint: soil control checkpoint).
+			previousCheckpoint: soil control lastCheckpoint).
 		soil control checkpoint: lsn ]
 	
 ]

--- a/src/Soil-Core/SoilTransaction.class.st
+++ b/src/Soil-Core/SoilTransaction.class.st
@@ -229,9 +229,8 @@ SoilTransaction >> checkpoint [
 		journal validateIn: self.
 		soil journal writeTransactionJournal: journal.
 		journal commitIn: soil.
-		soil journal 
-			addTransactionJournal: journal;
-			checkpoint ]
+		soil journal addTransactionJournal: journal.
+		soil checkpoint ]
 				ensure: [self releaseLocks ] ].
 		soil notificationHandler transactionCommitted: self
 

--- a/src/Soil-Core/SoilTransaction.class.st
+++ b/src/Soil-Core/SoilTransaction.class.st
@@ -77,6 +77,44 @@ SoilTransaction >> basicAbort [
 	objectMap := nil
 ]
 
+{ #category : #accessing }
+SoilTransaction >> basicCommit [
+	"serialize objects and collect all to be written records. This can be done without 
+	resources that need locking. This reduces time needed for locking"
+	self prepareRecordsForCommit.
+	"if there are no records to commit we can just return and don't allocate any
+	resources"
+	(recordsToCommit isEmpty and: [indexUpdatesToCommit isEmpty ]) ifTrue: [ 
+		soil notificationHandler transactionCommitted: self.
+		^ self ].
+	"only one transactions is allowed at a time. We use the critical block of the database
+	to avoid parallel committing"
+	soil critical: [ 
+	"enter lock phase. Acquire lock on global databaseVersion which centrally locks
+	the database for commiting until this checkpoint is done. The ensure block is needed
+	to be sure to release all locks at the end."
+		[ 
+		"lock global database version and create a version for new modification"
+		writeVersion := self buildWriteVersion.
+		"lock all records in the segment and check indexes for out of date versions"
+		self acquireLocksAndDetectWriteSkew.
+		"lastObjectIndexes contains the highest allocated index number per segment. We
+		lock all positions in order to update the index numbers in the database."
+		lastObjectIndexes keysDo: [ :segment |
+			locks add: (segment lockAppendingFor: self) ].
+		"convert the records into journal entries, write the journal to disk and then
+		execute the journal on the database"
+		journal := self buildJournal.
+		journal validateIn: self.
+		soil journal writeTransactionJournal: journal.
+		journal commitIn: soil.
+		soil journal addTransactionJournal: journal.
+		soil basicCommit ]
+				ensure: [self releaseLocks ] ].
+		soil notificationHandler transactionCommitted: self
+
+]
+
 { #category : #public }
 SoilTransaction >> behaviorDescriptionFor: aClass [
 	| behaviorDescription objectId |
@@ -199,55 +237,17 @@ SoilTransaction >> buildWriteVersion [
 ]
 
 { #category : #accessing }
-SoilTransaction >> checkpoint [
-	"serialize objects and collect all to be written records. This can be done without 
-	resources that need locking. This reduces time needed for locking"
-	self prepareRecordsForCommit.
-	"if there are no records to commit we can just return and don't allocate any
-	resources"
-	(recordsToCommit isEmpty and: [indexUpdatesToCommit isEmpty ]) ifTrue: [ 
-		soil notificationHandler transactionCommitted: self.
-		^ self ].
-	"only one transactions is allowed at a time. We use the critical block of the database
-	to avoid parallel committing"
-	soil critical: [ 
-	"enter lock phase. Acquire lock on global databaseVersion which centrally locks
-	the database for commiting until this checkpoint is done. The ensure block is needed
-	to be sure to release all locks at the end."
-		[ 
-		"lock global database version and create a version for new modification"
-		writeVersion := self buildWriteVersion.
-		"lock all records in the segment and check indexes for out of date versions"
-		self acquireLocksAndDetectWriteSkew.
-		"lastObjectIndexes contains the highest allocated index number per segment. We
-		lock all positions in order to update the index numbers in the database."
-		lastObjectIndexes keysDo: [ :segment |
-			locks add: (segment lockAppendingFor: self) ].
-		"convert the records into journal entries, write the journal to disk and then
-		execute the journal on the database"
-		journal := self buildJournal.
-		journal validateIn: self.
-		soil journal writeTransactionJournal: journal.
-		journal commitIn: soil.
-		soil journal addTransactionJournal: journal.
-		soil checkpoint ]
-				ensure: [self releaseLocks ] ].
-		soil notificationHandler transactionCommitted: self
-
+SoilTransaction >> commit [
+	self basicCommit.
+	soil checkpoint.
+	self basicAbort.
 ]
 
 { #category : #actions }
-SoilTransaction >> checkpointAndContinue [
-	self 
-		checkpoint;
-		continue
-]
-
-{ #category : #accessing }
-SoilTransaction >> commit [
-	self 
-		checkpoint;
-		basicAbort
+SoilTransaction >> commitAndContinue [
+	self basicCommit.
+	soil checkpoint.
+	self continue
 ]
 
 { #category : #actions }

--- a/src/Soil-Core/SoilTransaction.class.st
+++ b/src/Soil-Core/SoilTransaction.class.st
@@ -109,7 +109,7 @@ SoilTransaction >> basicCommit [
 		soil journal writeTransactionJournal: journal.
 		journal commitIn: soil.
 		soil journal addTransactionJournal: journal.
-		soil basicCommit ]
+		soil checkpoint ]
 				ensure: [self releaseLocks ] ].
 		soil notificationHandler transactionCommitted: self
 

--- a/src/Soil-Core/SoilTransaction.class.st
+++ b/src/Soil-Core/SoilTransaction.class.st
@@ -108,8 +108,7 @@ SoilTransaction >> basicCommit [
 		journal validateIn: self.
 		soil journal writeTransactionJournal: journal.
 		journal commitIn: soil.
-		soil journal addTransactionJournal: journal.
-		soil checkpoint ]
+		soil journal addTransactionJournal: journal ]
 				ensure: [self releaseLocks ] ].
 		soil notificationHandler transactionCommitted: self
 


### PR DESCRIPTION
This PR improves the usage of terms commit and checkpoint in Soil. 

- A commit is the generation of a transaction journal and committing this to the heap. In this stage the journal is written to disk using fdatasync(), the data to the heap is just written and flushed which hands out the data to the OS but does are not on disk. 
- A checkpoint makes sure that all heap files are written to disk and it generates a checkpoint entry in the journal to mark up to which point the data is persisted in a guaranteed way.

The changes to improve this:

- the selector checkpoint in the control file has been renamed to lastCheckpoint which makes reading about the checkpoint easier
- the checkpoint method in the transaction was renamed to basicCommit. Before the checkpoint method was doing a commit plus checkpoint. Now it only does the commit phase. In order to be backward compatible the #commit selector does basicCommit and checkpoint which is a preparation to separate both completely
- there is now a checkpoint method in Soil which moved up from the persistent journal. It creates an checkpoint entry, the entry being committed will write all heap files to disk and after the checkpoint entry is written to the journal

NOTE: Soil will be a lot slower now. Before there was no assurance that files are written properly. Now with the recovery we close it in a way it should be safe. But for the same reason it will be slow. Especially as we still do a checkpoint per transaction commit it will always force writing and that makes it slow. Later we move the checkpoint to a later time which accelerates the committing