### PR TITLE
set lockRegistry instance to nil to make sure the weak value dictiona…

### DIFF
--- a/src/Soil-File/SoilLockableStream.class.st
+++ b/src/Soil-File/SoilLockableStream.class.st
@@ -29,6 +29,7 @@ SoilLockableStream >> close [
 	fileStream ifNotNil: [  
 		fileStream closed 
 			ifFalse: [ fileStream close ] ].
+	lockRegistry := nil 
 
 ]
 


### PR DESCRIPTION
…ry works better in case the stream is kept