### PR TITLE
BTree remove index 

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -27,6 +27,91 @@ SoilBTreeTest >> tearDown [
 ]
 
 { #category : #tests }
+SoilBTreeTest >> testAdd2 [
+	| entries |
+	index := SoilBTree new 
+		path: 'sunit-btree';
+		destroy;
+		initializeFilesystem;
+		initializeHeaderPage;
+		keySize: 1016;
+		valueSize: 8.
+	
+	entries :=  #(6 16 26 36 46 ).
+	
+	index at: 6  put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 6) equals: #[ 1 2 3 4 5 6 7 8 ].
+	
+	index at: 16  put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 6) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 16) equals: #[ 1 2 3 4 5 6 7 8 ].
+	
+	"We have two pages"
+	self assert: index pages size equals: 2.
+	"one index, one data"
+	self assert: index indexPages size equals: 1.
+	self assert: index dataPages size equals: 1.
+	"index page has just the default entry for the smalles possible key"
+	self assert: (index rootPage items collect: #key) size equals: 1.
+	self assert: (index rootPage items collect: #key) first equals: 0. 
+	
+	
+	"with adding 26, we have to split the data page"
+	index at: 26  put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: index pages size equals: 3.
+	self assert: index indexPages size equals: 1.
+	self assert: index dataPages size equals: 2.
+	
+	self assert: (index at: 6) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 16) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 26) equals: #[ 1 2 3 4 5 6 7 8 ].
+	
+	"index page has two entries: 0 and 16"
+	self assert: (index rootPage items collect: #key) size equals: 2.
+	self assert: (index rootPage items collect: #key) first equals: 0. 
+	self assert: (index rootPage items collect: #key) second equals: 16. 
+	
+	"adding 36 causes overlow in data node, have to add the new page to index"
+	index at: 36  put: #[ 1 2 3 4 5 6 7 8 ].
+	
+	self assert: index pages size equals: 4.
+	self assert: index indexPages size equals: 1.
+	self assert: index dataPages size equals: 3.
+	
+	self assert: (index at: 6) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 16) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 26) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 36) equals: #[ 1 2 3 4 5 6 7 8 ].
+	
+	"index page has trhee entries: 0 and 16 and 26"
+	self assert: (index rootPage items collect: #key) size equals: 3.
+	self assert: (index rootPage items collect: #key) first equals: 0. 
+	self assert: (index rootPage items collect: #key) second equals: 16. 
+	self assert: (index rootPage items collect: #key) third equals: 26. 
+	
+	"adding 46 causes overlow in data node and the index node"
+	index at: 46  put: #[ 1 2 3 4 5 6 7 8 ].
+	
+	self assert: index pages size equals: 7.
+	self assert: index indexPages size equals: 3.
+	self assert: index dataPages size equals: 4.
+	
+	self assert: (index at: 6) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 16) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 26) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 36) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 46) equals: #[ 1 2 3 4 5 6 7 8 ].
+	
+	"index page has trhee entries: 0 and 16 and 26"
+
+	self assert: (index rootPage items collect: #key) first equals: 0. 
+	self assert: (index rootPage items collect: #key) second equals: 26. 
+
+	self assert: index indexPages second items second key equals: 16.
+	self assert: index indexPages first items second key equals: 36.
+]
+
+{ #category : #tests }
 SoilBTreeTest >> testAddFirstOverflow [
 
 	| page capacity |
@@ -82,8 +167,8 @@ SoilBTreeTest >> testAddSecondOverflow [
 	1 to: capacity do: [ :n | index at: capacity + n put: #[ 1 2 3 4 5 6 7 8 ]].
 	self assert: index pages size equals: 4.
 	page := index pageAt: 4.
-	self assert: page numberOfItems equals: 253.
-	self assert: page items first key equals: 256.
+	self assert: page numberOfItems equals: 254.
+	self assert: page items first key equals: 255.
 	"check that the next pointer is correct after split"
 	self assert: ((index headerPage nextPageIn: index) nextPageIn: index) identicalTo: (index pageAt: 4).
 	index writePages.
@@ -101,8 +186,8 @@ SoilBTreeTest >> testAddSecondOverflowReload [
 	1 to: capacity do: [ :n | index at: capacity + n put: #[ 1 2 3 4 5 6 7 8 ]].
 	self assert: index pages size equals: 4.
 	page := index pageAt: 4.
-	self assert: page numberOfItems equals: 253.
-	self assert: page items first key equals: 256.
+	self assert: page numberOfItems equals: 254.
+	self assert: page items first key equals: 255.
 	"check that the next pointer is correct after split"
 	self assert: ((index headerPage nextPageIn: index) nextPageIn: index) identicalTo: (index pageAt: 4).
 
@@ -304,8 +389,8 @@ SoilBTreeTest >> testLastPage [
 	1 to: capacity - 1 do: [ :n |
 		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
 	index at: capacity put: #[ 8 7 6 5 4 3 2 1 ].
-	self assert: index pages size equals: 199.
-	self assert: index lastPage index equals: 199.
+	self assert: index pages size equals: 200.
+	self assert: index lastPage index equals: 200.
 	self assert: index lastPage isLastPage.
 	lastItem := index lastPage itemAt: capacity ifAbsent: [nil].
 	self assert: lastItem value equals: #[ 8 7 6 5 4 3 2 1 ].
@@ -371,6 +456,39 @@ SoilBTreeTest >> testPageAddFirstAndLoad [
 	"load succeeds"
 	self assert: (index at: #foo) equals: #[ 1 2 3 4 5 6 7 8 ].
 
+]
+
+{ #category : #tests }
+SoilBTreeTest >> testRemoveFromIndex [
+	| entries |
+	"We test that removing an entry will update the index"
+	index := SoilBTree new 
+		path: 'sunit-btree';
+		destroy;
+		initializeFilesystem;
+		initializeHeaderPage;
+		keySize: 1016;
+		valueSize: 8.
+	
+	entries :=  #(104 247 56 281 61 286 66 337 308 1 400 272 347 335 45 62 207 7 123 140).
+	
+	
+	entries do: [:toAdd |
+		index at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+
+	"can we find all the keys we added?"
+	entries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	"page 10 is the index page that has the index"
+	self assert: (index pageAt: 10) items last key equals: 335.
+	"now we remove 335"
+	index removeKey: 335.
+	"it is removed"
+	self assert: (index at: 335 ifAbsent: [true]).
+	"and the index is removed, too"
+	self deny: (index pageAt: 10) items last key equals: 335.
+	"we can add it back"
+	index at: 335  put: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index pageAt: 10) items last key equals: 335.
 ]
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -515,6 +515,7 @@ SoilBTreeTest >> testRemoveFromIndexAll [
 	entries do: [:entry| |removed|
 		removed := index removeKey: entry.
 		self assert: removed key equals: entry.
+		self assert: removed value equals: #[ 1 2 3 4 5 6 7 8 ].
 		remainingEntries remove: entry.
 		"check that all remaining entries can be found"	
 		remainingEntries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].

--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -512,8 +512,9 @@ SoilBTreeTest >> testRemoveFromIndexAll [
 	entries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
 	
 	
-	entries do: [:entry|
-		index removeKey: entry.
+	entries do: [:entry| |removed|
+		removed := index removeKey: entry.
+		self assert: removed key equals: entry.
 		remainingEntries remove: entry.
 		"check that all remaining entries can be found"	
 		remainingEntries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
@@ -528,11 +529,13 @@ SoilBTreeTest >> testRemoveFromIndexAll [
 { #category : #tests }
 SoilBTreeTest >> testRemoveKey [
 
-	| capacity |
+	| capacity removed |
 	capacity := index headerPage itemCapacity.
 	1 to: capacity do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
 	
-	index removeKey: 20.
+	removed := index removeKey: 20.
+	self assert: removed value equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: removed key equals: 20.
 	
 	self assert: (index at: 1) equals: #[ 1 2 3 4 5 6 7 8 ].
 	self assert: (index at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].

--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -492,6 +492,40 @@ SoilBTreeTest >> testRemoveFromIndex [
 ]
 
 { #category : #tests }
+SoilBTreeTest >> testRemoveFromIndexAll [
+	| entries remainingEntries |
+	"We test that removing an entry will update the index"
+	index := SoilBTree new 
+		path: 'sunit-btree';
+		destroy;
+		initializeFilesystem;
+		initializeHeaderPage;
+		keySize: 512;
+		valueSize: 512.
+	
+	entries :=  #(104 247 56 281 61 286 66 337 308 1 400 272 347 335 45 62 207 7 123 140).
+	remainingEntries := entries asOrderedCollection.
+	
+	entries do: [:toAdd |
+		index at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+	"can we find all the keys we added?"
+	entries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	
+	
+	entries do: [:entry|
+		index removeKey: entry.
+		remainingEntries remove: entry.
+		"check that all remaining entries can be found"	
+		remainingEntries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+		 ].
+	self assert: index isEmpty.
+	"and add back"
+	entries do: [:toAdd |
+		index at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+	entries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]]
+]
+
+{ #category : #tests }
 SoilBTreeTest >> testRemoveKey [
 
 	| capacity |

--- a/src/Soil-Core/SoilAbstractBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilAbstractBTreeDataPage.class.st
@@ -91,6 +91,12 @@ SoilAbstractBTreeDataPage >> readFrom: aStream [
 	next := (aStream next: self pointerSize) asInteger
 ]
 
+{ #category : #removing }
+SoilAbstractBTreeDataPage >> remove: aKey for: aBTree [
+	"remove and return the item"
+	^ self itemRemoveAt: aKey ifAbsent: nil
+]
+
 { #category : #accessing }
 SoilAbstractBTreeDataPage >> valueSize [ 
 	^ valueSize

--- a/src/Soil-Core/SoilAbstractBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilAbstractBTreeDataPage.class.st
@@ -52,12 +52,17 @@ SoilAbstractBTreeDataPage >> insertItem: anItem for: iterator [
 	"We have to split"
 	newPage := iterator index splitPage: self.
 	"newPage is the one with the small values"
-	pageWithItem := ((self smallestKey > anItem key)
+	pageWithItem := ((self smallestKey <= anItem key)
 						ifTrue: [ newPage ]
 						ifFalse: [ self ]).
 	iterator currentPage: pageWithItem.
 	"we need to add the new page to the index above"
 	^ return indexEntry: (newPage smallestKey -> newPage index)
+]
+
+{ #category : #testing }
+SoilAbstractBTreeDataPage >> isIndexPage [
+	^ false
 ]
 
 { #category : #testing }

--- a/src/Soil-Core/SoilBTreeIndexPage.class.st
+++ b/src/Soil-Core/SoilBTreeIndexPage.class.st
@@ -65,6 +65,11 @@ SoilBTreeIndexPage >> insertItem: item for: iterator [
 	^ return indexEntry: (newPage smallestKey -> newPage index)
 ]
 
+{ #category : #testing }
+SoilBTreeIndexPage >> isIndexPage [
+	^ true
+]
+
 { #category : #printing }
 SoilBTreeIndexPage >> printOn: aStream [ 
 	aStream << 'index page : #' << index asString
@@ -84,6 +89,21 @@ SoilBTreeIndexPage >> readItemsFrom: aStream [
 	items := SortedCollection new: numberOfItems.
 	numberOfItems timesRepeat: [ 
 		items add: (aStream next: self keySize) asInteger -> (aStream next: self pointerSize) asInteger ]
+]
+
+{ #category : #removing }
+SoilBTreeIndexPage >> remove: aKey for: aBTree [
+	| item page ret  |
+	
+	item := self findKey: aKey.
+	page := aBTree pageAt: item value.
+	ret := page remove: aKey for: aBTree.
+	"if the key is in the index, we have to update or remove"
+	(self hasKey: aKey) ifTrue: [
+				(ret notNil and: [page isNotEmpty])
+					ifTrue: [ item key: page items first key]
+				   ifFalse: [ret := self itemRemoveAt: aKey]].
+	^ ret
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilBTreeIndexPage.class.st
+++ b/src/Soil-Core/SoilBTreeIndexPage.class.st
@@ -102,7 +102,7 @@ SoilBTreeIndexPage >> remove: aKey for: aBTree [
 	(self hasKey: aKey) ifTrue: [
 				(ret notNil and: [page isNotEmpty])
 					ifTrue: [ item key: page items first key]
-				   ifFalse: [ret := self itemRemoveAt: aKey]].
+				   ifFalse: [self itemRemoveAt: aKey]].
 	^ ret
 ]
 

--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -44,6 +44,11 @@ SoilBTreePage >> insertItem: anItem for: iterator [
 	^ self subclassResponsibility
 ]
 
+{ #category : #testing }
+SoilBTreePage >> isIndexPage [
+	^ self subclassResponsibility
+]
+
 { #category : #accessing }
 SoilBTreePage >> pointerSize [
 	"this is the size in bytes used to point to other pages"
@@ -56,13 +61,18 @@ SoilBTreePage >> readFrom: aStream [
 	self readLastTransactionFrom: aStream
 ]
 
+{ #category : #removing }
+SoilBTreePage >> remove: aKey for: aBTree [ 
+	^ self subclassResponsibility
+]
+
 { #category : #private }
 SoilBTreePage >> split: newPage [
 	| middle |
 	
 	newPage 
 		index: index.
-	middle := (items size / 2) ceiling.
+	middle := (items size - 1 / 2) ceiling.
 	newPage setItems: (items copyFrom: middle + 1 to: items size).
 	items removeLast: items size - middle.
 	^ newPage

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -25,6 +25,11 @@ SoilBasicBTree >> asCopyOnWrite [
 ]
 
 { #category : #accessing }
+SoilBasicBTree >> dataPages [
+	^ (self pages reject: [ :page | page isIndexPage ]) asArray
+]
+
+{ #category : #accessing }
 SoilBasicBTree >> flush [
 	self store flush
 ]
@@ -32,6 +37,11 @@ SoilBasicBTree >> flush [
 { #category : #testing }
 SoilBasicBTree >> hasHeaderPage [
 	^ store hasHeaderPage 
+]
+
+{ #category : #accessing }
+SoilBasicBTree >> indexPages [
+	^ (self pages select: [ :page | page isIndexPage ]) asArray
 ]
 
 { #category : #initialization }
@@ -107,6 +117,13 @@ SoilBasicBTree >> open [
 { #category : #initialization }
 SoilBasicBTree >> pageClass [
 	^ SoilBTreeDataPage
+]
+
+{ #category : #removing }
+SoilBasicBTree >> removeKey: key ifAbsent: aBlock [
+	| return |
+	return := self rootPage remove: key for: self.
+	^ return ifNil: [aBlock value]
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilIndex.class.st
+++ b/src/Soil-Core/SoilIndex.class.st
@@ -202,7 +202,7 @@ SoilIndex >> removeKey: key [
 		ifAbsent: [ KeyNotFound signalFor: key in: self ]
 ]
 
-{ #category : #'instance creation' }
+{ #category : #removing }
 SoilIndex >> removeKey: key ifAbsent: aBlock [
 	| page index |
 	page := self newIterator 

--- a/src/Soil-Core/SoilIndexItemsPage.class.st
+++ b/src/Soil-Core/SoilIndexItemsPage.class.st
@@ -49,6 +49,12 @@ SoilIndexItemsPage >> firstItem [
 ]
 
 { #category : #testing }
+SoilIndexItemsPage >> hasKey: aKey [
+
+	^ items anySatisfy: [ :each | each key = aKey ]
+]
+
+{ #category : #testing }
 SoilIndexItemsPage >> hasRoom [
 	| used itemSize |
 	itemSize := self keySize + self valueSize.
@@ -77,6 +83,11 @@ SoilIndexItemsPage >> initialize [
 { #category : #testing }
 SoilIndexItemsPage >> isEmpty [
 	^ items isEmpty 
+]
+
+{ #category : #testing }
+SoilIndexItemsPage >> isNotEmpty [
+	^ items isNotEmpty
 ]
 
 { #category : #testing }


### PR DESCRIPTION
This is PR
- Fixes insertion / order to have the smallest to the left
- imporves BTree remove to remove the value from the Index, too

What is missing (next steps)

- rebalance on remove
- dealing with empty pages 

Closes #272