### PR TITLE
Cleanup: move methods up in hierachy of Index classes

### DIFF
--- a/src/Soil-Core/SoilBTree.class.st
+++ b/src/Soil-Core/SoilBTree.class.st
@@ -9,11 +9,6 @@ Class {
 	#category : #'Soil-Core-Index-BTree'
 }
 
-{ #category : #'as yet unclassified' }
-SoilBTree >> allocatePage [ 
-	^ self newPage 
-]
-
 { #category : #'open/close' }
 SoilBTree >> close [ 
 	super close.
@@ -67,11 +62,6 @@ SoilBTree >> path [
 SoilBTree >> path: aStringOrFileReference [
 
 	path := aStringOrFileReference asFileReference 
-]
-
-{ #category : #'as yet unclassified' }
-SoilBTree >> persistentIndex [
-	^ self 
 ]
 
 { #category : #converting }

--- a/src/Soil-Core/SoilBTreeHeaderPage.class.st
+++ b/src/Soil-Core/SoilBTreeHeaderPage.class.st
@@ -62,10 +62,6 @@ SoilBTreeHeaderPage >> initialize [
 	size := 0
 ]
 
-{ #category : #initialization }
-SoilBTreeHeaderPage >> initializeInIndex: aSoilSkipList [
-]
-
 { #category : #testing }
 SoilBTreeHeaderPage >> isHeaderPage [
 	^ true

--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -40,6 +40,11 @@ SoilBTreePage >> find: aKey with: aBTree [
 	^ self subclassResponsibility
 ]
 
+{ #category : #private }
+SoilBTreePage >> findPreviousPage: aKey with: aBTree path: aPath [ 
+	^ self subclassResponsibility
+]
+
 { #category : #assertions }
 SoilBTreePage >> hasUnderflow [
 	^ self numberOfItems < ((self itemCapacity  / 2) ceiling - 1)
@@ -50,6 +55,10 @@ SoilBTreePage >> initialize [
 	super initialize.
 	lastTransaction := 0.
 	needWrite := true
+]
+
+{ #category : #initialization }
+SoilBTreePage >> initializeInIndex: aSoilSkipList [
 ]
 
 { #category : #adding }

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -8,9 +8,6 @@ See SoilBTree for more information
 Class {
 	#name : #SoilBasicBTree,
 	#superclass : #SoilIndex,
-	#instVars : [
-		'dirtyPages'
-	],
 	#category : #'Soil-Core-Index-BTree'
 }
 
@@ -25,6 +22,11 @@ SoilBasicBTree >> addDirtyPage: aPage [
 	dirtyPages add: aPage
 ]
 
+{ #category : #'instance creation' }
+SoilBasicBTree >> allocatePage [ 
+	^ self newPage
+]
+
 { #category : #converting }
 SoilBasicBTree >> asCopyOnWrite [
 	^ SoilCopyOnWriteBTree new
@@ -35,11 +37,6 @@ SoilBasicBTree >> asCopyOnWrite [
 { #category : #accessing }
 SoilBasicBTree >> dataPages [
 	^ (self pages reject: [ :page | page isIndexPage ]) asArray
-]
-
-{ #category : #accessing }
-SoilBasicBTree >> dirtyPages [
-	^ dirtyPages
 ]
 
 { #category : #accessing }
@@ -136,21 +133,6 @@ SoilBasicBTree >> open [
 { #category : #initialization }
 SoilBasicBTree >> pageClass [
 	^ SoilBTreeDataPage
-]
-
-{ #category : #removing }
-SoilBasicBTree >> recyclePage: aPage [
-	"the header stays untouched even it it gets empty"
-	aPage isHeaderPage ifTrue: [ ^ aPage ].
-	"remove page from chain of item pages"
-	self removePage: aPage. 
-	"add page to free list chain"
-	^ self addToFreePages: aPage
-]
-
-{ #category : #removing }
-SoilBasicBTree >> removeDirtyPage: aPage [ 
-	dirtyPages remove: aPage 
 ]
 
 { #category : #removing }

--- a/src/Soil-Core/SoilBasicSkipList.class.st
+++ b/src/Soil-Core/SoilBasicSkipList.class.st
@@ -8,9 +8,6 @@ See SoilSkipList for more information
 Class {
 	#name : #SoilBasicSkipList,
 	#superclass : #SoilIndex,
-	#instVars : [
-		'dirtyPages'
-	],
 	#category : #'Soil-Core-Index-SkipList'
 }
 
@@ -23,11 +20,6 @@ SoilBasicSkipList class >> isAbstract [
 { #category : #adding }
 SoilBasicSkipList >> addDirtyPage: aPage [ 
 	dirtyPages add: aPage
-]
-
-{ #category : #accessing }
-SoilBasicSkipList >> dirtyPages [
-	^ dirtyPages
 ]
 
 { #category : #testing }
@@ -56,21 +48,6 @@ SoilBasicSkipList >> maxLevel: anInteger [
 { #category : #'instance creation' }
 SoilBasicSkipList >> newIterator [ 
 	^ SoilSkipListIterator on: self 
-]
-
-{ #category : #removing }
-SoilBasicSkipList >> recyclePage: aPage [
-	"the header stays untouched even it it gets empty"
-	aPage isHeaderPage ifTrue: [ ^ aPage ].
-	"remove page from chain of item pages"
-	self removePage: aPage. 
-	"add page to free list chain"
-	^ self addToFreePages: aPage
-]
-
-{ #category : #removing }
-SoilBasicSkipList >> removeDirtyPage: aPage [ 
-	dirtyPages remove: aPage 
 ]
 
 { #category : #removing }

--- a/src/Soil-Core/SoilCopyOnWriteBTree.class.st
+++ b/src/Soil-Core/SoilCopyOnWriteBTree.class.st
@@ -11,11 +11,6 @@ Class {
 SoilCopyOnWriteBTree >> addDirtyPage: aPage [ 
 ]
 
-{ #category : #'as yet unclassified' }
-SoilCopyOnWriteBTree >> allocatePage [
-	^ self newPage
-]
-
 { #category : #testing }
 SoilCopyOnWriteBTree >> isRegistered [
 	^ wrapped isRegistered

--- a/src/Soil-Core/SoilCopyOnWriteSkipList.class.st
+++ b/src/Soil-Core/SoilCopyOnWriteSkipList.class.st
@@ -12,7 +12,7 @@ SoilCopyOnWriteSkipList >> addDirtyPage: aPage [
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SoilCopyOnWriteSkipList >> allocatePage [
 	^ wrapped allocatePage 
 ]

--- a/src/Soil-Core/SoilIndex.class.st
+++ b/src/Soil-Core/SoilIndex.class.st
@@ -16,7 +16,8 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'id',
-		'store'
+		'store',
+		'dirtyPages'
 	],
 	#category : #'Soil-Core-Index-Common'
 }
@@ -50,6 +51,11 @@ SoilIndex >> addToFreePages: aPage [
 			ifFalse: [ currentFreePage := store pageAt: currentFreePage next ]].
 	currentFreePage addPage: newFreePage.
 	^ newFreePage 
+]
+
+{ #category : #'instance creation' }
+SoilIndex >> allocatePage [
+	^ self subclassResponsibility
 ]
 
 { #category : #private }
@@ -94,6 +100,11 @@ SoilIndex >> close [
 { #category : #'as yet unclassified' }
 SoilIndex >> decreaseSize [
 	self headerPage decreaseSize 
+]
+
+{ #category : #accessing }
+SoilIndex >> dirtyPages [
+	^ dirtyPages
 ]
 
 { #category : #enumerating }
@@ -245,6 +256,11 @@ SoilIndex >> pages [
 	^ self store pages
 ]
 
+{ #category : #'as yet unclassified' }
+SoilIndex >> persistentIndex [
+	^ self 
+]
+
 { #category : #'instance creation' }
 SoilIndex >> readPageClassFrom: aStream [
 	^ SoilIndexPage readPageClassFrom: aStream
@@ -256,6 +272,21 @@ SoilIndex >> readPageFrom: aStream [
 	page := (self readPageClassFrom: aStream) basicNew.
 	page initializeInIndex: self. 
 	^ page readFrom: aStream 
+]
+
+{ #category : #removing }
+SoilIndex >> recyclePage: aPage [
+	"the header stays untouched even it it gets empty"
+	aPage isHeaderPage ifTrue: [ ^ aPage ].
+	"remove page from chain of item pages"
+	self removePage: aPage. 
+	"add page to free list chain"
+	^ self addToFreePages: aPage
+]
+
+{ #category : #removing }
+SoilIndex >> removeDirtyPage: aPage [ 
+	dirtyPages remove: aPage
 ]
 
 { #category : #removing }
@@ -276,6 +307,11 @@ SoilIndex >> removeKey: key ifAbsent: aBlock [
 			self decreaseSize.
 			(page itemRemoveIndex: index) value ]
 		ifFalse: [ aBlock value ]
+]
+
+{ #category : #removing }
+SoilIndex >> removePage: aPage [ 
+	^ self subclassResponsibility
 ]
 
 { #category : #public }

--- a/src/Soil-Core/SoilIndexPage.class.st
+++ b/src/Soil-Core/SoilIndexPage.class.st
@@ -51,6 +51,11 @@ SoilIndexPage class >> readPageCodeFrom: aStream [
 	
 ]
 
+{ #category : #testing }
+SoilIndexPage >> hasRoom [
+	^ self subclassResponsibility
+]
+
 { #category : #utilities }
 SoilIndexPage >> headerSize [ 
 	^ 2 "pageCode, version" 
@@ -60,6 +65,11 @@ SoilIndexPage >> headerSize [
 SoilIndexPage >> initialize [ 
 	super initialize.
 	version := self latestVersion
+]
+
+{ #category : #testing }
+SoilIndexPage >> isDirty [
+	^ self subclassResponsibility
 ]
 
 { #category : #testing }
@@ -92,6 +102,11 @@ SoilIndexPage >> latestVersion [
 { #category : #accessing }
 SoilIndexPage >> markForWrite [
 	needWrite := true 
+]
+
+{ #category : #testing }
+SoilIndexPage >> needsCleanup [
+	^ self subclassResponsibility
 ]
 
 { #category : #testing }

--- a/src/Soil-Core/SoilPagedIndexStore.class.st
+++ b/src/Soil-Core/SoilPagedIndexStore.class.st
@@ -15,7 +15,7 @@ SoilPagedIndexStore class >> isAbstract [
 	^ self == SoilPagedIndexStore
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 SoilPagedIndexStore >> allocatePage [
 	^ index allocatePage 
 ]

--- a/src/Soil-Core/SoilSkipList.class.st
+++ b/src/Soil-Core/SoilSkipList.class.st
@@ -14,7 +14,7 @@ SoilSkipList >> acceptSoil: aSoilVisitor [
 	^ aSoilVisitor visitSkipList: self
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'instance creation' }
 SoilSkipList >> allocatePage [
 	^ self newPage 
 		offset: (self nextFreePage 
@@ -149,11 +149,6 @@ SoilSkipList >> path [
 SoilSkipList >> path: aStringOrFileReference [
 
 	path := aStringOrFileReference asFileReference 
-]
-
-{ #category : #'as yet unclassified' }
-SoilSkipList >> persistentIndex [
-	^ self 
 ]
 
 { #category : #initialization }

--- a/src/Soil-Core/SoilSkipListHeaderPage.class.st
+++ b/src/Soil-Core/SoilSkipListHeaderPage.class.st
@@ -77,11 +77,6 @@ SoilSkipListHeaderPage >> initialize [
 	size := 0
 ]
 
-{ #category : #initialization }
-SoilSkipListHeaderPage >> initializeInIndex: aSoilSkipList [ 
-	
-]
-
 { #category : #testing }
 SoilSkipListHeaderPage >> isHeaderPage [
 	^ true

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -49,6 +49,10 @@ SoilSkipListPage >> initialize [
 ]
 
 { #category : #initialization }
+SoilSkipListPage >> initializeInIndex: aSoilSkipList [
+]
+
+{ #category : #initialization }
 SoilSkipListPage >> initializeLevel: maxLevel [
 	| promote level |
 	level := 1. 


### PR DESCRIPTION
Cleanup after page recycling was added to BTree (move methods / ivars up in hierachy, categorize...)