### PR TITLE
Size for BTree

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -118,14 +118,14 @@ SoilBTreeTest >> testAddFirstOverflow [
 	capacity := index headerPage itemCapacity.
 	1 to: capacity do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
 	self assert: index pages size equals: 3.
-	self assert: (index pageAt: 1) numberOfItems equals: 127.
+	self assert: (index pageAt: 1) numberOfItems equals: 126.
 	"if we add a page, the current one is split and half is moved there"
 	index at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
 	self assert: index pages size equals: 3.
 	page := index pageAt: 3.
 	self assert: page numberOfItems equals: 128.
-	self assert: page items first key equals: 128.
-	self assert: page items last key asByteArray equals: #[ 255 ].
+	self assert: page items first key equals: 127.
+	self assert: page items last key asByteArray equals: #[ 254 ].
 	"check that the next pointer is correct after split"
 	self assert: (index pageAt:((index headerPage) next)) identicalTo: (index pageAt: 3)
 ]
@@ -170,13 +170,13 @@ SoilBTreeTest >> testAddSecondOverflow [
 	capacity := index headerPage itemCapacity.
 	1 to: capacity do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
 	self assert: index pages size equals: 3.
-	self assert: (index pageAt: 1) numberOfItems equals: 127.
+	self assert: (index pageAt: 1) numberOfItems equals: 126.
 	"if we add a page, the current one is split and half is moved there"
 	1 to: capacity do: [ :n | index at: capacity + n put: #[ 1 2 3 4 5 6 7 8 ]].
 	self assert: index pages size equals: 4.
 	page := index pageAt: 4.
-	self assert: page numberOfItems equals: 254.
-	self assert: page items first key equals: 255.
+	self assert: page numberOfItems equals: 253.
+	self assert: page items first key equals: 254.
 	"check that the next pointer is correct after split"
 	self assert: ((index headerPage nextPageIn: index) nextPageIn: index) identicalTo: (index pageAt: 4).
 	index writePages.
@@ -189,13 +189,13 @@ SoilBTreeTest >> testAddSecondOverflowReload [
 	capacity := index headerPage itemCapacity.
 	1 to: capacity do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
 	self assert: index pages size equals: 3.
-	self assert: (index pageAt: 1) numberOfItems equals: 127.
+	self assert: (index pageAt: 1) numberOfItems equals: 126.
 	"if we add a page, the current one is split and half is moved there"
 	1 to: capacity do: [ :n | index at: capacity + n put: #[ 1 2 3 4 5 6 7 8 ]].
 	self assert: index pages size equals: 4.
 	page := index pageAt: 4.
-	self assert: page numberOfItems equals: 254.
-	self assert: page items first key equals: 255.
+	self assert: page numberOfItems equals: 253.
+	self assert: page items first key equals: 254.
 	"check that the next pointer is correct after split"
 	self assert: ((index headerPage nextPageIn: index) nextPageIn: index) identicalTo: (index pageAt: 4).
 
@@ -214,7 +214,7 @@ SoilBTreeTest >> testAt [
 	capacity := index headerPage itemCapacity.
 	1 to: capacity do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
 	self assert: index pages size equals: 3.
-	self assert: (index pageAt: 1) numberOfItems equals: 127.
+	self assert: (index pageAt: 1) numberOfItems equals: 126.
 	"if we add a page, the current one is split and half is moved there"
 	index at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
 	self assert: index pages size equals: 3.
@@ -232,7 +232,7 @@ SoilBTreeTest >> testAtSecondOverflow [
 	capacity := index headerPage itemCapacity.
 	1 to: capacity*2 do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
 	self assert: index pages size equals: 4.
-	self assert: (index pageAt: 1) numberOfItems equals: 127.
+	self assert: (index pageAt: 1) numberOfItems equals: 126.
 	"if we add a page, the current one is split and half is moved there"
 	1 to: capacity do: [ :n | index at: capacity + n put: #[ 1 2 3 4 5 6 7 8 ] ].
 	self assert: index pages size equals: 4.
@@ -277,12 +277,12 @@ SoilBTreeTest >> testIndexRewriting [
 	index flush.
 	self assert: index headerPage lastPageIndex equals: 3.
 	self assert: (index pageAt: 3) items size equals: 128.
-	self assert: (index pageAt: 1) items size equals: 127.
+	self assert: (index pageAt: 1) items size equals: 126.
 	fileSizeBefore := index path size.
 	index newPluggableRewriter rewrite.
 	self assert: index headerPage lastPageIndex equals: 3.
 	self assert: (index pageAt: 3) items size equals: 128.
-	self assert: (index pageAt: 1) items size equals: 127.
+	self assert: (index pageAt: 1) items size equals: 126.
 	
 	self assert: index path size equals: fileSizeBefore
 
@@ -362,8 +362,8 @@ SoilBTreeTest >> testOverflowCopyOnWriteSplitting [
 
 	page := copyOnWrite pageAt: 3.
 	self assert: page numberOfItems equals: 127.
-	self assert: page items first key equals: 255.
-	self assert: page items last key asByteArray equals: #[1 251]
+	self assert: page items first key equals: 253.
+	self assert: page items last key asByteArray equals: #[1 249]
 ]
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
@@ -390,7 +390,7 @@ SoilIndexIteratorTest >> testPrevious [
 		index at: n put: (n asByteArrayOfSize: 8) ].
 	iterator := index newIterator.
 	"select a key where we have to cross over to another page"
-	toFind := index class == SoilSkipList ifTrue: [ 253 ] ifFalse: [ 255 ].
+	toFind := index class == SoilSkipList ifTrue: [ 253 ] ifFalse: [ 254 ].
 	"the key is indeed the first one in the page"
 	self assert: (iterator findPageFor: toFind) firstItem key equals: toFind.
 	
@@ -425,7 +425,7 @@ SoilIndexIteratorTest >> testPreviousAssociation [
 	iterator := index newIterator.
 	
 	"select a key where we have to cross over to another page"
-	toFind := index class == SoilSkipList ifTrue: [ 253 ] ifFalse: [ 255 ].
+	toFind := index class == SoilSkipList ifTrue: [ 253 ] ifFalse: [ 254 ].
 	"the key is indeed the first one in the page"
 	self assert: (iterator findPageFor: toFind) firstItem key equals: toFind.
 	
@@ -490,7 +490,7 @@ SoilIndexIteratorTest >> testPreviousPage [
 		index at: n put: (n asByteArrayOfSize: 8) ].
 	iterator := index newIterator.
 	"select a key where we have to cross over to another page"
-	toFind := index class == SoilSkipList ifTrue: [ 253 ] ifFalse: [ 255 ].
+	toFind := index class == SoilSkipList ifTrue: [ 253 ] ifFalse: [ 254 ].
 	"the key is indeed the first one in the page"
 	self assert: (iterator findPageFor: toFind) firstItem key equals: toFind.
 	

--- a/src/Soil-Core/SoilBTreeHeaderPage.class.st
+++ b/src/Soil-Core/SoilBTreeHeaderPage.class.st
@@ -10,7 +10,8 @@ Class {
 	#superclass : #SoilAbstractBTreeDataPage,
 	#instVars : [
 		'lastPageIndex',
-		'firstFreePageIndex'
+		'firstFreePageIndex',
+		'size'
 	],
 	#category : #'Soil-Core-Index-BTree'
 }
@@ -18,6 +19,12 @@ Class {
 { #category : #accessing }
 SoilBTreeHeaderPage class >> pageCode [ 
 	^ 3
+]
+
+{ #category : #utilities }
+SoilBTreeHeaderPage >> decreaseSize [
+ 	size := size - 1.
+ 	dirty := true
 ]
 
 { #category : #accessing }
@@ -33,12 +40,20 @@ SoilBTreeHeaderPage >> headerSize [
 		+ 2 "keySize"
 		+ self pointerSize "lastPageIndex"
 		+ self pointerSize "lastFreePageIndex"
+		+ 6 "size"
+]
+
+{ #category : #utilities }
+SoilBTreeHeaderPage >> increaseSize [
+ 	size := size + 1.
+ 	dirty := true
 ]
 
 { #category : #initialization }
 SoilBTreeHeaderPage >> initialize [ 
 	super initialize.
-	firstFreePageIndex := 0
+	firstFreePageIndex := 0.
+	size := 0
 ]
 
 { #category : #initialization }
@@ -85,7 +100,18 @@ SoilBTreeHeaderPage >> readFrom: aStream [
 	valueSize := (aStream next: 2) asInteger.
 	lastPageIndex :=(aStream next: self pointerSize) asInteger.
 	firstFreePageIndex :=(aStream next: 4) asInteger.
+	size := (aStream next: 6) asInteger.
 	self readItemsFrom: aStream
+]
+
+{ #category : #accessing }
+SoilBTreeHeaderPage >> size [
+	^size
+]
+
+{ #category : #accessing }
+SoilBTreeHeaderPage >> size: anInteger [
+ 	size := anInteger
 ]
 
 { #category : #writing }
@@ -95,5 +121,6 @@ SoilBTreeHeaderPage >> writeHeaderOn: aStream [
 		nextPutAll: (keySize asByteArrayOfSize: 2);
 		nextPutAll: (valueSize asByteArrayOfSize: 2);
 		nextPutAll: (lastPageIndex asByteArrayOfSize: self pointerSize);
-		nextPutAll: (firstFreePageIndex asByteArrayOfSize: 4)
+		nextPutAll: (firstFreePageIndex asByteArrayOfSize: 4);
+		nextPutAll: (self size asByteArrayOfSize: 6).
 ]

--- a/src/Soil-Core/SoilBTreeIterator.class.st
+++ b/src/Soil-Core/SoilBTreeIterator.class.st
@@ -16,6 +16,7 @@ SoilBTreeIterator >> basicAt: indexKey put: anObject [
 	| possiblePriorValue |
 	possiblePriorValue := index rootPage insertItem: (indexKey -> anObject) for: self.
 	"as an optimization we return the prior value stored in the list. If there was none we return nil"
+	 index increaseSize.
 	^ possiblePriorValue returnValue
 ]
 

--- a/src/Soil-Core/SoilBTreeIterator.class.st
+++ b/src/Soil-Core/SoilBTreeIterator.class.st
@@ -16,7 +16,10 @@ SoilBTreeIterator >> basicAt: indexKey put: anObject [
 	| possiblePriorValue |
 	possiblePriorValue := index rootPage insertItem: (indexKey -> anObject) for: self.
 	"as an optimization we return the prior value stored in the list. If there was none we return nil"
-	 index increaseSize.
+	 possiblePriorValue returnValue ifNil: [
+		"only increase size if there was no prior value"
+		index increaseSize].
+	
 	^ possiblePriorValue returnValue
 ]
 

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -132,6 +132,11 @@ SoilBasicBTree >> rootPage [
 	^ self store pageAt: 2
 ]
 
+{ #category : #accessing }
+SoilBasicBTree >> size [
+	^ self headerPage size
+]
+
 { #category : #splitting }
 SoilBasicBTree >> splitIndexPage: page [ 
 	| newPage |

--- a/src/Soil-Core/SoilBasicSkipList.class.st
+++ b/src/Soil-Core/SoilBasicSkipList.class.st
@@ -17,19 +17,9 @@ SoilBasicSkipList class >> isAbstract [
 	^ self == SoilBasicSkipList
 ]
 
-{ #category : #'as yet unclassified' }
-SoilBasicSkipList >> decreaseSize [
-	self headerPage decreaseSize 
-]
-
 { #category : #testing }
 SoilBasicSkipList >> hasHeaderPage [
 	^ store hasHeaderPage 
-]
-
-{ #category : #'as yet unclassified' }
-SoilBasicSkipList >> increaseSize [
-	self headerPage increaseSize 
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilIndex.class.st
+++ b/src/Soil-Core/SoilIndex.class.st
@@ -59,6 +59,11 @@ SoilIndex >> close [
 	store := nil
 ]
 
+{ #category : #'as yet unclassified' }
+SoilIndex >> decreaseSize [
+	self headerPage decreaseSize 
+]
+
 { #category : #enumerating }
 SoilIndex >> do: aBlock [
 	self newIterator do: aBlock
@@ -98,6 +103,11 @@ SoilIndex >> hasHeaderPage [
 { #category : #accessing }
 SoilIndex >> headerPage [
 	^ self store headerPage
+]
+
+{ #category : #'as yet unclassified' }
+SoilIndex >> increaseSize [
+	self headerPage increaseSize 
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -428,6 +428,7 @@ SoilIndexIterator >> removeKey: key ifAbsent: aBlock [
 	currentPage 
 		itemAt: indexKey 
 		put: SoilObjectId removed.
+	index decreaseSize.
 	^ oldValue
 ]
 

--- a/src/Soil-Core/SoilSkipListIterator.class.st
+++ b/src/Soil-Core/SoilSkipListIterator.class.st
@@ -119,14 +119,6 @@ SoilSkipListIterator >> printOn: aStream [
 	aStream << 'path: ' << levels asString
 ]
 
-{ #category : #removing }
-SoilSkipListIterator >> removeKey: key ifAbsent: aBlock [
-	| value |
-	value := super removeKey: key ifAbsent: aBlock.
-	index decreaseSize.
-	^ value
-]
-
 { #category : #accessing }
 SoilSkipListIterator >> size [ 
 	| headerPage |


### PR DESCRIPTION
This PR implements size caching for BTree following the implementation that we have on the SkpList (PR #797).

fixes #226