### PR TITLE
Guard SoilPagedIndexStore>>#pageAt:put:  against overrides

### DIFF
--- a/src/Soil-Core/SoilPagedIndexStore.class.st
+++ b/src/Soil-Core/SoilPagedIndexStore.class.st
@@ -107,10 +107,12 @@ SoilPagedIndexStore >> pageAt: anInteger [
 
 { #category : #accessing }
 SoilPagedIndexStore >> pageAt: anInteger put: aPage [ 
+	
 	^ pagesMutex critical: [  
 		pages 
 			at: anInteger 
-			put: aPage ]
+			ifPresent: [ self error: 'Page already there, should not happen!' ]
+			ifAbsentPut: aPage ] 
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Make sure to never just override an exisiting page in the store.

We change SoilPagedIndexStore>>#pageAt:put: to use #at:ifPresent:ifAbsentPut: to raise an error in this case