### PR TITLE
Btree: fix next pointer, more tests index iterator

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -465,6 +465,8 @@ SoilBTreeTest >> testRemoveFromIndexAll [
 		remainingEntries remove: entry.
 		"check that all remaining entries can be found"	
 		remainingEntries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+		"check size, this makes sure we can iterate over all remaining entries"
+		self assert: index values size equals: remainingEntries size.	
 		 ].
 	self assert: index isEmpty.
 	"and add back"
@@ -523,6 +525,10 @@ SoilBTreeTest >> testSplitIndexPage [
 	
 	"can we find all the keys we added?"
 	entries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	
+	"check size, this makes sure we can iterate over all remaining entries"
+	self assert: index values size equals: entries size.	
+
 ]
 
 { #category : #tests }
@@ -555,4 +561,8 @@ SoilBTreeTest >> testSplitIndexPageReleoad [
 	
 	"can we find all the keys we added?"
 	entries do: [:each | self assert: (index at: each ) equals: (#[ 1 2 3 4 5 6 7 8 ] asByteArrayOfSize: 512)].
+	
+	"check size, this makes sure we can iterate over all remaining entries"
+	self assert: index values size equals: entries size.	
+
 ]

--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -493,7 +493,6 @@ SoilIndexedDictionaryTest >> testNextcloseToWithTransaction [
 { #category : #tests }
 SoilIndexedDictionaryTest >> testRemoveKeyIfAbsentWithTransaction [
 
-
 	| tx tx2 tag |
 	tx := soil newTransaction.
 	tx root: dict.

--- a/src/Soil-Core-Tests/SoilIndexedIteratorTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedIteratorTest.class.st
@@ -169,6 +169,10 @@ SoilIndexedIteratorTest >> testPrior [
 	iterator := index newIterator.
 	"select a key where we have to cross over to another page"
 	toFind := index class == SoilSkipList ifTrue: [ 254 ] ifFalse: [ 255 ].
+	"the key is indeed the first one in the page"
+	self assert: (iterator findPageFor: toFind) firstItem key equals: toFind.
+	
+	iterator := index newIterator.
 	value := iterator
 		find: toFind;
 		prior.
@@ -197,10 +201,74 @@ SoilIndexedIteratorTest >> testPriorAssociation [
 	1 to: capacity do: [ :n |
 		index at: n put: (n asByteArrayOfSize: 8) ].
 	iterator := index newIterator.
+	
 	"select a key where we have to cross over to another page"
 	toFind := index class == SoilSkipList ifTrue: [ 254 ] ifFalse: [ 255 ].
+	"the key is indeed the first one in the page"
+	self assert: (iterator findPageFor: toFind) firstItem key equals: toFind.
+	
+	iterator := index newIterator.
 	value := iterator
 		find: toFind;
 		priorAssociation.
 	self assert: value value equals: ((toFind - 1) asByteArrayOfSize: 8)
+]
+
+{ #category : #tests }
+SoilIndexedIteratorTest >> testPriorAssociationFirstPage [
+	
+	| capacity iterator value  |
+	capacity := index headerPage itemCapacity * 2.
+	1 to: capacity do: [ :n |
+		index at: n put: (n asByteArrayOfSize: 8) ].
+	
+	"prior of first"
+	iterator := index newIterator.
+	value := iterator
+		find: 1;
+		priorAssociation.
+	self assert: value value equals: nil.
+	
+	"prior of last"
+	iterator := index newIterator.
+	value := iterator
+		find: capacity;
+		priorAssociation.
+	self assert: value value equals: (capacity - 1 asByteArrayOfSize: 8).
+]
+
+{ #category : #tests }
+SoilIndexedIteratorTest >> testPriorPage [
+	
+	| capacity iterator page toFind priorPage |
+	capacity := index headerPage itemCapacity * 2.
+	1 to: capacity do: [ :n |
+		index at: n put: (n asByteArrayOfSize: 8) ].
+	iterator := index newIterator.
+	"select a key where we have to cross over to another page"
+	toFind := index class == SoilSkipList ifTrue: [ 254 ] ifFalse: [ 255 ].
+	"the key is indeed the first one in the page"
+	self assert: (iterator findPageFor: toFind) firstItem key equals: toFind.
+	
+	iterator := index newIterator.
+	priorPage := iterator
+		find: toFind;
+		priorPage.
+		
+	iterator := index newIterator.
+	page := iterator findPageFor: toFind.
+			
+	self assert: priorPage next equals: page index
+]
+
+{ #category : #tests }
+SoilIndexedIteratorTest >> testPriorPageFirstPage [
+	
+	| capacity iterator |
+	capacity := index headerPage itemCapacity * 2.
+	1 to: capacity do: [ :n |
+		index at: n put: (n asByteArrayOfSize: 8) ].
+	iterator := index newIterator.
+	iterator firstPage. "set iterator currentPage to first page"
+	self assert: iterator priorPage equals: nil
 ]

--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -73,6 +73,7 @@ SoilBTreePage >> split: newPage [
 	middle := (items size - 1 / 2) ceiling.
 	newPage setItems: (items copyFrom: middle + 1 to: items size).
 	items removeLast: items size - middle.
+	dirty := true.
 	^ newPage
 ]
 

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -144,6 +144,7 @@ SoilBasicBTree >> splitPage: page [
 	| newPage |
 	newPage := page split: store newPage.
 	newPage index: self store nextPageIndex.
+	newPage next: page next.
 	page next: newPage index.
 	self store pageAt: newPage index put: newPage.
 	^ newPage 

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -85,12 +85,11 @@ SoilIndexIterator >> basicNextAssociation [
 						^ i ]
 					ifNil: [ 
 						"if we did not find an element after the current key we
-						need to proceed with the next page. 
-						if the next index is 0 there is no next page and we 
-						return nil"
-						(currentPage next = 0) ifTrue: [ ^ nil ].
+						need to proceed with the next page.
+						For the last page there is no next page and we return nil"
+						(currentPage isLastPage) ifTrue: [ ^ nil ].
 						"if there is a next page we set it to current and restart"
-						currentPage := index store pageAt: currentPage next.
+						currentPage := self nextPage.
 						currentKey := nil ] ]
 			ifNil: [
 				"without currentKey we are looking for the first item in a page.
@@ -169,7 +168,8 @@ SoilIndexIterator >> findPriorPageOf: aPage [
 	"For now we use a very slow approach that searched all pages from the first following the next pointer.
 	TODO:
 	We need to do something more clever that iterates similar to finding a key, thus not requiring all pages"
-	^ self pagesDo: [ :page | page next == aPage index ifTrue: [ ^page ] ]
+	self pagesDo: [ :page | page next == aPage index ifTrue: [ ^page ] ].
+	^nil
 ]
 
 { #category : #accessing }
@@ -196,6 +196,11 @@ SoilIndexIterator >> firstAssociation [
 	item := self nextAssociation.
 	currentKey := item ifNotNil: [ item key ].
 	^ item
+]
+
+{ #category : #accessing }
+SoilIndexIterator >> firstPage [
+	^ currentPage := index firstPage
 ]
 
 { #category : #accessing }
@@ -227,6 +232,7 @@ SoilIndexIterator >> last [
 SoilIndexIterator >> lastAssociation [
 	"Note: key will be index key"
 	| lastAssociation restoredItem |
+	"priorAssociation will use last page if currentPage is nil"
 	lastAssociation := self priorAssociation ifNil: [ ^nil ].
 	restoredItem := self restoreItem: lastAssociation.
 	^ restoredItem 
@@ -362,12 +368,17 @@ SoilIndexIterator >> priorAssociation [
 					ifNil: [ 
 						"are we the first page? if yes, there is no item before"
 						currentPage isHeaderPage ifTrue: [ ^nil ].
-						currentPage := self findPriorPageOf: currentPage.
+						currentPage := self priorPage.
 						currentKey := nil ] ]
 			ifNil: [
 				currentPage isEmpty ifTrue: [ ^ nil ].
 				^ currentPage lastItem ifNotNil: [ :item2 | currentKey := item2 key. item2 ] ] ].
 	Error signal: 'shouldnt happen'
+]
+
+{ #category : #accessing }
+SoilIndexIterator >> priorPage [ 
+	^ self findPriorPageOf: currentPage
 ]
 
 { #category : #removing }


### PR DESCRIPTION
- more tests for the iterator
- SoilIndexIterator: add #firstPage and #priorPage
- use #priorPage and #nextPage 
- Btree: fix next pointer
- Btree tests: check that itaration works after split (that next pointer is correct)
- make sure #priorPage  works on the first page