### PR TITLE
BTree index page: never change the index of an existing page

### DIFF
--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -70,8 +70,6 @@ SoilBTreePage >> remove: aKey for: aBTree [
 SoilBTreePage >> split: newPage [
 	| middle |
 	
-	newPage 
-		index: index.
 	middle := (items size - 1 / 2) ceiling.
 	newPage setItems: (items copyFrom: middle + 1 to: items size).
 	items removeLast: items size - middle.

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -77,17 +77,20 @@ SoilBasicBTree >> newHeaderPage [
 
 { #category : #'instance creation' }
 SoilBasicBTree >> newIndexPage [
-	^ SoilBTreeIndexPage new 
+	| newPage |
+	newPage := SoilBTreeIndexPage new 
 		keySize: self keySize;
 		pageSize: self pageSize;
-		yourself
+		yourself.
+		
+	newPage index: self store nextPageIndex.
+	^newPage
 ]
 
 { #category : #'instance creation' }
 SoilBasicBTree >> newIndexPageFromRoot: rootIndexPage [
 	| newPage |
 	newPage := self newIndexPage.
-	newPage index: self store nextPageIndex.
 	self store pageAt: newPage index put: newPage.
 	"now move over all items"
 	newPage setItems: rootIndexPage items.
@@ -135,7 +138,6 @@ SoilBasicBTree >> rootPage [
 SoilBasicBTree >> splitIndexPage: page [ 
 	| newPage |
 	newPage := page split: self newIndexPage.
-	newPage index: self store nextPageIndex.
 	self store pageAt: newPage index put: newPage.
 	^ newPage 
 ]

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -77,14 +77,11 @@ SoilBasicBTree >> newHeaderPage [
 
 { #category : #'instance creation' }
 SoilBasicBTree >> newIndexPage [
-	| newPage |
-	newPage := SoilBTreeIndexPage new 
+	^ SoilBTreeIndexPage new 
 		keySize: self keySize;
 		pageSize: self pageSize;
-		yourself.
-		
-	newPage index: self store nextPageIndex.
-	^newPage
+		index: self store nextPageIndex;
+		yourself
 ]
 
 { #category : #'instance creation' }


### PR DESCRIPTION
When splitting a BTree index page, we where changing the index of an already existing page

If we want to re-use empty pages, this is not a good idea.

This PR 
- makes sure the index of a page is never changed after creation
- move the setting to one place: #newIndexPage