### PR TITLE
#lastAssociation should not rely on  #previousAssociation  to return last item on first call

### DIFF
--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -255,9 +255,9 @@ SoilIndexIterator >> lastAssociation [
 { #category : #accessing }
 SoilIndexIterator >> lastNonEmptyPage [
 	currentPage := self lastPage.
-	[currentPage isEmpty] whileTrue: [ currentPage := 
-		"if the page is emprty, go to the prev page, if that returns nil all pages are empty"
-		self previousPage ifNil: [^nil]].
+	[currentPage isEmpty] whileTrue: [ 
+		"if the page is empty, go to the previous page, if that returns nil all pages are empty"
+		currentPage := self previousPage ifNil: [^nil]].
 	^ currentPage
 ]
 

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -245,11 +245,11 @@ SoilIndexIterator >> lastAssociation [
 	| lastAssociation restoredItem |
 	currentPage := self lastNonEmptyPage ifNil: [ ^nil ]. 
 	lastAssociation := currentPage lastItem.
+	currentKey := lastAssociation key.
 	[restoredItem := self restoreItem: lastAssociation] whileNil: [   
 			"if the last entry is deleted, we need to take the one before"
-			lastAssociation := self previousAssociation ifNil: [ ^nil ] ].
-	currentKey := restoredItem key.
-	^ restoredItem key -> (self convertValue: restoredItem value).
+			lastAssociation := self previousAssociation ifNil: [ ^nil ]].
+	^ restoredItem key -> (self convertValue: restoredItem value)
 ]
 
 { #category : #accessing }
@@ -374,7 +374,8 @@ SoilIndexIterator >> previous: anInteger [
 SoilIndexIterator >> previousAssociation [
 	| item |
 	"Find the association before"
-	currentPage ifNil: [ ^ self error: 'you need to navigate first using find: or last, for example'].
+	currentKey ifNil: [ ^ self error: 'you need to navigate first using find: or last, for example'].
+	currentPage ifNil: [ self findPageFor: currentKey].
 	[ currentPage isNil ] whileFalse: [  
 		item := currentKey 
 			ifNotNil: [  

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -243,15 +243,22 @@ SoilIndexIterator >> last: anInteger [
 SoilIndexIterator >> lastAssociation [
 	"Note: key will be index key"
 	| lastAssociation restoredItem |
-	currentPage := nil.
-	currentKey := nil.
-	"previousAssociation returns last key if currentPage is nil"
-	lastAssociation := self previousAssociation ifNil: [ ^nil ].
+	currentPage := self lastNonEmptyPage ifNil: [ ^nil ]. 
+	lastAssociation := currentPage lastItem.
 	[restoredItem := self restoreItem: lastAssociation] whileNil: [   
 			"if the last entry is deleted, we need to take the one before"
 			lastAssociation := self previousAssociation ifNil: [ ^nil ] ].
 
 	^ restoredItem key -> (self convertValue: restoredItem value).
+]
+
+{ #category : #accessing }
+SoilIndexIterator >> lastNonEmptyPage [
+	currentPage := self lastPage.
+	[currentPage isEmpty] whileTrue: [ currentPage := 
+		"if the page is emprty, go to the prev page, if that returns nil all pages are empty"
+		self previousPage ifNil: [^nil]].
+	^ currentPage
 ]
 
 { #category : #accessing }
@@ -366,10 +373,8 @@ SoilIndexIterator >> previous: anInteger [
 { #category : #accessing }
 SoilIndexIterator >> previousAssociation [
 	| item |
-	"Find the association before, if currentPage is not set we return the last association"
-	currentPage ifNil: [ 
-		currentPage := index lastPage.
-		currentKey := nil ].
+	"Find the association before"
+	currentPage ifNil: [ ^ self error: 'you need to navigate first using find: or last, for example'].
 	[ currentPage isNil ] whileFalse: [  
 		item := currentKey 
 			ifNotNil: [  

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -248,7 +248,7 @@ SoilIndexIterator >> lastAssociation [
 	[restoredItem := self restoreItem: lastAssociation] whileNil: [   
 			"if the last entry is deleted, we need to take the one before"
 			lastAssociation := self previousAssociation ifNil: [ ^nil ] ].
-
+	currentKey := restoredItem key.
 	^ restoredItem key -> (self convertValue: restoredItem value).
 ]
 


### PR DESCRIPTION
- add check to #previousAssociation to make sure that currentPage is set
- Get the first item in lastAssociation via lastNonEmptyPage instead

In a next step, I  think previousAssociation can be simplified

fixes #760