### PR TITLE
BTree: faster #priviousPage

### DIFF
--- a/src/Soil-Core/SoilAbstractBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilAbstractBTreeDataPage.class.st
@@ -27,6 +27,16 @@ SoilAbstractBTreeDataPage >> find: aKey with: aBTree [
 
 ]
 
+{ #category : #private }
+SoilAbstractBTreeDataPage >> findPreviousPage: aKey with: aBTree path: aPath [
+	| pageToCheck |
+	pageToCheck := aPath reverse detect: [:each | (each itemBefore: aKey) isNotNil].
+	pageToCheck := aBTree pageAt: (pageToCheck itemBefore: aKey) value.
+	"if we get an index page, follow the last till reaching the data page"
+	[pageToCheck isIndexPage ] whileTrue: [ pageToCheck := aBTree pageAt: pageToCheck lastItem value].
+	^ pageToCheck 
+]
+
 { #category : #utilities }
 SoilAbstractBTreeDataPage >> headerSize [
 	^ super headerSize  

--- a/src/Soil-Core/SoilBTreeIndexPage.class.st
+++ b/src/Soil-Core/SoilBTreeIndexPage.class.st
@@ -36,17 +36,13 @@ SoilBTreeIndexPage >> findKey: aKey [
 ]
 
 { #category : #private }
-SoilBTreeIndexPage >> findPreviousPage: aKey with: aBTree [
-	| item page |
+SoilBTreeIndexPage >> findPreviousPage: aKey with: aBTree path: aPath [
+	| item page  |
+	"we record the path of all index pages taken to find the key"
+	aPath add: self.
 	item := self findKey: aKey.
 	page := aBTree pageAt: item value.
-		
-	^ page isIndexPage 
-		ifFalse: [
-			"if we get a data page, we know that the prior page is just the page
-			referenced from the index entry before "
-			aBTree pageAt: (self itemBefore: aKey) value]
-		ifTrue:  [ page findPreviousPage: aKey with: aBTree ]
+	^ page findPreviousPage: aKey with: aBTree path: aPath
 ]
 
 { #category : #utilities }

--- a/src/Soil-Core/SoilBTreeIterator.class.st
+++ b/src/Soil-Core/SoilBTreeIterator.class.st
@@ -29,10 +29,10 @@ SoilBTreeIterator >> findPreviousPageOf: aPage [
 	
 	aPage isHeaderPage ifTrue: [ ^nil ].
 	aPage isEmpty ifTrue: [ ^super findPreviousPageOf: aPage ].
-	"faster search not yet working"
-	self flag: #TOOD.
-	^ super findPreviousPageOf: aPage.
-	"currentPage := index rootPage findPreviousPage: aPage firstItem key with: index"
+	currentPage := index rootPage findPreviousPage: aPage firstItem key with: index path: OrderedCollection new.
+	"for now use assert to make sure this is correct"
+	self assert: (self nextPage == aPage).
+	^currentPage
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
This PR implements a #findPreviousPageOf: for BTree.

We record the path of index pages taken while searching for the smallest key of the page that we look the previousPage of, then we use the path to go to that page.