### PR TITLE
Fix behavior registry version management bug

### DIFF
--- a/src/Soil-Core-Tests/SoilMigrationTest.class.st
+++ b/src/Soil-Core-Tests/SoilMigrationTest.class.st
@@ -423,6 +423,52 @@ SoilMigrationTest >> testMaterializingObjectWithReOrderedIvars [
 ]
 
 { #category : #tests }
+SoilMigrationTest >> testMaterializingVersionUpdateBug [
+	| tx tx2 object dict object2 tx3 |
+	
+	"create a class with two instVars one and two"
+	object := migrationClass new.
+	object 
+		instVarNamed: #one put: 1;
+		instVarNamed: #two put: 2.
+	dict := SoilPersistentDictionary new.
+	"put the version 1 shaped object under key v1"
+	dict at: #v1 put: object.
+	tx := soil newTransaction.
+	tx root: dict. 
+	"commit the object will write the first version of the behavior description"
+	tx commit.
+
+	"now we change the shape of the class"
+	migrationClass 
+		addSlot: #three asSlot.
+	object2 := migrationClass new.
+	object2 instVarNamed: #three put: 3.
+	tx2 := soil newTransaction.
+	"putting the version 2 shape of the object under key v2 to distinguish from v1"
+	tx2 root at: #v2 put: object2.
+	tx2 markDirty: object2.
+	"committing will write version 2 of the behavior description"
+	tx2 commit.
+	
+	"change the class again so it is distinction to the version 2 shape"
+	migrationClass 
+		 addSlot: #four asSlot.
+	tx3 := soil newTransaction.
+	"materializing the version 1 object caused a mismatch in version tracking. We ended up with 
+	two behavior description that have version 2"
+	(tx3 root at: #v1) yourself.
+	"reading the version 2 object will try to load version 2 of the behavior description but will
+	fail materializing because it gets the third version 2 (which should have been version 3) that
+	has more instVars as version 2 and it will fail reading as the stream is running short"
+	self 
+		shouldnt: [ (tx3 root at: #v2) yourself ]
+		raise: Error.
+	tx3 abort.
+
+]
+
+{ #category : #tests }
 SoilMigrationTest >> testSerializingObjectWithChangedShape [
 	| tx tx2 materializedRoot object tx3 description topDescription obj |
 	object := migrationClass new.

--- a/src/Soil-Core/SoilBehaviorRegistry.class.st
+++ b/src/Soil-Core/SoilBehaviorRegistry.class.st
@@ -38,7 +38,7 @@ SoilBehaviorRegistry >> behaviorVersionsUpTo: aSOBehaviorDescription transaction
 	self loadHistoryForBehaviorWithIndex: objectId index transaction: transaction.
 	chain := versions at: objectId index.
 	chain first isCurrent ifFalse: [ 
-		chain addFirst: ((SoilBehaviorDescription for: aSOBehaviorDescription objectClass) version: (aSOBehaviorDescription version + 1))].
+		chain addFirst: ((SoilBehaviorDescription for: aSOBehaviorDescription objectClass) version: (chain first version + 1))].
 	offset := chain detectIndex: [ :each | each matchesDescription: aSOBehaviorDescription ].
 	^ chain copyFrom: 1 to: offset
 ]


### PR DESCRIPTION
fixed version management in behavior registry. It was wrongly assuming that the next version of a behavior description is the lookup argument version + 1. But it needs to be the next version from the chain's top