### PR TITLE
add random insertion test for SkipList

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -133,9 +133,9 @@ SoilBTreeTest >> testAddFirstOverflow [
 { #category : #tests }
 SoilBTreeTest >> testAddRandom [
 	| numEntries entries |
-	"just some random addind and checking that we can find it. tree is configured to create lots of pages"
+	"just some random adding and checking that we can find it. tree is configured to create lots of pages"
 	index := SoilBTree new 
-		path: 'sunit-btree';
+		path: 'sunit-btree-testAddRandom';
 		destroy;
 		initializeFilesystem;
 		initializeHeaderPage;
@@ -151,8 +151,14 @@ SoilBTreeTest >> testAddRandom [
 		entries add: toAdd.
 		index at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
 	
+	"check size"
+	self assert: index size equals: entries size.
+	
 	"can we find all the keys we added?"
 	entries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	
+	"iterate index, all should be in entries"
+	index do: [:each | self assert: each equals: #[ 1 2 3 4 5 6 7 8 ]]
 ]
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilSkipListTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListTest.class.st
@@ -146,6 +146,38 @@ SoilSkipListTest >> testAddLastFitting [
 ]
 
 { #category : #tests }
+SoilSkipListTest >> testAddRandom [
+	| numEntries entries |
+	"just some random adding and checking that we can find it, configured to create lots of pages"
+	index := SoilSkipList new 
+		path: 'sunit-skiplist-testAddRandom';
+		destroy;
+		initializeFilesystem;
+		initializeHeaderPage;
+		maxLevel: 10;
+		keySize: 512;
+		valueSize: 512.
+	
+	numEntries := 20.
+	entries := Set new: numEntries.
+	
+	
+	numEntries timesRepeat: [ | toAdd |
+		toAdd := (numEntries*20) atRandom.
+		entries add: toAdd.
+		index at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+	
+	"check size"
+	self assert: index size equals: entries size.
+	
+	"can we find all the keys we added?"
+	entries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	
+	"iterate index, all should be in entries"
+	index do: [:each | self assert: each equals: #[ 1 2 3 4 5 6 7 8 ]]
+]
+
+{ #category : #tests }
 SoilSkipListTest >> testAt [
 	
 	| capacity |

--- a/src/Soil-Core/SoilIndex.class.st
+++ b/src/Soil-Core/SoilIndex.class.st
@@ -213,6 +213,11 @@ SoilIndex >> removeKey: key ifAbsent: aBlock [
 		ifFalse: [ aBlock value ]
 ]
 
+{ #category : #enumerating }
+SoilIndex >> reverseDo: aBlock [
+	self newIterator reverseDo: aBlock
+]
+
 { #category : #accessing }
 SoilIndex >> size [
 	"We iterate over all elements to get the size. Slow!"


### PR DESCRIPTION
- add #reverseDo: on the level of the index
- add #testAddRandom for SkipList
- improve random tests check using #do: and #size.

For reverseDo: I immediatly found a bug (see #781 ), so checking this will be part of a later PR