### PR TITLE
800-Iterator-basicAssociationsDo-should-reset 

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
@@ -584,3 +584,21 @@ SoilIndexIteratorTest >> testValues [
 	self assert: iterator values first equals: (1 asByteArrayOfSize: 8).
 	self assert: iterator values last equals: (capacity asByteArrayOfSize: 8)
 ]
+
+{ #category : #tests }
+SoilIndexIteratorTest >> testbasicAssociationsDo [
+	
+	| iterator capacity result |
+	iterator := index newIterator.
+	
+	capacity := index headerPage itemCapacity * 2.
+	1 to: capacity do: [ :n |
+		iterator at: n put: (n asByteArrayOfSize: 8) ].
+	
+	result := OrderedCollection new.
+	iterator basicAssociationsDo: [ :each | result add: each ].
+
+	self assert: result size equals: capacity.
+	self assert: result first value equals: (1 asByteArrayOfSize: 8).
+	self assert: result last value equals: (capacity asByteArrayOfSize: 8)
+]

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -48,6 +48,8 @@ SoilIndexIterator >> atIndex: anInteger [
 { #category : #enumerating }
 SoilIndexIterator >> basicAssociationsDo: aBlock [
 	| item |
+	"set currentPage to nil to force starting at the first element"
+	currentPage := nil.
 	[ (item := self basicNextAssociation ) notNil ] whileTrue: [
 		(self restoreItem: item) ifNotNil: [ :assoc | 
  			aBlock value: assoc key -> (self convertValue: assoc value) ] ] 


### PR DESCRIPTION
- add test for #basicAssociationsDo:
- add reset to make it green (using at:put: on the same instance means that do: will start from the last added element on, not what we expect)

fixes #800