### PR TITLE
add #isOpen to Soil and SoilBinaryFile/SoilLockableStream

### DIFF
--- a/src/Soil-Core-Tests/SoilTest.class.st
+++ b/src/Soil-Core-Tests/SoilTest.class.st
@@ -166,6 +166,13 @@ SoilTest >> testInitializeDatabaseFailsIfExisting [
 ]
 
 { #category : #tests }
+SoilTest >> testIsOpen [
+	self assert: soil isOpen.
+	soil close.
+	self deny: soil isOpen
+]
+
+{ #category : #tests }
 SoilTest >> testMetricsUncached [
 	| tx metrics txn2 |
 	soil notificationHandler: SoilMetrics new.

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -213,6 +213,11 @@ Soil >> inspectionJournal [
 	^ self journal inspectionContent
 ]
 
+{ #category : #testing }
+Soil >> isOpen [
+	^control notNil and: [control isOpen]
+]
+
 { #category : #accessing }
 Soil >> journal [
 	^ journal 
@@ -295,6 +300,7 @@ Soil >> objectRepository [
 
 { #category : #'opening/closing' }
 Soil >> open [
+	self isOpen ifTrue: [ self error: 'Database already open' ].
 	self basicOpen.
 	journal recover
 ]

--- a/src/Soil-Core/SoilBinaryFile.class.st
+++ b/src/Soil-Core/SoilBinaryFile.class.st
@@ -47,6 +47,11 @@ SoilBinaryFile >> initializeStart [
 
 ]
 
+{ #category : #testing }
+SoilBinaryFile >> isOpen [
+	^stream isOpen
+]
+
 { #category : #locking }
 SoilBinaryFile >> lockAppendingFor: lockContext [
 	^ stream lockAppendingFor: lockContext 

--- a/src/Soil-File/SoilLockableStream.class.st
+++ b/src/Soil-File/SoilLockableStream.class.st
@@ -62,6 +62,11 @@ SoilLockableStream >> initializePath: aStringOrFileReference [
 	lockRegistry := SoilFileLockRegistry forPath: aStringOrFileReference asFileReference 
 ]
 
+{ #category : #testing }
+SoilLockableStream >> isOpen [
+	^fileStream closed not
+]
+
 { #category : #locking }
 SoilLockableStream >> lockAppendingFor: lockContext [
 	^ self registerLock: (self lockClass from: 0 to: 0 context: lockContext)


### PR DESCRIPTION
Guard #open in Soild to allow for just one opening. This raises an error (interesting to see if this actually happend).

Alternatively we could ignore.