### PR TITLE
add reverseDo: to the index and iterator

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
@@ -78,6 +78,22 @@ SoilIndexIteratorTest >> testAtPut [
 ]
 
 { #category : #tests }
+SoilIndexIteratorTest >> testDo [
+	
+	| capacity result |
+	capacity := index headerPage itemCapacity * 2.
+	1 to: capacity do: [ :n |
+		index at: n put: (n asByteArrayOfSize: 8) ].
+	
+	result := OrderedCollection new.
+	index newIterator do: [ :each | result add: each ].
+
+	self assert: result size equals: capacity.
+	self assert: result first equals: (1 asByteArrayOfSize: 8).
+	self assert: result last equals: (capacity asByteArrayOfSize: 8)
+]
+
+{ #category : #tests }
 SoilIndexIteratorTest >> testFindAndNext [
 	
 	| capacity iterator value |
@@ -426,4 +442,20 @@ SoilIndexIteratorTest >> testRemoveKey [
 	self assert: result equals: (capacity asByteArrayOfSize: 8).
 	"removing the key again raises KeyNotFound, too"
 	self should: [iterator removeKey: capacity] raise: KeyNotFound.
+]
+
+{ #category : #tests }
+SoilIndexIteratorTest >> testReverseDo [
+	
+	| capacity result |
+	capacity := index headerPage itemCapacity * 2.
+	1 to: capacity do: [ :n |
+		index at: n put: (n asByteArrayOfSize: 8) ].
+	
+	result := OrderedCollection new.
+	index newIterator reverseDo: [ :each | result add: each ].
+
+	self assert: result size equals: capacity.
+	self assert: result first equals: (capacity asByteArrayOfSize: 8).
+	self assert: result last equals: (1 asByteArrayOfSize: 8)
 ]

--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -268,7 +268,7 @@ SoilIndexedDictionaryTest >> testDoWithTransAction [
 	tx2 := soil newTransaction.
 
 	counter := 0.
-	tx2 root  do: [ :each |
+	tx2 root do: [ :each |
 		self assert: (each beginsWith: 'bar').
 		counter := counter + 1].
 	self assert: counter equals: 2.
@@ -276,7 +276,7 @@ SoilIndexedDictionaryTest >> testDoWithTransAction [
 	tx2 root removeKey: #one.
 	
 	counter := 0.
-	tx2 root  do: [ :each |
+	tx2 root do: [ :each |
 		self assert: (each beginsWith: 'bar').
 		counter := counter + 1].
 	self assert: counter equals: 1.
@@ -288,8 +288,6 @@ SoilIndexedDictionaryTest >> testDoWithTransAction [
 		self assert: (each beginsWith: 'bar').
 		counter := counter + 1].
 	self assert: counter equals: 2
-	
-	
 ]
 
 { #category : #tests }
@@ -550,6 +548,42 @@ SoilIndexedDictionaryTest >> testRemoveKeyWithTwoTransactions [
 	self assert: tx root size equals: 1.
 	"but commiting it will fail, as we have commited the remove in t2"
 	self should: [tx commit] raise: SoilObjectHasConcurrentChange
+]
+
+{ #category : #tests }
+SoilIndexedDictionaryTest >> testReverseDo [
+	| tx tx1 tx2 counter |
+	
+	tx := soil newTransaction.
+	tx root: dict.
+	dict at: #one put: #bar1.
+	dict at: #two put: #bar2.
+	tx commit.
+	"open a second transaction ..."
+	tx1 := soil newTransaction.
+	tx2 := soil newTransaction.
+
+	counter := 0.
+	tx2 root reverseDo: [ :each |
+		self assert: (each beginsWith: 'bar').
+		counter := counter + 1].
+	self assert: counter equals: 2.
+	
+	tx2 root removeKey: #one.
+	
+	counter := 0.
+	tx2 root reverseDo: [ :each |
+		self assert: (each beginsWith: 'bar').
+		counter := counter + 1].
+	self assert: counter equals: 1.
+	
+	tx2 commit.
+	"in tx1 the key is not removed, do: correcty uses the restorValue"
+	counter := 0.
+	tx1 root reverseDo: [ :each |
+		self assert: (each beginsWith: 'bar').
+		counter := counter + 1].
+	self assert: counter equals: 2
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -425,6 +425,17 @@ SoilIndexIterator >> restoreItem: anItem [
 	^ anItem 
 ]
 
+{ #category : #enumerating }
+SoilIndexIterator >> reverseDo: aBlock [ 
+	| item |
+	aBlock value: self lastAssociation value.
+	
+	[ (item := self previousAssociation ) notNil ] whileTrue: [ 
+ 		(self restoreItem: item) ifNotNil: [ :notNil |
+			(self convertValue: notNil value)
+				ifNotNil: [ :value | aBlock value: value ] ] ]
+]
+
 { #category : #accessing }
 SoilIndexIterator >> size [
 	"We iterate over all elements to get the size. Slow!"

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -212,6 +212,12 @@ SoilIndexedDictionary >> removeKey: key ifAbsent: aBlock [
 	^v
 ]
 
+{ #category : #enumerating }
+SoilIndexedDictionary >> reverseDo: aBlock [
+ 	self newIterator reverseDo: [ :objectId | 
+ 				aBlock value: objectId ]
+]
+
 { #category : #accessing }
 SoilIndexedDictionary >> second [
 	^ self newIterator first; next


### PR DESCRIPTION
besides implementing a common method find in collections, this is useful to strengthen the tests related to going backwards in indexes while crossing page boundaries. (these tests will be another PR later)