### PR TITLE
SkipList: faster #previousPage 

### DIFF
--- a/src/Soil-Core/SoilSkipListIterator.class.st
+++ b/src/Soil-Core/SoilSkipListIterator.class.st
@@ -59,26 +59,24 @@ SoilSkipListIterator >> findPageFor: indexKey [
 
 { #category : #private }
 SoilSkipListIterator >> findPreviousPageOf: aPage [
+	| pageIndex candidatePage keyOfPage |
 	aPage isHeaderPage ifTrue: [ ^nil ].
 	aPage isEmpty ifTrue: [ ^super findPreviousPageOf: aPage ].
+	keyOfPage := aPage smallestKey.
 	
-	"faster search not yet working"
-	self flag: #TOOD.
-	^ super findPreviousPageOf: aPage.
-
-"	currentPage := index headerPage.
+	currentPage := index headerPage.
 	levels size to: 1 by: -1 do: [ :level |
 		[ 
 			pageIndex := currentPage rightAt: level.
 			(pageIndex > 0) and: [ 
 				candidatePage := self pageAt: pageIndex.
-				(candidatePage isLastPage not and: [ (self pageAt: (candidatePage next)) == aPage])]]
+				candidatePage smallestKey < keyOfPage ] ]
 					whileTrue: [ currentPage := candidatePage  ].
 			self atLevel: level put: currentPage. ].
-		
-	self assert: (self nextPage == aPage).
 	
-	^ currentPage "
+	"for now keep an assert here to be sure this works correctly"
+	self assert: (self nextPage == aPage).
+	^ currentPage
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This brings back an implementation of #findPreviousPageOf: for the SkipList that uses the same approach as #findPageFor:, but comparing with < to stop before reaching the page that contains the key.

This allows us to use fast search to find the previousPage of a non-empty page with the same speed as looking up the page for a key.