### PR TITLE
799-Iterator-basicAssociationsDo-is-not-basic

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
@@ -78,6 +78,24 @@ SoilIndexIteratorTest >> testAddRandom [
 ]
 
 { #category : #tests }
+SoilIndexIteratorTest >> testAssociationsDo [
+	
+	| iterator capacity result |
+	iterator := index newIterator.
+	
+	capacity := index headerPage itemCapacity * 2.
+	1 to: capacity do: [ :n |
+		iterator at: n put: (n asByteArrayOfSize: 8) ].
+	
+	result := OrderedCollection new.
+	iterator associationsDo: [ :each | result add: each ].
+
+	self assert: result size equals: capacity.
+	self assert: result first value equals: (1 asByteArrayOfSize: 8).
+	self assert: result last value equals: (capacity asByteArrayOfSize: 8)
+]
+
+{ #category : #tests }
 SoilIndexIteratorTest >> testAtIfAbsent [
 	| iterator return |
 
@@ -583,22 +601,4 @@ SoilIndexIteratorTest >> testValues [
 	self assert: iterator values size equals: capacity.
 	self assert: iterator values first equals: (1 asByteArrayOfSize: 8).
 	self assert: iterator values last equals: (capacity asByteArrayOfSize: 8)
-]
-
-{ #category : #tests }
-SoilIndexIteratorTest >> testbasicAssociationsDo [
-	
-	| iterator capacity result |
-	iterator := index newIterator.
-	
-	capacity := index headerPage itemCapacity * 2.
-	1 to: capacity do: [ :n |
-		iterator at: n put: (n asByteArrayOfSize: 8) ].
-	
-	result := OrderedCollection new.
-	iterator basicAssociationsDo: [ :each | result add: each ].
-
-	self assert: result size equals: capacity.
-	self assert: result first value equals: (1 asByteArrayOfSize: 8).
-	self assert: result last value equals: (capacity asByteArrayOfSize: 8)
 ]

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -10,6 +10,15 @@ Class {
 	#category : #'Soil-Core-Index-Common'
 }
 
+{ #category : #enumerating }
+SoilIndexIterator >> associationsDo: aBlock [
+	| item |
+	"set currentPage to nil to force starting at the first element"
+	currentPage := nil.
+	[ (item := self nextAssociation ) notNil ] 
+		whileTrue: [ aBlock value: item ]
+]
+
 { #category : #accessing }
 SoilIndexIterator >> at: aKeyObject [
 	^ self 
@@ -43,16 +52,6 @@ SoilIndexIterator >> atIndex: anInteger [
 	2 to: anInteger do: [ :idx |
 		current := self nextAssociation ].
 	^ current value
-]
-
-{ #category : #enumerating }
-SoilIndexIterator >> basicAssociationsDo: aBlock [
-	| item |
-	"set currentPage to nil to force starting at the first element"
-	currentPage := nil.
-	[ (item := self basicNextAssociation ) notNil ] whileTrue: [
-		(self restoreItem: item) ifNotNil: [ :assoc | 
- 			aBlock value: assoc key -> (self convertValue: assoc value) ] ] 
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilIndexRewriter.class.st
+++ b/src/Soil-Core/SoilIndexRewriter.class.st
@@ -30,7 +30,7 @@ SoilIndexRewriter >> convertIndex [
 
 { #category : #running }
 SoilIndexRewriter >> convertItems [
-	index newIterator basicAssociationsDo: [ :item |
+	index newIterator associationsDo: [ :item |
 		self storeItem: (self restoreItem: item) ] 
 ]
 

--- a/src/Soil-Core/SoilPluggableIndexRewriter.class.st
+++ b/src/Soil-Core/SoilPluggableIndexRewriter.class.st
@@ -27,7 +27,7 @@ SoilPluggableIndexRewriter >> convertIndex [
 
 { #category : #running }
 SoilPluggableIndexRewriter >> convertItems [ 
-	index newIterator basicAssociationsDo: [ :item |
+	index newIterator associationsDo: [ :item |
 		self restoreItem: item ]
 ]
 
@@ -78,7 +78,7 @@ SoilPluggableIndexRewriter >> run [
 	self validatePath.
 	self prepareNewIndex.
 	[  
-		index newIterator basicAssociationsDo: [ :item |
+		index newIterator associationsDo: [ :item |
 				item ifNotNil: [  
 				(itemBlock value: item) ifNotNil: [ :newItem | 
 					self newIndexIterator at: newItem key put: newItem value ] ] ] ]


### PR DESCRIPTION
- rename #basicAssociationsDo: to #associationsDo:
- implement #associationsDo: in term of #nextAssociation, as we want to restore the value *and* need associations anyway, no need to use #basicAssocations here

fixes #799