### PR TITLE
581-rethink-and-speed-up-SoilPagedIndexStorefindPreviousPageOf

### DIFF
--- a/src/Soil-Core/SoilBTreeIterator.class.st
+++ b/src/Soil-Core/SoilBTreeIterator.class.st
@@ -28,6 +28,7 @@ SoilBTreeIterator >> findPageFor: indexKey [
 SoilBTreeIterator >> findPreviousPageOf: aPage [
 	
 	aPage isHeaderPage ifTrue: [ ^nil ].
+	aPage isEmpty ifTrue: [ ^super findPreviousPageOf: aPage ].
 	"The previous page can be found by searching using the index pages for the first item in aPage"
 	^currentPage := index rootPage findPreviousPage: aPage firstItem key with: index
 ]

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -165,13 +165,9 @@ SoilIndexIterator >> findPageFor: indexKey [
 
 { #category : #private }
 SoilIndexIterator >> findPreviousPageOf: aPage [
-	"For now we use a very slow approach that searched all pages from the first following the next pointer.
-	TODO:
-	We need to do something more clever that iterates similar to finding a key, thus not requiring all pages"
-	aPage isHeaderPage ifTrue: [ ^nil ].
-	
+	"Slow approach that searched all pages from the first following the next pointer, only called for empty pages"
+
 	self pagesDo: [ :page | page next == aPage index ifTrue: [ ^page ] ].
-	
 	self error: 'should not happen'
 ]
 

--- a/src/Soil-Core/SoilSkipListIterator.class.st
+++ b/src/Soil-Core/SoilSkipListIterator.class.st
@@ -54,6 +54,27 @@ SoilSkipListIterator >> findPageFor: indexKey [
 	^ currentPage 
 ]
 
+{ #category : #private }
+SoilSkipListIterator >> findPreviousPageOf: aPage [
+	| pageIndex candidatePage |
+	aPage isHeaderPage ifTrue: [ ^nil ].
+	aPage isEmpty ifTrue: [ ^super findPreviousPageOf: aPage ].
+
+	currentPage := index headerPage.
+	levels size to: 1 by: -1 do: [ :level |
+		[ 
+			pageIndex := currentPage rightAt: level.
+			(pageIndex > 0) and: [ 
+				candidatePage := self pageAt: pageIndex.
+				(candidatePage isLastPage not and: [ (self pageAt: (candidatePage next)) smallestKey <= aPage smallestKey])]]
+					whileTrue: [ currentPage := candidatePage  ].
+			self atLevel: level put: currentPage. ].
+		
+	self assert: (self nextPage == aPage).
+	
+	^ currentPage 
+]
+
 { #category : #accessing }
 SoilSkipListIterator >> index: aSoilSkipList [ 
 	super index: aSoilSkipList.

--- a/src/Soil-Core/SoilSkipListIterator.class.st
+++ b/src/Soil-Core/SoilSkipListIterator.class.st
@@ -66,7 +66,7 @@ SoilSkipListIterator >> findPreviousPageOf: aPage [
 			pageIndex := currentPage rightAt: level.
 			(pageIndex > 0) and: [ 
 				candidatePage := self pageAt: pageIndex.
-				(candidatePage isLastPage not and: [ (self pageAt: (candidatePage next)) smallestKey <= aPage smallestKey])]]
+				(candidatePage isLastPage not and: [ (self pageAt: (candidatePage next)) == aPage])]]
 					whileTrue: [ currentPage := candidatePage  ].
 			self atLevel: level put: currentPage. ].
 		


### PR DESCRIPTION
implement a fast #findPreviousPageOf: for SkipList searching lile #findPageFor:, but stopping when we find the key in the next page.

Needs some careful check. There is an assert: in  #findPreviousPageOf:  to make sure we catch any problem early

fixes #581