### PR TITLE
SoilBTreeIterator:  fast #lastPage

### DIFF
--- a/src/Soil-Core/SoilBTreeIterator.class.st
+++ b/src/Soil-Core/SoilBTreeIterator.class.st
@@ -26,9 +26,9 @@ SoilBTreeIterator >> findPageFor: indexKey [
 
 { #category : #accessing }
 SoilBTreeIterator >> lastPage [
-	| pageNumber |
-	currentPage := index headerPage.
-	[ (pageNumber := currentPage next) isZero ] whileFalse: [ 
-		currentPage := self pageAt: pageNumber ].
-	^currentPage
+	"follow the last index entry till reaching a data page"
+	currentPage := index rootPage.
+	[ currentPage isIndexPage ] whileTrue: [
+		 currentPage := self pageAt: currentPage lastItem value ].
+	^ currentPage
 ]


### PR DESCRIPTION
this PR implements a fast #lastPage for BTree. We where following the next pointer of the data page, instead we can use the index page and follow the last entries till reaching a data page, which will be the last page