### PR TITLE
Improve index tests: encode key always in value used for better asserts

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -39,12 +39,12 @@ SoilBTreeTest >> testAdd2 [
 	
 	entries :=  #(6 16 26 36 46 ).
 	
-	index at: 6  put: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: 6) equals: #[ 1 2 3 4 5 6 7 8 ].
+	index at: 6  put: (6 asByteArrayOfSize: 8).
+	self assert: (index at: 6) equals: (6 asByteArrayOfSize: 8).
 	
-	index at: 16  put: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: 6) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: 16) equals: #[ 1 2 3 4 5 6 7 8 ].
+	index at: 16  put: (16 asByteArrayOfSize: 8).
+	self assert: (index at: 6) equals: (6 asByteArrayOfSize: 8).
+	self assert: (index at: 16) equals: (16 asByteArrayOfSize: 8).
 	
 	"We have two pages"
 	self assert: index pages size equals: 2.
@@ -57,14 +57,14 @@ SoilBTreeTest >> testAdd2 [
 	
 	
 	"with adding 26, we have to split the data page"
-	index at: 26  put: #[ 1 2 3 4 5 6 7 8 ].
+	index at: 26  put: (26 asByteArrayOfSize: 8).
 	self assert: index pages size equals: 3.
 	self assert: index indexPages size equals: 1.
 	self assert: index dataPages size equals: 2.
 	
-	self assert: (index at: 6) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: 16) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: 26) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 6) equals: (6 asByteArrayOfSize: 8).
+	self assert: (index at: 16) equals: (16 asByteArrayOfSize: 8).
+	self assert: (index at: 26) equals: (26 asByteArrayOfSize: 8).
 	
 	"index page has two entries: 0 and 16"
 	self assert: (index rootPage items collect: #key) size equals: 2.
@@ -72,16 +72,16 @@ SoilBTreeTest >> testAdd2 [
 	self assert: (index rootPage items collect: #key) second equals: 16. 
 	
 	"adding 36 causes overlow in data node, have to add the new page to index"
-	index at: 36  put: #[ 1 2 3 4 5 6 7 8 ].
+	index at: 36  put: (36 asByteArrayOfSize: 8).
 	
 	self assert: index pages size equals: 4.
 	self assert: index indexPages size equals: 1.
 	self assert: index dataPages size equals: 3.
 	
-	self assert: (index at: 6) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: 16) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: 26) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: 36) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 6) equals: (6 asByteArrayOfSize: 8).
+	self assert: (index at: 16) equals: (16 asByteArrayOfSize: 8).
+	self assert: (index at: 26) equals: (26 asByteArrayOfSize: 8).
+	self assert: (index at: 36) equals: (36 asByteArrayOfSize: 8).
 	
 	"index page has trhee entries: 0 and 16 and 26"
 	self assert: (index rootPage items collect: #key) size equals: 3.
@@ -90,17 +90,17 @@ SoilBTreeTest >> testAdd2 [
 	self assert: (index rootPage items collect: #key) third equals: 26. 
 	
 	"adding 46 causes overlow in data node and the index node"
-	index at: 46  put: #[ 1 2 3 4 5 6 7 8 ].
+	index at: 46  put: (46 asByteArrayOfSize: 8).
 	
 	self assert: index pages size equals: 7.
 	self assert: index indexPages size equals: 3.
 	self assert: index dataPages size equals: 4.
 	
-	self assert: (index at: 6) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: 16) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: 26) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: 36) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: 46) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 6) equals: (6 asByteArrayOfSize: 8).
+	self assert: (index at: 16) equals: (16 asByteArrayOfSize: 8).
+	self assert: (index at: 26) equals: (26 asByteArrayOfSize: 8).
+	self assert: (index at: 36) equals: (36 asByteArrayOfSize: 8).
+	self assert: (index at: 46) equals: (46 asByteArrayOfSize: 8).
 	
 	"index page has trhee entries: 0 and 16 and 26"
 
@@ -116,11 +116,11 @@ SoilBTreeTest >> testAddFirstOverflow [
 
 	| page capacity |
 	capacity := index headerPage itemCapacity.
-	1 to: capacity do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	1 to: capacity do: [ :n | index at: n put: (n asByteArrayOfSize: 8) ].
 	self assert: index pages size equals: 3.
 	self assert: (index pageAt: 1) numberOfItems equals: 126.
 	"if we add a page, the current one is split and half is moved there"
-	index at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	index at: capacity + 1 put: (capacity + 1 asByteArrayOfSize: 8) .
 	self assert: index pages size equals: 3.
 	page := index pageAt: 3.
 	self assert: page numberOfItems equals: 128.
@@ -149,17 +149,17 @@ SoilBTreeTest >> testAddRandom [
 	numEntries timesRepeat: [ | toAdd |
 		toAdd := (numEntries*20) atRandom.
 		entries add: toAdd.
-		index at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: toAdd  put: (toAdd asByteArrayOfSize: 8) ].
 	
 	"check size"
 	self assert: index size equals: entries size.
 	
 	"can we find all the keys we added?"
-	entries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	entries do: [:each | self assert: (index at: each ) equals: (each asByteArrayOfSize: 8)].
 	
 	"iterate index, all should be in entries"
-	index do: [:each | self assert: each equals: #[ 1 2 3 4 5 6 7 8 ]].
-	index reverseDo: [:each | self assert: each equals: #[ 1 2 3 4 5 6 7 8 ]]
+	index do: [:each | self assert: each equals: (each asByteArrayOfSize: 8)].
+	index reverseDo: [:each | self assert: each equals: (each asByteArrayOfSize: 8)]
 	
 ]
 
@@ -168,11 +168,11 @@ SoilBTreeTest >> testAddSecondOverflow [
 
 	| page capacity |
 	capacity := index headerPage itemCapacity.
-	1 to: capacity do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	1 to: capacity do: [ :n | index at: n put: (n asByteArrayOfSize: 8) ].
 	self assert: index pages size equals: 3.
 	self assert: (index pageAt: 1) numberOfItems equals: 126.
 	"if we add a page, the current one is split and half is moved there"
-	1 to: capacity do: [ :n | index at: capacity + n put: #[ 1 2 3 4 5 6 7 8 ]].
+	1 to: capacity do: [ :n | index at: capacity + n put: (capacity + n asByteArrayOfSize: 8)].
 	self assert: index pages size equals: 4.
 	page := index pageAt: 4.
 	self assert: page numberOfItems equals: 253.
@@ -187,11 +187,11 @@ SoilBTreeTest >> testAddSecondOverflowReload [
 	| page capacity |
 
 	capacity := index headerPage itemCapacity.
-	1 to: capacity do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	1 to: capacity do: [ :n | index at: n put: (n asByteArrayOfSize: 8) ].
 	self assert: index pages size equals: 3.
 	self assert: (index pageAt: 1) numberOfItems equals: 126.
 	"if we add a page, the current one is split and half is moved there"
-	1 to: capacity do: [ :n | index at: capacity + n put: #[ 1 2 3 4 5 6 7 8 ]].
+	1 to: capacity do: [ :n | index at: capacity + n put: (capacity + n asByteArrayOfSize: 8)].
 	self assert: index pages size equals: 4.
 	page := index pageAt: 4.
 	self assert: page numberOfItems equals: 253.
@@ -204,7 +204,7 @@ SoilBTreeTest >> testAddSecondOverflowReload [
 	index := SoilBTree new 
 		path: 'sunit-btree';
 		initializeFilesystem.
-	self assert: (index at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: capacity) equals: (capacity asByteArrayOfSize: 8).
 ]
 
 { #category : #tests }
@@ -212,16 +212,16 @@ SoilBTreeTest >> testAt [
 
 	| capacity |
 	capacity := index headerPage itemCapacity.
-	1 to: capacity do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	1 to: capacity do: [ :n | index at: n put: (n asByteArrayOfSize: 8) ].
 	self assert: index pages size equals: 3.
 	self assert: (index pageAt: 1) numberOfItems equals: 126.
 	"if we add a page, the current one is split and half is moved there"
-	index at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	index at: capacity + 1 put: (capacity + 1 asByteArrayOfSize: 8).
 	self assert: index pages size equals: 3.
 	
-	self assert: (index at: 1) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: capacity + 1) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 1) equals: (1 asByteArrayOfSize: 8).
+	self assert: (index at: capacity) equals: (capacity asByteArrayOfSize: 8).
+	self assert: (index at: capacity + 1) equals: (capacity + 1 asByteArrayOfSize: 8).
 	self should: [ index at: capacity + 2  ] raise: KeyNotFound
 ]
 
@@ -230,17 +230,17 @@ SoilBTreeTest >> testAtSecondOverflow [
 
 	| capacity |
 	capacity := index headerPage itemCapacity.
-	1 to: capacity*2 do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	1 to: capacity*2 do: [ :n | index at: n put: (n asByteArrayOfSize: 8)  ].
 	self assert: index pages size equals: 4.
 	self assert: (index pageAt: 1) numberOfItems equals: 126.
 	"if we add a page, the current one is split and half is moved there"
-	1 to: capacity do: [ :n | index at: capacity + n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	1 to: capacity do: [ :n | index at: capacity + n put:(capacity + n asByteArrayOfSize: 8)  ].
 	self assert: index pages size equals: 4.
 	
-	self assert: (index at: 1) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: capacity + 1) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: capacity + capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 1) equals: (1 asByteArrayOfSize: 8) .
+	self assert: (index at: capacity) equals: (capacity asByteArrayOfSize: 8).
+	self assert: (index at: capacity + 1) equals:  (capacity + 1 asByteArrayOfSize: 8).
+	self assert: (index at: capacity + capacity) equals: (capacity + capacity asByteArrayOfSize: 8).
 	self should: [ index at: capacity * 2 + 1  ] raise: KeyNotFound
 ]
 
@@ -259,12 +259,11 @@ SoilBTreeTest >> testFirst [
 	| capacity |
 	capacity := index headerPage itemCapacity * 2.
 
-	2 to: capacity do: [ :n |
-		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	index at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
+	1 to: capacity do: [ :n |
+		index at: n put: (n asByteArrayOfSize: 8)].
 	self assert: index pages size equals: 4.
-	self assert: index first equals: #[ 8 7 6 5 4 3 2 1 ].
-	self assert: (index first: 2) second equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: index first equals: (1 asByteArrayOfSize: 8).
+	self assert: (index first: 2) second equals: (2 asByteArrayOfSize: 8)
 ]
 
 { #category : #tests }
@@ -273,7 +272,7 @@ SoilBTreeTest >> testIndexRewriting [
 	| capacity fileSizeBefore |
 	capacity := index firstPage itemCapacity.
 	1 to: capacity + 1 do: [ :n | 
-		index at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: n put: (n asByteArrayOfSize: 8) ].
 	index flush.
 	self assert: index headerPage lastPageIndex equals: 3.
 	self assert: (index pageAt: 3) items size equals: 128.
@@ -294,7 +293,7 @@ SoilBTreeTest >> testIndexRewritingWithCleaning [
 	| capacity |
 	capacity := index firstPage itemCapacity.
 	1 to: capacity + 1 do: [ :n | 
-		index at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: n  put: (n asByteArrayOfSize: 8) ].
 	index flush.
 	1 to: capacity do: [ :n | 
 		index at: n  put: SoilObjectId removed ].
@@ -302,7 +301,7 @@ SoilBTreeTest >> testIndexRewritingWithCleaning [
 	index newPluggableRewriter cleanRemoved run.
 	self assert: index headerPage lastPageIndex equals: 2.
 	self assert: (index pageAt: 1) items size equals: 1.
-	self assert: (index at: capacity + 1) asByteArray equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: capacity + 1) asByteArray equals: (capacity + 1 asByteArrayOfSize: 8).
 
 ]
 
@@ -326,11 +325,10 @@ SoilBTreeTest >> testLast [
 	| capacity |
 	capacity := index headerPage itemCapacity * 2.
 
-	1 to: capacity - 1 do: [ :n |
-		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	index at: capacity put: #[ 8 7 6 5 4 3 2 1 ].
+	1 to: capacity  do: [ :n |
+		index at: n put: (n asByteArrayOfSize: 8) ].
 	self assert: index pages size equals: 4.
-	self assert: index last equals: #[ 8 7 6 5 4 3 2 1 ]
+	self assert: index last equals: (capacity asByteArrayOfSize: 8)
 ]
 
 { #category : #tests }
@@ -340,14 +338,13 @@ SoilBTreeTest >> testLastPage [
 	index maxLevel: 8.
 	capacity := index firstPage itemCapacity * 100.
 
-	1 to: capacity - 1 do: [ :n |
-		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	index at: capacity put: #[ 8 7 6 5 4 3 2 1 ].
+	1 to: capacity do: [ :n |
+		index at: n put: (n asByteArrayOfSize: 8) ].
 	self assert: index pages size equals: 200.
 	self assert: index lastPage index equals: 200.
 	self assert: index lastPage isLastPage.
 	lastItem := index lastPage itemAt: capacity ifAbsent: [nil].
-	self assert: lastItem value equals: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: lastItem value equals: (capacity asByteArrayOfSize: 8)
 ]
 
 { #category : #tests }
@@ -357,7 +354,7 @@ SoilBTreeTest >> testOverflowCopyOnWriteSplitting [
 	copyOnWrite := index asCopyOnWrite.
 	capacity := copyOnWrite headerPage itemCapacity.
 	1 to: capacity * 2 by: 2 do: [ :n | 
-		copyOnWrite at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		copyOnWrite at: n  put: (n asByteArrayOfSize: 8) ].
 	self assert: copyOnWrite pages size equals: 3.
 
 	page := copyOnWrite pageAt: 3.
@@ -370,12 +367,12 @@ SoilBTreeTest >> testOverflowCopyOnWriteSplitting [
 SoilBTreeTest >> testPageAddFirst [
 	
 	| page indexPage |
-	index at: #foo put: #[ 1 2 3 4 5 6 7 8 ].
+	index at: 1 put: (1 asByteArrayOfSize: 8).
 	index writePages.
 	self assert: index pages size equals: 2.
 	page := index headerPage.
 	self assert: page numberOfItems equals: 1.
-	self assert: page items first key equals: (index indexKey: #foo).
+	self assert: page items first key equals: (index indexKey: 1).
 	"the index page was updated"
 	indexPage := index rootPage.
 	"Index has been updated"
@@ -388,12 +385,12 @@ SoilBTreeTest >> testPageAddFirst [
 SoilBTreeTest >> testPageAddFirstAndLoad [
 	
 	| page indexPage |
-	index at: #foo put: #[ 1 2 3 4 5 6 7 8 ].
+	index at: 1 put: (1 asByteArrayOfSize: 8).
 	index writePages.
 	self assert: index pages size equals: 2.
 	page := index headerPage.
 	self assert: page numberOfItems equals: 1.
-	self assert: page items first key equals: (index indexKey: #foo).
+	self assert: page items first key equals: (index indexKey: 1).
 	"the index page was updated"
 	indexPage := index rootPage.
 	"Index has been updated"
@@ -406,9 +403,9 @@ SoilBTreeTest >> testPageAddFirstAndLoad [
 		path: 'sunit-btree';
 		initializeFilesystem.
 	
-	self assert: page items first key equals:(index indexKey: #foo).
+	self assert: page items first key equals:(index indexKey: 1).
 	"load succeeds"
-	self assert: (index at: #foo) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 1) equals:  (1 asByteArrayOfSize: 8).
 
 ]
 
@@ -428,10 +425,10 @@ SoilBTreeTest >> testRemoveFromIndex [
 	
 	
 	entries do: [:toAdd |
-		index at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: toAdd  put: (toAdd asByteArrayOfSize: 8) ].
 
 	"can we find all the keys we added?"
-	entries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	entries do: [:each | self assert: (index at: each ) equals: (each asByteArrayOfSize: 8)].
 	"page 10 is the index page that has the index"
 	self assert: (index pageAt: 10) items last key equals: 335.
 	"now we remove 335"
@@ -441,8 +438,9 @@ SoilBTreeTest >> testRemoveFromIndex [
 	"and the index is removed, too"
 	self deny: (index pageAt: 10) items last key equals: 335.
 	"we can add it back"
-	index at: 335  put: #[ 1 2 3 4 5 6 7 8 ].
+	index at: 335  put: (335 asByteArrayOfSize: 8).
 	self assert: (index pageAt: 10) items last key equals: 335.
+	self assert: (index pageAt: 10) items last value equals: (335 asByteArrayOfSize: 8)
 ]
 
 { #category : #tests }
@@ -461,17 +459,17 @@ SoilBTreeTest >> testRemoveFromIndexAll [
 	remainingEntries := entries asOrderedCollection.
 	
 	entries do: [:toAdd |
-		index at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: toAdd  put: (toAdd asByteArrayOfSize: 8) ].
 	"can we find all the keys we added?"
-	entries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	entries do: [:each | self assert: (index at: each ) equals: (each asByteArrayOfSize: 8)].
 	
 	
 	entries do: [:entry| |removed|
 		removed := index removeKey: entry.
-		self assert: removed equals: #[ 1 2 3 4 5 6 7 8 ].
+		self assert: removed equals:  (removed asByteArrayOfSize: 8).
 		remainingEntries remove: entry.
 		"check that all remaining entries can be found"	
-		remainingEntries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+		remainingEntries do: [:each | self assert: (index at: each ) equals: (each asByteArrayOfSize: 8)].
 		"check size, this makes sure we can iterate over all remaining entries"
 		self assert: index values size equals: remainingEntries size.	
 		 ].
@@ -482,8 +480,8 @@ SoilBTreeTest >> testRemoveFromIndexAll [
 	
 	"and add back"
 	entries do: [:toAdd |
-		index at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
-	entries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]]
+		index at: toAdd  put: (toAdd asByteArrayOfSize: 8) ].
+	entries do: [:each | self assert: (index at: each ) equals: (each asByteArrayOfSize: 8)]
 ]
 
 { #category : #tests }
@@ -491,13 +489,13 @@ SoilBTreeTest >> testRemoveKey [
 
 	| capacity removed |
 	capacity := index headerPage itemCapacity.
-	1 to: capacity do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	1 to: capacity do: [ :n | index at: n put: (n asByteArrayOfSize: 8) ].
 	
 	removed := index removeKey: 20.
-	self assert: removed equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: removed equals: (20 asByteArrayOfSize: 8).
 	
-	self assert: (index at: 1) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 1) equals: (1 asByteArrayOfSize: 8).
+	self assert: (index at: capacity) equals: (capacity asByteArrayOfSize: 8).
 	self should: [ index at: 20 ] raise: KeyNotFound.
 	self should: [ index removeKey: 20  ] raise: KeyNotFound.
 ]
@@ -507,10 +505,9 @@ SoilBTreeTest >> testSize [
 	
 	| capacity |
 	capacity := index headerPage itemCapacity.
-	index at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
-	2 to: capacity do: [ :n |
-		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	index at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	1 to: capacity do: [ :n |
+		index at: n put: (n asByteArrayOfSize: 8) ].
+	index at: capacity + 1 put:  (capacity + 1 asByteArrayOfSize: 8).
 	self assert: index pages size equals: 3.
 	self assert: index size equals: capacity + 1.
 ]
@@ -531,10 +528,10 @@ SoilBTreeTest >> testSplitIndexPage [
 	
 	
 	entries do: [:toAdd |
-		index at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: toAdd  put: (toAdd asByteArrayOfSize: 8) ].
 	
 	"can we find all the keys we added?"
-	entries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	entries do: [:each | self assert: (index at: each ) equals: (each asByteArrayOfSize: 8)].
 	
 	"check size, this makes sure we can iterate over all remaining entries"
 	self assert: index values size equals: entries size.	
@@ -557,10 +554,10 @@ SoilBTreeTest >> testSplitIndexPageReleoad [
 	
 	
 	entries do: [:toAdd |
-		index at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: toAdd  put:  (toAdd asByteArrayOfSize: 512) ].
 	
 	"can we find all the keys we added?"
-	entries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	entries do: [:each | self assert: (index at: each ) equals: (each asByteArrayOfSize: 512)].
 	
 	"write and reload"
 	index writePages.
@@ -570,7 +567,7 @@ SoilBTreeTest >> testSplitIndexPageReleoad [
 		initializeFilesystem.
 	
 	"can we find all the keys we added?"
-	entries do: [:each | self assert: (index at: each ) equals: (#[ 1 2 3 4 5 6 7 8 ] asByteArrayOfSize: 512)].
+	entries do: [:each | self assert: (index at: each ) equals: (each asByteArrayOfSize: 512)].
 	
 	"check size, this makes sure we can iterate over all remaining entries"
 	self assert: index values size equals: entries size.	

--- a/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
@@ -64,17 +64,17 @@ SoilIndexIteratorTest >> testAddRandom [
 	numEntries timesRepeat: [ | toAdd |
 		toAdd := (numEntries*20) atRandom.
 		entries add: toAdd.
-		iterator at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		iterator at: toAdd  put: (toAdd asByteArrayOfSize: 8)].
 	
 	"check size"
 	self assert: iterator size equals: entries size.
 	
 	"can we find all the keys we added?"
-	entries do: [:each | self assert: (iterator at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	entries do: [:each | self assert: (iterator at: each ) equals:(each asByteArrayOfSize: 8)].
 	
 	"iterate index, all should be in entries"
-	iterator do: [:each | self assert: each equals: #[ 1 2 3 4 5 6 7 8 ]].
-	iterator reverseDo: [:each | self assert: each equals: #[ 1 2 3 4 5 6 7 8 ]]
+	iterator do: [:each | self assert: each equals: (each asByteArrayOfSize: 8)].
+	iterator reverseDo: [:each | self assert: each equals: (each asByteArrayOfSize: 8)]
 ]
 
 { #category : #tests }
@@ -202,18 +202,17 @@ SoilIndexIteratorTest >> testFirst [
 	
 	| capacity first |
 	capacity := index headerPage itemCapacity * 2.
-	index at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
-	2 to: capacity do: [ :n |
-		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	1 to: capacity do: [ :n |
+		index at: n put: (n asByteArrayOfSize: 8) ].
 	first := index newIterator first.
-	self assert: first equals: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: first equals:  (1 asByteArrayOfSize: 8).
 	"we get always the first"
-	self assert: first equals: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: first equals: (1 asByteArrayOfSize: 8).
 	
 	first := index newIterator first: 3.
 	self assert: first size equals: 3.
-	self assert: first third equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: first first equals: #[ 8 7 6 5 4 3 2 1 ]
+	self assert: first third equals: (3 asByteArrayOfSize: 8).
+	self assert: first first equals: (1 asByteArrayOfSize: 8).
 ]
 
 { #category : #tests }
@@ -271,16 +270,15 @@ SoilIndexIteratorTest >> testLast [
 	"check last on empty iterator"
 	self assert: index newIterator last equals: nil.
 	
-	1 to: capacity - 1  do: [ :n |
-		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	index at: capacity put: #[ 8 7 6 5 4 3 2 1 ].
+	1 to: capacity do: [ :n |
+		index at: n put: (n asByteArrayOfSize: 8) ].
 	last := index newIterator last.
-	self assert: last equals: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: last equals: (capacity asByteArrayOfSize: 8).
 	
 	last := index newIterator last: 3.
 	self assert: last size equals: 3.
-	self assert: last first equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: last third equals: #[ 8 7 6 5 4 3 2 1 ]
+	self assert: last first equals: (capacity - 2 asByteArrayOfSize: 8). 
+	self assert: last third equals: (capacity asByteArrayOfSize: 8)
 ]
 
 { #category : #tests }
@@ -309,11 +307,10 @@ SoilIndexIteratorTest >> testLastPage [
 	"check last on empty iterator"
 	self assert: index newIterator lastPage identicalTo: index headerPage.
 	
-	1 to: capacity - 1  do: [ :n |
-		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	index at: capacity put: #[ 8 7 6 5 4 3 2 1 ].
+	1 to: capacity  do: [ :n |
+		index at: n put: (n asByteArrayOfSize: 8) ].
 	lastPage := index newIterator lastPage.
-	self assert: lastPage lastItem value equals: #[ 8 7 6 5 4 3 2 1 ]
+	self assert: lastPage lastItem value equals: (capacity asByteArrayOfSize: 8)
 ]
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -88,17 +88,17 @@ SoilIndexedDictionaryTest >> testAddRandom [
 	numEntries timesRepeat: [ | toAdd |
 		toAdd := (numEntries*20) atRandom.
 		entries add: toAdd.
-		dict at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		dict at: toAdd  put: (toAdd asByteArrayOfSize: 8)].
 	
 	"check size"
 	self assert: dict size equals: entries size.
 	
 	"can we find all the keys we added?"
-	entries do: [:each | self assert: (dict at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	entries do: [:each | self assert: (dict at: each ) equals: (each asByteArrayOfSize: 8)].
 	
 	"iterate index, all should be in entries"
-	dict do: [:each | self assert: each equals: #[ 1 2 3 4 5 6 7 8 ]].
-	dict reverseDo: [:each | self assert: each equals: #[ 1 2 3 4 5 6 7 8 ]]
+	dict do: [:each | self assert: each equals: (each asByteArrayOfSize: 8)].
+	dict reverseDo: [:each | self assert: each equals: (each asByteArrayOfSize: 8)]
 ]
 
 { #category : #tests }
@@ -114,17 +114,17 @@ SoilIndexedDictionaryTest >> testAddRandomRemove [
 	numEntries timesRepeat: [ | toAdd |
 		toAdd := (numEntries*20) atRandom.
 		entries add: toAdd.
-		dict at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		dict at: toAdd  put:  (toAdd asByteArrayOfSize: 8) ].
 	
 	"check size"
 	self assert: dict size equals: entries size.
 	
 	"can we find all the keys we added?"
-	entries do: [:each | self assert: (dict at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	entries do: [:each | self assert: (dict at: each ) equals:  (each asByteArrayOfSize: 8)].
 	
 	"iterate index, all should be in entries"
-	dict do: [:each | self assert: each equals: #[ 1 2 3 4 5 6 7 8 ]].
-	dict reverseDo: [:each | self assert: each equals: #[ 1 2 3 4 5 6 7 8 ]].
+	dict do: [:each | self assert: each equals: (each asByteArrayOfSize: 8)].
+	dict reverseDo: [:each | self assert: each equals: (each asByteArrayOfSize: 8)].
 	
 	"we remove half randomly"
 	numRemoved := numEntries quo: 2.
@@ -136,7 +136,7 @@ SoilIndexedDictionaryTest >> testAddRandomRemove [
 				dict removeKey: toRemove]].
 		
 	"can we find all the keys that should still be there?"
-	(entries copyWithoutAll: removed) do: [:each | self assert: (dict at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	(entries copyWithoutAll: removed) do: [:each | self assert: (dict at: each ) equals: (each asByteArrayOfSize: 8)].
 	
 	"all the removed ones are gone"
 	removed do: [ :each | self assert: (dict at: each ifAbsent: [ true ]) ]

--- a/src/Soil-Core-Tests/SoilSkipListTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListTest.class.st
@@ -33,9 +33,9 @@ SoilSkipListTest >> testAddFirstOverflowAppending [
 	| page capacity |
 	capacity := index firstPage itemCapacity.
 	1 to: capacity do: [ :n | 
-		index at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: n put: (n asByteArrayOfSize: 8) ].
 	self assert: index pages size equals: 1.
-	index at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	index at: capacity + 1 put: ((capacity + 1) asByteArrayOfSize: 8).
 	self assert: index pages size equals: 2.
 	page := index pageAt: 2.
 	self assert: page numberOfItems equals: 1.
@@ -49,9 +49,9 @@ SoilSkipListTest >> testAddFirstOverflowReload [
 	| page capacity |
 	capacity := index firstPage itemCapacity.
 	1 to: capacity do: [ :n | 
-		index at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: n  put:(n asByteArrayOfSize: 8)  ].
 	self assert: index pages size equals: 1.
-	index at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	index at: capacity + 1 put: (capacity + 1 asByteArrayOfSize: 8).
 	self assert: index pages size equals: 2.
 	page := index pageAt: 2.
 	self assert: page numberOfItems equals: 1.
@@ -65,7 +65,7 @@ SoilSkipListTest >> testAddFirstOverflowReload [
 		path: 'sunit-skiplist';
 		initializeFilesystem.
 	"we should be able to do a lookup"
-	self assert: ((index at: capacity) asByteArrayOfSize: 8) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: ((index at: capacity) asByteArrayOfSize: 8) equals: (capacity asByteArrayOfSize: 8).
 ]
 
 { #category : #tests }
@@ -74,9 +74,9 @@ SoilSkipListTest >> testAddFirstOverflowSplitting [
 	| page capacity |
 	capacity := index firstPage itemCapacity.
 	1 to: capacity * 2 by: 2 do: [ :n | 
-		index at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: n  put: (n asByteArrayOfSize: 8)].
 	self assert: index pages size equals: 1.
-	index at: capacity - 2 put: #[ 1 2 3 4 5 6 7 8 ].
+	index at: capacity - 2 put: (capacity - 2 asByteArrayOfSize: 8).
 	self assert: index pages size equals: 2.
 	page := index pageAt: 2.
 	self assert: page numberOfItems equals: 126.
@@ -90,9 +90,9 @@ SoilSkipListTest >> testAddInBetween [
 	| page capacity |
 	capacity := index firstPage itemCapacity.
 	1 to: capacity do: [ :n |
-		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: n put: (n asByteArrayOfSize: 8) ].
 	self assert: index pages size equals: 1.
-	index at: (capacity / 2) floor put: #[ 1 2 3 4 5 6 7 8 ].
+	index at: (capacity / 2) floor put: ((capacity / 2) floor asByteArrayOfSize: 8).
 	self assert: index pages size equals: 1.
 	page := index pageAt: 1.
 	self assert: page numberOfItems equals: 252.
@@ -105,9 +105,9 @@ SoilSkipListTest >> testAddInBetweenOverflowing [
 	| page capacity |
 	capacity := index firstPage itemCapacity.
 	1 to: capacity * 2 by: 2 do: [ :n | 
-		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: n put: (n asByteArrayOfSize: 8) ].
 	self assert: index pages size equals: 1.
-	index at: 32 put: #[ 8 7 6 5 4 3 2 1 ].
+	index at: 32 put: (32 asByteArrayOfSize: 8).
 	self assert: index pages size equals: 2.
 	page := index pageAt: 2.
 	self assert: page numberOfItems equals: 126.
@@ -122,7 +122,7 @@ SoilSkipListTest >> testAddInBetweenOverwriting [
 	| page capacity |
 	capacity := index firstPage itemCapacity.
 	1 to: capacity * 2 by: 2 do: [ :n | 
-		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: n put: (n asByteArrayOfSize: 8) ].
 	self assert: index pages size equals: 1.
 	index at: 31 put: #[ 8 7 6 5 4 3 2 1 ].
 	self assert: index pages size equals: 1.
@@ -136,9 +136,9 @@ SoilSkipListTest >> testAddLastFitting [
 	
 	| page |
 	1 to: 61 do: [ :n | 
-		index at: (index indexKey: n asString ) put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: (index indexKey: n asString ) put: (n asByteArrayOfSize: 8) ].
 	self assert: index pages size equals: 1.
-	index at: (index indexKey: 63 asString) put: #[ 1 2 3 4 5 6 7 8 ].
+	index at: (index indexKey: 63 asString) put: (63 asByteArrayOfSize: 8).
 	self assert: index pages size equals: 1.
 	page := index pageAt: 1.
 	self assert: page numberOfItems equals: 62.
@@ -165,17 +165,17 @@ SoilSkipListTest >> testAddRandom [
 	numEntries timesRepeat: [ | toAdd |
 		toAdd := (numEntries*20) atRandom.
 		entries add: toAdd.
-		index at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: toAdd  put: (toAdd asByteArrayOfSize: 8) ].
 	
 	"check size"
 	self assert: index size equals: entries size.
 	
 	"can we find all the keys we added?"
-	entries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	entries do: [:each | self assert: (index at: each ) equals: (each asByteArrayOfSize: 8)].
 	
 	"iterate index, all should be in entries"
-	index do: [:each | self assert: each equals: #[ 1 2 3 4 5 6 7 8 ]].
-	index reverseDo: [:each | self assert: each equals: #[ 1 2 3 4 5 6 7 8 ]]
+	index do: [:each | self assert: each equals: (each asByteArrayOfSize: 8)].
+	index reverseDo: [:each | self assert: each equals: (each asByteArrayOfSize: 8)]
 ]
 
 { #category : #tests }
@@ -184,13 +184,13 @@ SoilSkipListTest >> testAt [
 	| capacity |
 	capacity := index firstPage itemCapacity.
 	1 to: capacity do: [ :n | 
-		index at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: n  put: (n asByteArrayOfSize: 8)  ].
 	self assert: index pages size equals: 1.
-	index at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	index at: capacity + 1 put: (capacity + 1  asByteArrayOfSize: 8).
 	self assert: index pages size equals: 2.
 	
 	"we should be able to find the key that is on the second page"
-	self assert: (index at: capacity + 1) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: capacity + 1) equals:  (capacity + 1  asByteArrayOfSize: 8).
 	self should: [ index at: capacity + 2  ] raise: KeyNotFound
 ]
 
@@ -213,14 +213,13 @@ SoilSkipListTest >> testDo [
 	
 	| capacity col |
 	capacity := index firstPage itemCapacity.
-	index at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
-	2 to: capacity do: [ :n |
-		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	index at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	1 to: capacity do: [ :n |
+		index at: n put:  (n asByteArrayOfSize: 8) ].
+	index at: capacity + 1 put:  (capacity + 1 asByteArrayOfSize: 8).
 	self assert: index pages size equals: 2.
 	col := OrderedCollection new.
 	index do: [ :item | col add: item ].
-	self assert: col first equals: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: col first equals: (1 asByteArrayOfSize: 8).
 	self assert: col size equals: capacity + 1
 ]
 
@@ -228,19 +227,19 @@ SoilSkipListTest >> testDo [
 SoilSkipListTest >> testFindKey [
 	| value |
 	1 to: 200 do: [ :n |
-		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: n put: (n asByteArrayOfSize: 8)].
 	value := index find: 133. 
-	self assert: value equals: #[ 1 2 3 4 5 6 7 8 ]
+	self assert: value equals: (133 asByteArrayOfSize: 8)
 ]
 
 { #category : #tests }
 SoilSkipListTest >> testFindKeyReverse [
 	| value |
 	200 to: 1 by: -1 do: [ :n |
-		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: n put: (n asByteArrayOfSize: 8) ].
 	"skipList writePages."
 	value := index find: 133. 
-	self assert: value equals: #[ 1 2 3 4 5 6 7 8 ]
+	self assert: value equals: (133 asByteArrayOfSize: 8)
 ]
 
 { #category : #tests }
@@ -250,18 +249,18 @@ SoilSkipListTest >> testFirst [
 	capacity := index firstPage itemCapacity * 2.
 
 	2 to: capacity do: [ :n |
-		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	index at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
+		index at: n put: (n asByteArrayOfSize: 8) ].
+	index at: 1 put: (1 asByteArrayOfSize: 8).
 	self assert: index pages size equals: 3.
-	self assert: index first equals: #[ 8 7 6 5 4 3 2 1 ].
-	self assert: (index first: 2) second equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: index first equals: (1 asByteArrayOfSize: 8).
+	self assert: (index first: 2) second equals:(2 asByteArrayOfSize: 8)
 ]
 
 { #category : #tests }
 SoilSkipListTest >> testFirstArgLargerThenSize [
 
 	1 to: 4 do: [ :n |
-		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: n put: (n asByteArrayOfSize: 8)].
 	self assert: index pages size equals: 1.
 	self assert: (index first: 5) size equals: 4
 ]
@@ -272,7 +271,7 @@ SoilSkipListTest >> testIndexRewriting [
 	| capacity fileSizeBefore |
 	capacity := index firstPage itemCapacity.
 	1 to: capacity + 1 do: [ :n | 
-		index at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: n  put: (n asByteArrayOfSize: 8) ].
 	index flush.
 	fileSizeBefore := index path size.
 	index newPluggableRewriter rewrite.
@@ -287,7 +286,7 @@ SoilSkipListTest >> testIndexRewritingWithCleaning [
 	| capacity |
 	capacity := index firstPage itemCapacity.
 	1 to: capacity + 1 do: [ :n | 
-		index at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: n  put: (n asByteArrayOfSize: 8) ].
 	index flush.
 	1 to: capacity do: [ :n | 
 		index at: n  put: SoilObjectId removed ].
@@ -295,7 +294,7 @@ SoilSkipListTest >> testIndexRewritingWithCleaning [
 	index newPluggableRewriter cleanRemoved rewrite.
 	self assert: index headerPage lastPageIndex equals: 1.
 	self assert: (index pageAt: 1) items size equals: 1.
-	self assert: (index at: capacity + 1) asByteArray equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: capacity + 1) equals: (capacity + 1 asByteArrayOfSize: 8).
 
 ]
 
@@ -320,10 +319,10 @@ SoilSkipListTest >> testLast [
 	capacity := index firstPage itemCapacity * 2.
 
 	1 to: capacity - 1 do: [ :n |
-		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	index at: capacity put: #[ 8 7 6 5 4 3 2 1 ].
+		index at: n put: (n asByteArrayOfSize: 8)].
+	index at: capacity put: (capacity asByteArrayOfSize: 8).
 	self assert: index pages size equals: 2.
-	self assert: index last equals: #[ 8 7 6 5 4 3 2 1 ]
+	self assert: index last equals: (capacity asByteArrayOfSize: 8)
 ]
 
 { #category : #tests }
@@ -334,20 +333,20 @@ SoilSkipListTest >> testLastPage [
 	capacity := index firstPage itemCapacity * 100.
 
 	1 to: capacity - 1 do: [ :n |
-		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	index at: capacity put: #[ 8 7 6 5 4 3 2 1 ].
+		index at: n put: (n asByteArrayOfSize: 8)].
+	index at: capacity put: (capacity asByteArrayOfSize: 8).
 	self assert: index pages size equals: 99.
 	self assert: index lastPage index equals: 99.
 	self assert: index lastPage isLastPage.
 	lastItem := index lastPage itemAt: capacity ifAbsent: [nil].
-	self assert: lastItem value equals: #[ 8 7 6 5 4 3 2 1 ].
+	self assert: lastItem value equals: (capacity asByteArrayOfSize: 8)
 ]
 
 { #category : #tests }
 SoilSkipListTest >> testLatestVersionRoundtrip [
 	
 	1 to: 10 do: [ :n | 
-		index at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: n  put: (n asByteArrayOfSize: 8) ].
 	index removeKey: 4.
 	self assert: index pages size equals: 1.
 	self assert: index size equals: 9.
@@ -365,7 +364,7 @@ SoilSkipListTest >> testLatestVersionRoundtrip [
 { #category : #tests }
 SoilSkipListTest >> testMorePages [
 	1 to: 512 do: [ :n |
-		index at: (index indexKey: n asString) put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: (index indexKey: n asString) put: (n asByteArrayOfSize: 8) ].
 	index writePages.
 	self assert: index pages size equals: 3
 ]
@@ -377,9 +376,9 @@ SoilSkipListTest >> testOverflowCopyOnWriteAppending [
 	copyOnWrite := index asCopyOnWrite.
 	capacity := copyOnWrite firstPage itemCapacity.
 	1 to: capacity do: [ :n | 
-		copyOnWrite at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		copyOnWrite at: n  put: (n asByteArrayOfSize: 8) ].
 	self assert: copyOnWrite pages size equals: 1.
-	copyOnWrite at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+	copyOnWrite at: capacity + 1 put: (capacity + 1 asByteArrayOfSize: 8).
 	self assert: copyOnWrite pages size equals: 2.
 	page := copyOnWrite pageAt: 2.
 	self assert: page numberOfItems equals: 1.
@@ -394,9 +393,9 @@ SoilSkipListTest >> testOverflowCopyOnWriteSplitting [
 	copyOnWrite := index asCopyOnWrite.
 	capacity := copyOnWrite firstPage itemCapacity.
 	1 to: capacity * 2 by: 2 do: [ :n | 
-		copyOnWrite at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		copyOnWrite at: n  put:  (n asByteArrayOfSize: 8) ].
 	self assert: copyOnWrite pages size equals: 1.
-	copyOnWrite at: 2 put: #[ 1 2 3 4 5 6 7 8 ].
+	copyOnWrite at: 2 put: (2 asByteArrayOfSize: 8).
 	self assert: copyOnWrite pages size equals: 2.
 	page := copyOnWrite pageAt: 2.
 	self assert: page numberOfItems equals: 126.
@@ -426,10 +425,10 @@ SoilSkipListTest >> testRemoveAllFromPage [
 	
 	
 	entries do: [:toAdd |
-		index at: toAdd  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: toAdd  put:  (toAdd asByteArrayOfSize: 8) ].
 
 	"can we find all the keys we added?"
-	entries do: [:each | self assert: (index at: each ) equals: #[ 1 2 3 4 5 6 7 8 ]].
+	entries do: [:each | self assert: (index at: each ) equals: (each asByteArrayOfSize: 8)].
 	"#values iterates using #basicNextAssociation"
 	self assert: index values size equals: entries size.
 	
@@ -445,16 +444,16 @@ SoilSkipListTest >> testRemoveKey [
 
 	| capacity removed |
 	capacity := index headerPage itemCapacity.
-	1 to: capacity do: [ :n | index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
+	1 to: capacity do: [ :n | index at: n put:  (n asByteArrayOfSize: 8) ].
 	
 	removed := index removeKey: 20.
-	self assert: removed equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: removed equals: (20 asByteArrayOfSize: 8).
 	
-	self assert: (index at: 1) equals: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: capacity) equals: #[ 1 2 3 4 5 6 7 8 ].
+	self assert: (index at: 1) equals: (1 asByteArrayOfSize: 8).
+	self assert: (index at: capacity) equals: (capacity asByteArrayOfSize: 8).
 	self should: [ index at: 20  ] raise: KeyNotFound.
-	index at: 20 put: #[ 1 2 3 4 5 6 7 8 ].
-	self assert: (index at: 20) equals: #[ 1 2 3 4 5 6 7 8 ].
+	index at: 20 put: (20 asByteArrayOfSize: 8).
+	self assert: (index at: 20) equals:(20 asByteArrayOfSize: 8).
 	
 	self should: [ index removeKey: capacity + 1 ] raise: KeyNotFound
 ]
@@ -464,10 +463,10 @@ SoilSkipListTest >> testSize [
 	
 	| capacity |
 	capacity := index firstPage itemCapacity.
-	index at: 1 put: #[ 8 7 6 5 4 3 2 1 ].
+	index at: 1 put:  (1 asByteArrayOfSize: 8).
 	2 to: capacity do: [ :n |
-		index at: n put: #[ 1 2 3 4 5 6 7 8 ] ].
-	index at: capacity + 1 put: #[ 1 2 3 4 5 6 7 8 ].
+		index at: n put:  (n asByteArrayOfSize: 8) ].
+	index at: capacity + 1 put: (capacity + 1 asByteArrayOfSize: 8).
 	self assert: index pages size equals: 2.
 	self assert: index size equals: capacity + 1.
 ]
@@ -499,7 +498,7 @@ SoilSkipListTest >> testVersionOneRoundtrip [
 		instVarNamed: #version put: 1;
 		size: -1.
 	1 to: 10 do: [ :n | 
-		index at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: n  put:  (n asByteArrayOfSize: 8) ].
 	index removeKey: 4.
 	self assert: index pages size equals: 1.
 	self assert: index size equals: 9.
@@ -520,7 +519,7 @@ SoilSkipListTest >> testVersionOneRoundtripAndCompact [
 		instVarNamed: #version put: 1;
 		size: -1.
 	1 to: 10 do: [ :n | 
-		index at: n  put: #[ 1 2 3 4 5 6 7 8 ] ].
+		index at: n  put:  (n asByteArrayOfSize: 8) ].
 	index removeKey: 4.
 	self assert: index pages size equals: 1.
 	self assert: index size equals: 9.


### PR DESCRIPTION
This PR makes sure to always encode the key in the value for all the  index tests.

This is better as we now can test that we get the correct lookup for all cases.