### PR TITLE
677-SoilPagedFileIndexStoreinitializeFilesystem-not-guarded-by-streamSemaphore

### DIFF
--- a/src/Soil-Core/SoilPagedFileIndexStore.class.st
+++ b/src/Soil-Core/SoilPagedFileIndexStore.class.st
@@ -91,14 +91,15 @@ SoilPagedFileIndexStore >> isOpen [
 
 { #category : #'open/close' }
 SoilPagedFileIndexStore >> open [
-	streamSemaphore critical: [  
-		self 
-			openStream ]
+	self isOpen ifTrue: [ self error: 'Index store already open' ].
+	self openStream
 ]
 
 { #category : #'open/close' }
 SoilPagedFileIndexStore >> openStream [
-	stream := SoilLockableStream path: index path.
+	streamSemaphore critical: [  
+		stream := SoilLockableStream path: index path
+	]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- move semaphore guard to openStream
-  guard #open to now allow multiple opening

fixes #677