### PR TITLE
use "previous" instead of "prior"

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexedIteratorTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedIteratorTest.class.st
@@ -160,7 +160,7 @@ SoilIndexedIteratorTest >> testLastWithRemovedItem [
 ]
 
 { #category : #tests }
-SoilIndexedIteratorTest >> testPrior [
+SoilIndexedIteratorTest >> testPrevious [
 	
 	| capacity iterator value toFind |
 	capacity := index headerPage itemCapacity * 2.
@@ -175,12 +175,12 @@ SoilIndexedIteratorTest >> testPrior [
 	iterator := index newIterator.
 	value := iterator
 		find: toFind;
-		prior.
+		previous.
 	self assert: value equals: ((toFind - 1) asByteArrayOfSize: 8)
 ]
 
 { #category : #tests }
-SoilIndexedIteratorTest >> testPrior5 [
+SoilIndexedIteratorTest >> testPrevious5 [
 	
 	| capacity iterator result |
 	capacity := index headerPage itemCapacity * 2.
@@ -189,12 +189,12 @@ SoilIndexedIteratorTest >> testPrior5 [
 	iterator := index newIterator.
 	result := iterator
 		find: 6;
-		prior: 5.
+		previous: 5.
 	self assert: result size equals: 5.
 ]
 
 { #category : #tests }
-SoilIndexedIteratorTest >> testPriorAssociation [
+SoilIndexedIteratorTest >> testPreviousAssociation [
 	
 	| capacity iterator value toFind |
 	capacity := index headerPage itemCapacity * 2.
@@ -210,12 +210,12 @@ SoilIndexedIteratorTest >> testPriorAssociation [
 	iterator := index newIterator.
 	value := iterator
 		find: toFind;
-		priorAssociation.
+		previousAssociation.
 	self assert: value value equals: ((toFind - 1) asByteArrayOfSize: 8)
 ]
 
 { #category : #tests }
-SoilIndexedIteratorTest >> testPriorAssociationFirstPage [
+SoilIndexedIteratorTest >> testPreviousAssociationFirstPage [
 	
 	| capacity iterator value  |
 	capacity := index headerPage itemCapacity * 2.
@@ -226,19 +226,19 @@ SoilIndexedIteratorTest >> testPriorAssociationFirstPage [
 	iterator := index newIterator.
 	value := iterator
 		find: 1;
-		priorAssociation.
+		previousAssociation.
 	self assert: value value equals: nil.
 	
 	"prior of last"
 	iterator := index newIterator.
 	value := iterator
 		find: capacity;
-		priorAssociation.
+		previousAssociation.
 	self assert: value value equals: (capacity - 1 asByteArrayOfSize: 8).
 ]
 
 { #category : #tests }
-SoilIndexedIteratorTest >> testPriorPage [
+SoilIndexedIteratorTest >> testPreviousPage [
 	
 	| capacity iterator page toFind priorPage |
 	capacity := index headerPage itemCapacity * 2.
@@ -253,7 +253,7 @@ SoilIndexedIteratorTest >> testPriorPage [
 	iterator := index newIterator.
 	priorPage := iterator
 		find: toFind;
-		priorPage.
+		previousPage.
 		
 	iterator := index newIterator.
 	page := iterator findPageFor: toFind.
@@ -262,7 +262,7 @@ SoilIndexedIteratorTest >> testPriorPage [
 ]
 
 { #category : #tests }
-SoilIndexedIteratorTest >> testPriorPageFirstPage [
+SoilIndexedIteratorTest >> testPreviousPageFirstPage [
 	
 	| capacity iterator |
 	capacity := index headerPage itemCapacity * 2.
@@ -270,5 +270,5 @@ SoilIndexedIteratorTest >> testPriorPageFirstPage [
 		index at: n put: (n asByteArrayOfSize: 8) ].
 	iterator := index newIterator.
 	iterator firstPage. "set iterator currentPage to first page"
-	self assert: iterator priorPage equals: nil
+	self assert: iterator previousPage equals: nil
 ]

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -164,7 +164,7 @@ SoilIndexIterator >> findPageFor: indexKey [
 ]
 
 { #category : #private }
-SoilIndexIterator >> findPriorPageOf: aPage [
+SoilIndexIterator >> findPreviousPageOf: aPage [
 	"For now we use a very slow approach that searched all pages from the first following the next pointer.
 	TODO:
 	We need to do something more clever that iterates similar to finding a key, thus not requiring all pages"
@@ -232,8 +232,8 @@ SoilIndexIterator >> last [
 SoilIndexIterator >> lastAssociation [
 	"Note: key will be index key"
 	| lastAssociation restoredItem |
-	"priorAssociation will use last page if currentPage is nil"
-	lastAssociation := self priorAssociation ifNil: [ ^nil ].
+	"previousAssociation will use last page if currentPage is nil"
+	lastAssociation := self previousAssociation ifNil: [ ^nil ].
 	restoredItem := self restoreItem: lastAssociation.
 	^ restoredItem 
 		ifNotNil: [ restoredItem key -> (self convertValue: restoredItem value) ] 
@@ -300,7 +300,7 @@ SoilIndexIterator >> nextCloseTo: key [
 
 { #category : #private }
 SoilIndexIterator >> nextKeyCloseTo: key [
-	"Note: returnrd key will be an index key"
+	"Note: returned key will be an index key"
 	| indexKey |
 	indexKey := index indexKey: key.
 	self findPageFor: indexKey.
@@ -336,23 +336,23 @@ SoilIndexIterator >> pagesDo: aBlock [
 ]
 
 { #category : #accessing }
-SoilIndexIterator >> prior [
-	^ self priorAssociation value
+SoilIndexIterator >> previous [
+	^ self previousAssociation value
 ]
 
 { #category : #accessing }
-SoilIndexIterator >> prior: anInteger [
+SoilIndexIterator >> previous: anInteger [
 	| result |
 	result := OrderedCollection new: anInteger.
 	anInteger timesRepeat: [
-		| prior |
-		prior := self prior ifNil: [ ^ result].
-		result add: prior ].
+		| previous |
+		previous := self previous ifNil: [ ^ result].
+		result add: previous ].
 	^ result
 ]
 
 { #category : #accessing }
-SoilIndexIterator >> priorAssociation [
+SoilIndexIterator >> previousAssociation [
 	| item |
 	"Find the association before, if currentPage is not set we return the last association"
 	currentPage ifNil: [ 
@@ -368,7 +368,7 @@ SoilIndexIterator >> priorAssociation [
 					ifNil: [ 
 						"are we the first page? if yes, there is no item before"
 						currentPage isHeaderPage ifTrue: [ ^nil ].
-						currentPage := self priorPage.
+						currentPage := self previousPage.
 						currentKey := nil ] ]
 			ifNil: [
 				currentPage isEmpty ifTrue: [ ^ nil ].
@@ -377,8 +377,8 @@ SoilIndexIterator >> priorAssociation [
 ]
 
 { #category : #accessing }
-SoilIndexIterator >> priorPage [ 
-	^ self findPriorPageOf: currentPage
+SoilIndexIterator >> previousPage [ 
+	^ self findPreviousPageOf: currentPage
 ]
 
 { #category : #removing }


### PR DESCRIPTION
rename

This does not add any deprecated methods as the names are only used on the level of the iterator