### PR TITLE
Simplify #findPreviousPageOf:

### DIFF
--- a/src/Soil-Core/SoilBTreeIterator.class.st
+++ b/src/Soil-Core/SoilBTreeIterator.class.st
@@ -32,7 +32,6 @@ SoilBTreeIterator >> findPageFor: indexKey [
 SoilBTreeIterator >> findPreviousPageOf: aPage [
 	
 	aPage isHeaderPage ifTrue: [ ^nil ].
-	aPage isEmpty ifTrue: [ ^super findPreviousPageOf: aPage ].
 	currentPage := index rootPage findPreviousPage: aPage firstItem key with: index path: OrderedCollection new.
 	"for now use assert to make sure this is correct"
 	self assert: (self nextPage == aPage).

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -175,10 +175,7 @@ SoilIndexIterator >> findPageFor: indexKey [
 
 { #category : #private }
 SoilIndexIterator >> findPreviousPageOf: aPage [
-	"Slow approach that searched all pages from the first following the next pointer, only called for empty pages"
-
-	self pagesDo: [ :page | page next == aPage offset ifTrue: [ ^page ] ].
-	self error: 'should not happen'
+	self subclassResponsibility
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilSkipListIterator.class.st
+++ b/src/Soil-Core/SoilSkipListIterator.class.st
@@ -64,7 +64,6 @@ SoilSkipListIterator >> findPageFor: indexKey [
 SoilSkipListIterator >> findPreviousPageOf: aPage [
 	| pageIndex candidatePage keyOfPage |
 	aPage isHeaderPage ifTrue: [ ^nil ].
-	aPage isEmpty ifTrue: [ ^super findPreviousPageOf: aPage ].
 	keyOfPage := aPage smallestKey.
 	
 	currentPage := index headerPage.


### PR DESCRIPTION
As pages can not be empty (other than the headerpage), we do not need the slow fallback for #findPreviousPageOf:  anymore