### PR TITLE
Trivial cleanup: structure test package

### DIFF
--- a/src/Soil-Core-Tests/SOTestClusterAlwaysRoot.class.st
+++ b/src/Soil-Core-Tests/SOTestClusterAlwaysRoot.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SOTestClusterAlwaysRoot,
 	#superclass : #SoilTestClusterRoot,
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-TestData'
 }
 
 { #category : #testing }

--- a/src/Soil-Core-Tests/SoilBTreePageTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreePageTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SoilBTreePageTest,
 	#superclass : #TestCase,
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Index'
 }
 
 { #category : #helper }

--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'index'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Index'
 }
 
 { #category : #running }

--- a/src/Soil-Core-Tests/SoilBackupTest.class.st
+++ b/src/Soil-Core-Tests/SoilBackupTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'soil',
 		'backupSoil'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Visitor'
 }
 
 { #category : #accessing }

--- a/src/Soil-Core-Tests/SoilBaseTestObject.class.st
+++ b/src/Soil-Core-Tests/SoilBaseTestObject.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #SoilBaseTestObject,
 	#superclass : #Object,
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-TestData'
 }

--- a/src/Soil-Core-Tests/SoilBehaviorRegistryTest.class.st
+++ b/src/Soil-Core-Tests/SoilBehaviorRegistryTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'soil',
 		'registry'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Model'
 }
 
 { #category : #initialization }

--- a/src/Soil-Core-Tests/SoilCleanCodeTest.class.st
+++ b/src/Soil-Core-Tests/SoilCleanCodeTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#pools : [
 		'SoilTypeCodes'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-CleanCode'
 }
 
 { #category : #cleanup }

--- a/src/Soil-Core-Tests/SoilClusterVersionTest.class.st
+++ b/src/Soil-Core-Tests/SoilClusterVersionTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SoilClusterVersionTest,
 	#superclass : #TestCase,
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Model'
 }
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
+++ b/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'soil',
 		'copy'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Journal'
 }
 
 { #category : #helper }

--- a/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'index',
 		'classToTest'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Index'
 }
 
 { #category : #'building suites' }

--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -6,7 +6,7 @@ Class {
 		'dict',
 		'classToTest'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Index'
 }
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilLogSequenceNumberTest.class.st
+++ b/src/Soil-Core-Tests/SoilLogSequenceNumberTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SoilLogSequenceNumberTest,
 	#superclass : #TestCase,
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Journal'
 }
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilMigrationTest.class.st
+++ b/src/Soil-Core-Tests/SoilMigrationTest.class.st
@@ -5,7 +5,7 @@ Class {
 		'soil',
 		'migrationClass'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Model'
 }
 
 { #category : #helpers }

--- a/src/Soil-Core-Tests/SoilMultiVersionTest.class.st
+++ b/src/Soil-Core-Tests/SoilMultiVersionTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'soil'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Model'
 }
 
 { #category : #accessing }

--- a/src/Soil-Core-Tests/SoilObjectFileTest.class.st
+++ b/src/Soil-Core-Tests/SoilObjectFileTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SoilObjectFileTest,
 	#superclass : #TestCase,
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Files'
 }
 
 { #category : #'instance creation' }

--- a/src/Soil-Core-Tests/SoilObjectIndexTest.class.st
+++ b/src/Soil-Core-Tests/SoilObjectIndexTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SoilObjectIndexTest,
 	#superclass : #TestCase,
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Files'
 }
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilObjectRepositoryTest.class.st
+++ b/src/Soil-Core-Tests/SoilObjectRepositoryTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'soil'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Model'
 }
 
 { #category : #initialization }

--- a/src/Soil-Core-Tests/SoilObjectSegmentTest.class.st
+++ b/src/Soil-Core-Tests/SoilObjectSegmentTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SoilObjectSegmentTest,
 	#superclass : #TestCase,
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Model'
 }
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilPersistentDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilPersistentDictionaryTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'soil'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Model'
 }
 
 { #category : #accessing }

--- a/src/Soil-Core-Tests/SoilSkipListPageTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListPageTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SoilSkipListPageTest,
 	#superclass : #TestCase,
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Index'
 }
 
 { #category : #'instance creation' }

--- a/src/Soil-Core-Tests/SoilSkipListTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'index'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Index'
 }
 
 { #category : #running }

--- a/src/Soil-Core-Tests/SoilTest.class.st
+++ b/src/Soil-Core-Tests/SoilTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'soil'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Model'
 }
 
 { #category : #accessing }

--- a/src/Soil-Core-Tests/SoilTestClass1.class.st
+++ b/src/Soil-Core-Tests/SoilTestClass1.class.st
@@ -6,7 +6,7 @@ Class {
 		'two',
 		'three'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-TestData'
 }
 
 { #category : #accessing }

--- a/src/Soil-Core-Tests/SoilTestClassWithTransient.class.st
+++ b/src/Soil-Core-Tests/SoilTestClassWithTransient.class.st
@@ -9,7 +9,7 @@ Class {
 		'two',
 		'three'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-TestData'
 }
 
 { #category : #accessing }

--- a/src/Soil-Core-Tests/SoilTestClusterRoot.class.st
+++ b/src/Soil-Core-Tests/SoilTestClusterRoot.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'nested'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-TestData'
 }
 
 { #category : #accessing }

--- a/src/Soil-Core-Tests/SoilTestGraphRoot.class.st
+++ b/src/Soil-Core-Tests/SoilTestGraphRoot.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'nested'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-TestData'
 }
 
 { #category : #accessing }

--- a/src/Soil-Core-Tests/SoilTestNestedObject.class.st
+++ b/src/Soil-Core-Tests/SoilTestNestedObject.class.st
@@ -5,7 +5,7 @@ Class {
 		'reference',
 		'label'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-TestData'
 }
 
 { #category : #accessing }

--- a/src/Soil-Core-Tests/SoilTransactionJournalTest.class.st
+++ b/src/Soil-Core-Tests/SoilTransactionJournalTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'soil'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Journal'
 }
 
 { #category : #helper }
@@ -12,7 +12,7 @@ SoilTransactionJournalTest class >> classUnderTest [
 	^ SoilPersistentDatabaseJournal 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #running }
 SoilTransactionJournalTest >> fillDatabase [ 
 	| tx dict |
 	tx := soil newTransaction.

--- a/src/Soil-Core-Tests/SoilTransactionTest.class.st
+++ b/src/Soil-Core-Tests/SoilTransactionTest.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'soil'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Model'
 }
 
 { #category : #accessing }


### PR DESCRIPTION
Add some tags for the classes in the test package, this allows to easier e.g. find all the tests related to indexing