### PR TITLE
Remove dead code:  #objectIn:

### DIFF
--- a/src/Soil-Core/SoilNewObjectEntry.class.st
+++ b/src/Soil-Core/SoilNewObjectEntry.class.st
@@ -71,11 +71,6 @@ SoilNewObjectEntry >> objectIds [
 	^ { objectId }
 ]
 
-{ #category : #'as yet unclassified' }
-SoilNewObjectEntry >> objectIn: aSoilTransaction [
-	^ (aSoilTransaction materializeRecord: bytes asSoilClusterVersion) object 
-]
-
 { #category : #printing }
 SoilNewObjectEntry >> printOn: aStream [ 
 	super printOn: aStream.

--- a/src/Soil-Core/SoilNewObjectVersionEntry.class.st
+++ b/src/Soil-Core/SoilNewObjectVersionEntry.class.st
@@ -18,11 +18,6 @@ SoilNewObjectVersionEntry >> oldBytes: aCollection [
 	oldBytes := aCollection
 ]
 
-{ #category : #'as yet unclassified' }
-SoilNewObjectVersionEntry >> oldObjectIn: aSoilTransaction [
-	^ (aSoilTransaction materializeRecord: oldBytes asSoilClusterVersion) object
-]
-
 { #category : #'instance creation' }
 SoilNewObjectVersionEntry >> readFrom: aStream [ 
 	| oldBytesSize |


### PR DESCRIPTION
This PR removes two unused methods #objectIn: (no sender) that themselves send #asSoilClusterVersion which would be DNU

The methods are therefore dead code