### PR TITLE
Goard SoilBinaryFile against multiple opening without closing first

### DIFF
--- a/src/Soil-Core/SoilBinaryFile.class.st
+++ b/src/Soil-Core/SoilBinaryFile.class.st
@@ -49,7 +49,7 @@ SoilBinaryFile >> initializeStart [
 
 { #category : #testing }
 SoilBinaryFile >> isOpen [
-	^stream isOpen
+	^stream notNil and: [stream isOpen]
 ]
 
 { #category : #locking }
@@ -59,6 +59,7 @@ SoilBinaryFile >> lockAppendingFor: lockContext [
 
 { #category : #'open/close' }
 SoilBinaryFile >> open [
+	self isOpen ifTrue: [ self error: 'File already open' ].
 	stream := self soil lockableStream initializePath: self path
 ]
 

--- a/src/Soil-Core/SoilJournalFragmentFile.class.st
+++ b/src/Soil-Core/SoilJournalFragmentFile.class.st
@@ -194,8 +194,9 @@ SoilJournalFragmentFile >> inspectionTransactionJournals [
 			evaluated: #committedAt)
 ]
 
-{ #category : #'instance creation' }
+{ #category : #'open/close' }
 SoilJournalFragmentFile >> open [
+	self isOpen ifTrue: [ self error: 'File already open' ].
 	stream := SoilLockableStream path: path 
 ]
 


### PR DESCRIPTION
This seem to not happening now, but this
- unifies the #open semantics
- guards against future bugs