### PR TITLE
 BTree: #findPreviousPageOf: without iterating all data pages

### DIFF
--- a/src/Soil-Core/SoilBTreeIndexPage.class.st
+++ b/src/Soil-Core/SoilBTreeIndexPage.class.st
@@ -35,6 +35,35 @@ SoilBTreeIndexPage >> findKey: aKey [
 	^nil
 ]
 
+{ #category : #searching }
+SoilBTreeIndexPage >> findKeyOffset: aKey [
+	| offset |
+	"this returns the offset of the index entry where aKey would be found"
+	offset := items size.
+	items
+		reverseDo: [ :each |
+			each key <= aKey 
+				ifTrue: [ ^ offset ].
+			offset := offset -1 ].
+	^nil
+]
+
+{ #category : #private }
+SoilBTreeIndexPage >> findPreviousPage: aKey with: aBTree [
+	| item page |
+	item := self findKey: aKey.
+	page := aBTree pageAt: item value.
+	
+	page isHeaderPage ifTrue: [ ^nil ].
+	
+	^ page isIndexPage 
+		ifFalse: [
+			"if we get a data page, we know that the prior page is just the page
+			referenced from the index enrty before "
+			aBTree pageAt: (self items at: (self findKeyOffset: aKey) - 1) value]
+		ifTrue:  [ page findPreviousPage: aKey with: aBTree ]
+]
+
 { #category : #utilities }
 SoilBTreeIndexPage >> headerSize [
 	^ super headerSize  

--- a/src/Soil-Core/SoilBTreeIterator.class.st
+++ b/src/Soil-Core/SoilBTreeIterator.class.st
@@ -24,6 +24,14 @@ SoilBTreeIterator >> findPageFor: indexKey [
 	^currentPage := index rootPage find: indexKey with: index
 ]
 
+{ #category : #private }
+SoilBTreeIterator >> findPreviousPageOf: aPage [
+	| key |
+	"The previous page can be found by searching using the index pages for the first item in aPage"
+	key := aPage firstItem key.
+	^currentPage := index rootPage findPreviousPage: key with: index
+]
+
 { #category : #accessing }
 SoilBTreeIterator >> lastPage [
 	"follow the last index entry till reaching a data page"


### PR DESCRIPTION
The PR implements a  #findPreviousPageOf: for the BTree that does not need to iterate over all the Data pages.

BTree part of #581