### PR TITLE
Trivial Clean: remove dead code SoilRestoringIndexIterator>>returnProxyForSoil:readVersion:

### DIFF
--- a/src/Soil-Core/SoilRestoringIndexIterator.class.st
+++ b/src/Soil-Core/SoilRestoringIndexIterator.class.st
@@ -102,14 +102,6 @@ SoilRestoringIndexIterator >> returnObjectId [
 ]
 
 { #category : #strategy }
-SoilRestoringIndexIterator >> returnProxyForSoil: aSoil readVersion: aReadVersion [
-	itemStrategy := SoilProxyValueStrategy new 
-		iterator: self;
-		objectRepository: aSoil;
-		yourself
-]
-
-{ #category : #strategy }
 SoilRestoringIndexIterator >> returnProxyForTransaction: aSoilTransaction [ 
 	itemStrategy := SoilProxyValueStrategy new 
 		objectRepository: aSoilTransaction;


### PR DESCRIPTION
SoilRestoringIndexIterator>>returnProxyForSoil:readVersion: is not used and sends a non-existing selector

(there is returnProxyForTransaction: which is used instead)