### PR TITLE
unify #removeKey:, add tests, do not search index twice fro remove

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
@@ -344,3 +344,21 @@ SoilIndexIteratorTest >> testPreviousPageFirstPage [
 	iterator firstPage. "set iterator currentPage to first page"
 	self assert: iterator previousPage equals: nil
 ]
+
+{ #category : #tests }
+SoilIndexIteratorTest >> testRemoveKey [
+	
+	| capacity iterator result |
+	capacity := index headerPage itemCapacity * 2.
+	1 to: capacity do: [ :n |
+		index at: n put: (n asByteArrayOfSize: 8) ].
+	iterator := index newIterator.
+	"removing non-existing keys raises KeyNotFound error"
+	self should: [iterator removeKey: capacity+1] raise: KeyNotFound.
+	result := iterator removeKey: 1.
+	self assert: result equals: (1 asByteArrayOfSize: 8).
+	result := iterator removeKey: capacity.
+	self assert: result equals: (capacity asByteArrayOfSize: 8).
+	"removing the key again raises KeyNotFound, too"
+	self should: [iterator removeKey: capacity] raise: KeyNotFound.
+]

--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -492,9 +492,8 @@ SoilIndexedDictionaryTest >> testNextcloseToWithTransaction [
 ]
 
 { #category : #tests }
-SoilIndexedDictionaryTest >> testRemoveKeyIfAbsentWithTransaction [
-
-	| tx tx2 tag |
+SoilIndexedDictionaryTest >> testRemoveKey [
+	| tx tx2 tag return |
 	tx := soil newTransaction.
 	tx root: dict.
 	dict at: #one put: #onevalue.
@@ -503,8 +502,9 @@ SoilIndexedDictionaryTest >> testRemoveKeyIfAbsentWithTransaction [
 	"open a second transaction ..."
 	tx2 := soil newTransaction.
 	"remove the key"
-	tx2 root removeKey: #two.
+	return := tx2 root removeKey: #two.
 	self assert: tx2 root size equals: 1.
+	self assert: return equals: #twovalue.
 	"remove again to test absent case"
 	tag := false.
 	tx2 root removeKey: #three ifAbsent: [ tag := true ].
@@ -512,8 +512,7 @@ SoilIndexedDictionaryTest >> testRemoveKeyIfAbsentWithTransaction [
 	"remove again to test absent case with already removed key"
 	tag := false.
 	tx2 root removeKey: #two ifAbsent: [ tag := true ].
-	self assert: tag.
-	
+	self assert: tag
 
 ]
 

--- a/src/Soil-Core-Tests/SoilPersistentDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilPersistentDictionaryTest.class.st
@@ -110,15 +110,16 @@ SoilPersistentDictionaryTest >> testNewPersistentDictionary [
 { #category : #tests }
 SoilPersistentDictionaryTest >> testRemoveKey [
 
-	| dict transaction |
+	| dict transaction removed |
 	transaction := soil newTransaction.
 	dict := SoilPersistentDictionary new.
 	transaction makeRoot: dict.
 	dict at: #test put: 'string'.
 	dict at: #test2 put: 'string2'.
-	dict removeKey: #test.
+	removed := dict removeKey: #test.
 	transaction commit.
-		
+	
+	self assert: removed equals: 'string'.
 	self assert: (dict at: #test2) equals: 'string2'.
 	self deny: (dict includesKey: #test)
 	

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -400,8 +400,15 @@ SoilIndexIterator >> removeItemsSuchThat: aBlock [
 
 { #category : #removing }
 SoilIndexIterator >> removeKey: key [
+	^ self 
+		removeKey: key 
+		ifAbsent: [ KeyNotFound signalFor: key in: self ]
+]
+
+{ #category : #removing }
+SoilIndexIterator >> removeKey: key ifAbsent: aBlock [
 	| returnValue |
-	returnValue := self at: key.
+	returnValue := self at: key ifAbsent: aBlock.
 	self 
 		at: key 
 		put: SoilObjectId removed.

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -399,10 +399,13 @@ SoilIndexIterator >> removeItemsSuchThat: aBlock [
 ]
 
 { #category : #removing }
-SoilIndexIterator >> removeKey: key [ 
-	^ self 
+SoilIndexIterator >> removeKey: key [
+	| returnValue |
+	returnValue := self at: key.
+	self 
 		at: key 
-		put: SoilObjectId removed
+		put: SoilObjectId removed.
+	^ returnValue
 ]
 
 { #category : #private }

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -407,12 +407,23 @@ SoilIndexIterator >> removeKey: key [
 
 { #category : #removing }
 SoilIndexIterator >> removeKey: key ifAbsent: aBlock [
-	| returnValue |
-	returnValue := self at: key ifAbsent: aBlock.
-	self 
-		at: key 
+	| indexKey item oldValue |
+	indexKey := index indexKey: key.
+	"We search for the data page for the key to update the value with a removed ID
+	and return the prior value just like #at: would do"
+	self findPageFor: indexKey.
+	item :=  self restoreItem: (currentPage itemAt: indexKey ifAbsent: aBlock).
+	oldValue := item
+		ifNotNil: [ 
+			(self convertValue: item value) 
+				ifNil: [ aBlock value ] ]
+		ifNil: [ aBlock value ].
+	"We replace the value with the removed ID. As the key stays, we do not need to do a full insert 
+	(e.g no need to update index pages for the BTree"
+	currentPage 
+		itemAt: indexKey 
 		put: SoilObjectId removed.
-	^ returnValue
+	^ oldValue
 ]
 
 { #category : #private }

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -412,7 +412,7 @@ SoilIndexIterator >> removeKey: key ifAbsent: aBlock [
 	"We search for the data page for the key to update the value with a removed ID
 	and return the prior value just like #at: would do"
 	self findPageFor: indexKey.
-	item :=  self restoreItem: (currentPage itemAt: indexKey ifAbsent: aBlock).
+	item :=  self restoreItem: (currentPage itemAt: indexKey ifAbsent: [^ aBlock value]).
 	oldValue := item
 		ifNotNil: [ 
 			(self convertValue: item value) 

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -206,11 +206,11 @@ SoilIndexedDictionary >> removeKey: key ifAbsent: aBlock [
 	"remove from newValues as there could be a new at:put: on that
 	key but removing the key will remove the value again"
 	newValues removeKey: key ifAbsent: nil.
-	v := self basicAt: key ifAbsent: [^ aBlock value].
+	v := self newIterator removeKey: key ifAbsent: [^ aBlock value].
 	removedValues 
 			at: key 
 			put: v asSoilObjectId.
-	^ self newIterator removeKey: key
+	^v
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- add more tests, especially regarding return value
- test what happend if we remove already removed keys

This fixes SoilIndexIterator to return the value, the lookup fixes the behavior, too, for removing keys that are already removed (raises now an exception)

In addition, this fixes the double lookup that we had for removeKey: (was a implemented as #at: plus #at:put:), now we search only once and update the existing item if it was there.