### PR TITLE
734-lastAssociation-should-always-return-the-last 

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
@@ -159,6 +159,19 @@ SoilIndexIteratorTest >> testLast [
 ]
 
 { #category : #tests }
+SoilIndexIteratorTest >> testLastAssociation [
+	| iterator |
+	
+	"lastAssociation always returns last"
+	iterator := index newIterator.
+	iterator at: 1 put: (1 asByteArrayOfSize: 8).
+	iterator at: 2 put: (2 asByteArrayOfSize: 8).
+
+	self assert: iterator lastAssociation value equals: (2 asByteArrayOfSize: 8).
+	self assert: iterator lastAssociation value equals: (2 asByteArrayOfSize: 8).
+]
+
+{ #category : #tests }
 SoilIndexIteratorTest >> testLastPage [
 	
 	| capacity lastPage |

--- a/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
@@ -162,6 +162,10 @@ SoilIndexIteratorTest >> testLast [
 SoilIndexIteratorTest >> testLastAssociation [
 	| iterator |
 	
+	"test empty index"
+	iterator := index newIterator.
+	self assert: iterator lastAssociation isNil.
+	
 	"lastAssociation always returns last"
 	iterator := index newIterator.
 	iterator at: 1 put: (1 asByteArrayOfSize: 8).

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -246,7 +246,7 @@ SoilIndexIterator >> lastAssociation [
 	currentPage := nil.
 	currentKey := nil.
 	"previousAssociation returns last key if currentPage is nil"
-	lastAssociation := self previousAssociation.
+	lastAssociation := self previousAssociation ifNil: [ ^nil ].
 	[restoredItem := self restoreItem: lastAssociation] whileNil: [   
 			"if the last entry is deleted, we need to take the one before"
 			lastAssociation := self previousAssociation ifNil: [ ^nil ] ].

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -243,14 +243,15 @@ SoilIndexIterator >> last: anInteger [
 SoilIndexIterator >> lastAssociation [
 	"Note: key will be index key"
 	| lastAssociation restoredItem |
-	"previousAssociation will use last page if currentPage is nil"
-	lastAssociation := self previousAssociation ifNil: [ ^nil ].
-	restoredItem := self restoreItem: lastAssociation.
-	^ restoredItem 
-		ifNotNil: [ restoredItem key -> (self convertValue: restoredItem value) ] 
-		ifNil: [
+	currentPage := nil.
+	currentKey := nil.
+	"previousAssociation returns last key if currentPage is nil"
+	lastAssociation := self previousAssociation.
+	[restoredItem := self restoreItem: lastAssociation] whileNil: [   
 			"if the last entry is deleted, we need to take the one before"
-			^ self lastAssociation ] 
+			lastAssociation := self previousAssociation ifNil: [ ^nil ] ].
+
+	^ restoredItem key -> (self convertValue: restoredItem value).
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
- add test for #lastAssociation : calling it twice with the same iterator should return the last

- change #lastAssociation to not use recursion but a loop calling #previousAssociation

fixes #734