### PR TITLE
Do not use #class to check for Proxy

### DIFF
--- a/src/Soil-Core-Tests/SoilPersistentDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilPersistentDictionaryTest.class.st
@@ -92,7 +92,7 @@ SoilPersistentDictionaryTest >> testCommitAndRead [
 
 	"should this not be transparently load it?"
 	"if the Proxy inherits from ProtoObject, it works"
-	self assert: (materialized at: #test) class equals: SoilObjectProxy
+	self assert: (materialized at: #test) isSoilProxy
 ]
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilTest.class.st
+++ b/src/Soil-Core-Tests/SoilTest.class.st
@@ -405,7 +405,7 @@ SoilTest >> testSerializingToSavedRoot [
 	tx3 := soil3 newTransaction.
 	materializedRoot := tx3 root.
 	materializedModelMap := materializedRoot at: modelName.
-	self assert: materializedModelMap class equals: SoilObjectProxy.
+	self assert: materializedModelMap isSoilProxy.
 	self assert: materializedModelMap soilRealObject class equals: Dictionary.
 	self assert: (materializedModelMap soilRealObject at: 'foo') class equals: SoilTestGraphRoot.
 	self assert: (materializedModelMap soilRealObject at: 'foo') nested reference nested label equals: 'nested under cluster'

--- a/src/Soil-Core/SoilTransaction.class.st
+++ b/src/Soil-Core/SoilTransaction.class.st
@@ -468,7 +468,7 @@ SoilTransaction >> objectAt: anObjectId ifAbsent: aBlock [
 
 { #category : #api }
 SoilTransaction >> objectIdOf: anObject [ 
-	^ (anObject class = SoilObjectProxy)
+	^ anObject isSoilProxy
 		ifTrue: [ anObject objectId ]
 		ifFalse: [ (objectMap at: anObject) objectId ].
 	


### PR DESCRIPTION
We are using in some places #class to check if an object is a proxy.

This works now as #class is not forwarded to the soilRealObject as it is inherited from ProtoObject, but it might be better to forward it do allow users to use the #class in #= methods, for example

This pr replaces all "= class" by #isSoilProxy