### PR TITLE
 864-finish-page-recycling-BTree-tests-and-allocatePage

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -267,6 +267,103 @@ SoilBTreeTest >> testFirst [
 ]
 
 { #category : #tests }
+SoilBTreeTest >> testFreePageAdd [
+	| iterator |
+	iterator := index newIterator.
+	1 to: 2500 do: [ :n | 
+		iterator at: n  put: (n asByteArrayOfSize: 8) ].
+	self assert: index headerPage lastPageOffset equals: 20.
+	self assert: index headerPage firstFreePageIndex equals: 0.
+	500 to: 1500 do: [ : n |
+		iterator removeKey: n ].
+	self assert: index headerPage lastPageOffset equals: 20.
+	self assert: index headerPage firstFreePageIndex equals: 0.
+	index cleanUpToVersion: nil.
+	self assert: index headerPage lastPageOffset equals: 20.
+	"the first page that gets empty is reused as free list page"
+	self assert: index headerPage firstFreePageIndex equals: 6.
+	"subsequent removed pages are added to the first page"
+	self assertCollection: (index store pageAt: 6) pageIndexes hasSameElements: #( 7 8 9 10 11 12).
+]
+
+{ #category : #tests }
+SoilBTreeTest >> testFreePageAddNested [
+	| iterator nestedFreeIndexes |
+	index
+		maxLevel: 8; 
+		valueSize: 512.
+	iterator := index newIterator.
+	"create enough pages to test"
+	1 to: 9000 do: [ :n | 
+		iterator at: n  put: (n asByteArrayOfSize: 8) ].
+	self assert: index headerPage lastPageOffset equals: 3017.
+	self assert: index headerPage firstFreePageIndex equals: 0.
+	"now we free more pages than a free page list has capacity"
+	10 to: 8990 do: [ : n |
+		iterator removeKey: n ].
+	index cleanUpToVersion: nil.
+	self assert: index headerPage firstFreePageIndex equals: 5.
+	self assert: (index store pageAt: 5) pageIndexes size equals: 1018.
+	"as there were more than free list capacity there is a next free
+	list page"
+	self assert: (index store pageAt: 5) next equals: 1030.
+	nestedFreeIndexes := ((index store pageAt: 1030) pageIndexes copy) copyWith: 1030.
+	"we fill the index with enough elements to use all free pages including the nested 
+	ones"
+	1 to: 15*1018 do: [ :n | 
+		iterator at: n  put: (n asByteArrayOfSize: 8) ].
+	"there should be no more free page"
+	self assert: index headerPage firstFreePageIndex equals: 0.
+	"and all pageIndexes of the next free page should be included"
+	self assert: ((index store pages collect: #offset) includesAll: nestedFreeIndexes)
+]
+
+{ #category : #tests }
+SoilBTreeTest >> testFreePageReuse [
+	| iterator |
+	iterator := index newIterator.
+	1 to: 2500 do: [ :n | 
+		iterator at: n  put: (n asByteArrayOfSize: 8) ].
+	self assert: index headerPage lastPageOffset equals: 20.
+	self assert: index headerPage firstFreePageIndex equals: 0.
+	500 to: 1500 do: [ : n |
+		iterator removeKey: n ].
+	index cleanUpToVersion: nil.
+	self assert: index headerPage lastPageOffset equals: 20.
+	2501 to: 2750+250 do: [ :n | 
+		iterator at: n  put: (n asByteArrayOfSize: 8) ].
+	index cleanUpToVersion: nil.
+	"first free page is #6 with content #( 9 10 11 12 ). Adding 500 entries should remove 
+	two pages for reuse"
+	self assertCollection: (index store pageAt: 6) pageIndexes hasSameElements: #( 11 12 ).
+]
+
+{ #category : #tests }
+SoilBTreeTest >> testFreePageReuseAtEndAppend [
+	| iterator |
+	iterator := index newIterator.
+	1 to: 2500 do: [ :n | 
+		iterator at: n  put: (n asByteArrayOfSize: 8) ].
+	self assert: index headerPage lastPageOffset equals: 20.
+	self assert: index headerPage firstFreePageIndex equals: 0.
+	500 to: 1500 do: [ : n |
+		iterator removeKey: n ].
+	index cleanUpToVersion: nil.
+	self assert: index headerPage lastPageOffset equals: 20.
+	self assertCollection: (index store pageAt: 6) pageIndexes hasSameElements: #( 7 8 9 10 11 12).
+	iterator := index newIterator.
+	2501 to: 3500 do: [ :n | 
+		iterator at: n  put: (n asByteArrayOfSize: 8) ].
+	index cleanUpToVersion: nil.
+	"readding the same amount of entries but at the end should reuse all 
+	free pages making first free 0."
+	self assert: index headerPage firstFreePageIndex  equals: 0.
+	"as the new entries did not fit exactly we have one more page at the 
+	end which should have update the header page"
+	self assert: index headerPage lastPageOffset equals: 21.
+]
+
+{ #category : #tests }
 SoilBTreeTest >> testIndexRewriting [
 	
 	| capacity fileSizeBefore |
@@ -355,7 +452,7 @@ SoilBTreeTest >> testOverflowCopyOnWriteSplitting [
 	capacity := copyOnWrite headerPage itemCapacity.
 	1 to: capacity * 2 by: 2 do: [ :n | 
 		copyOnWrite at: n  put: (n asByteArrayOfSize: 8) ].
-	self assert: copyOnWrite pages size equals: 3.
+	self assert: copyOnWrite pages size equals: 2.
 
 	page := copyOnWrite pageAt: 3.
 	self assert: page numberOfItems equals: 127.

--- a/src/Soil-Core/SoilAbstractBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilAbstractBTreeDataPage.class.st
@@ -30,8 +30,8 @@ SoilAbstractBTreeDataPage >> find: aKey with: aBTree [
 { #category : #private }
 SoilAbstractBTreeDataPage >> findPreviousPage: aKey with: aBTree path: aPath [
 	| pageToCheck |
-	pageToCheck := aPath reverse detect: [:each | (each itemBefore: aKey) isNotNil].
-	pageToCheck := aBTree pageAt: (pageToCheck itemBefore: aKey) value.
+	pageToCheck := aPath reverse detect: [:each | (each findItemBefore: aKey) isNotNil].
+	pageToCheck := aBTree pageAt: (pageToCheck findItemBefore: aKey) value.
 	"if we get an index page, follow the last till reaching the data page"
 	[pageToCheck isIndexPage ] whileTrue: [ pageToCheck := aBTree pageAt: pageToCheck lastItem value].
 	^ pageToCheck 

--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -41,6 +41,16 @@ SoilBTreePage >> find: aKey with: aBTree [
 ]
 
 { #category : #private }
+SoilBTreePage >> findItemBefore: aKey [
+	"like #itemBefore:, but comparung #<= like #find:with:"
+	| item |
+	item := items
+	 		reversed detect: [ :each |
+	 			each key <= aKey].
+	^ items before: item ifAbsent: nil
+]
+
+{ #category : #private }
 SoilBTreePage >> findPreviousPage: aKey with: aBTree path: aPath [ 
 	^ self subclassResponsibility
 ]

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -17,17 +17,15 @@ SoilBasicBTree class >> isAbstract [
 	^ self == SoilBasicBTree
 ]
 
-{ #category : #adding }
-SoilBasicBTree >> addDirtyPage: aPage [ 
-	dirtyPages add: aPage
-]
-
 { #category : #'instance creation' }
 SoilBasicBTree >> allocatePage [
-	^ self newPage 
-		offset: (self nextFreePage 
-			ifNotNil: [ :freePage | freePage offset ]
-			ifNil: [ store nextPageOffset ])
+	| page |
+	page := self newPage 
+		offset: (self nextFreePageIndex
+			ifNil: [ self nextPageOffset ]).
+	self store pageAt: page offset put: page.
+	self addDirtyPage: page.
+	^ page
 ]
 
 { #category : #converting }
@@ -60,7 +58,7 @@ SoilBasicBTree >> indexPages [
 { #category : #initialization }
 SoilBasicBTree >> initialize [ 
 	super initialize.
-	dirtyPages := Set new
+	dirtyPages := OrderedDictionary new
 ]
 
 { #category : #initialization }
@@ -143,6 +141,37 @@ SoilBasicBTree >> nextFreePage [
 			firstPage ]
 ]
 
+{ #category : #private }
+SoilBasicBTree >> nextFreePageIndex [
+	| firstFreePage freePageIndex |
+	firstFreePage := self firstFreePage ifNil: [ 
+		^ nil ].
+	^ firstFreePage hasFreePages 
+		ifTrue: [ 
+			freePageIndex := firstFreePage removeFirstIndex.
+			self removePageWithIndexIfPresent: freePageIndex.
+			self addDirtyPage: firstFreePage.
+			freePageIndex  ] 
+		ifFalse: [ 
+			"if firstFreePage has a next pointer we set that as 
+ 			new first free page. Next will return 0 if there is no
+ 			next page"
+			freePageIndex := firstFreePage next.
+			self headerPage firstFreePageIndex: firstFreePage next.
+			self removePageWithIndexIfPresent: firstFreePage offset.
+
+			self addDirtyPage: self headerPage.
+			firstFreePage offset ]
+]
+
+{ #category : #accessing }
+SoilBasicBTree >> nextPageOffset [
+	| offset |
+	offset := store nextPageOffset.
+	self addDirtyPage: store headerPage.
+	^ offset 
+]
+
 { #category : #'open/close' }
 SoilBasicBTree >> open [
  	self isOpen ifTrue: [ self error: 'Index already open' ].
@@ -152,11 +181,6 @@ SoilBasicBTree >> open [
 { #category : #initialization }
 SoilBasicBTree >> pageClass [
 	^ SoilBTreeDataPage
-]
-
-{ #category : #removing }
-SoilBasicBTree >> removeDirtyPage: aPage [ 
-	dirtyPages remove: aPage
 ]
 
 { #category : #removing }
@@ -187,6 +211,12 @@ SoilBasicBTree >> removePage: aPage [
 
 ]
 
+{ #category : #removing }
+SoilBasicBTree >> removePageWithIndexIfPresent: anInteger [ 
+	(store includesPageAt: anInteger) ifTrue: [ 
+		store removePageAt: anInteger ]
+]
+
 { #category : #accessing }
 SoilBasicBTree >> rootPage [
 	^ self store pageAt: 2
@@ -211,7 +241,6 @@ SoilBasicBTree >> splitPage: page [
 	newPage := page split: store allocatePage.
 	newPage next: page next.
 	page next: newPage offset.
-	self store pageAt: newPage offset put: newPage.
 	^ newPage 
 ]
 

--- a/src/Soil-Core/SoilBasicSkipList.class.st
+++ b/src/Soil-Core/SoilBasicSkipList.class.st
@@ -17,13 +17,6 @@ SoilBasicSkipList class >> isAbstract [
 	^ self == SoilBasicSkipList
 ]
 
-{ #category : #adding }
-SoilBasicSkipList >> addDirtyPage: aPage [ 
-	dirtyPages 
-		at: aPage offset 
-		ifAbsentPut: [ aPage ]
-]
-
 { #category : #'instance creation' }
 SoilBasicSkipList >> allocatePage [
 	| page |
@@ -33,15 +26,6 @@ SoilBasicSkipList >> allocatePage [
 	self store pageAt: page offset put: page.
 	self addDirtyPage: page.
 	^ page
-]
-
-{ #category : #'as yet unclassified' }
-SoilBasicSkipList >> cleanUpToVersion: aNumberOrNil [ 
-		SoilIndexCleaner new 
-			index: self;
-			readVersion: aNumberOrNil;
-			clean.
-
 ]
 
 { #category : #testing }

--- a/src/Soil-Core/SoilIndex.class.st
+++ b/src/Soil-Core/SoilIndex.class.st
@@ -24,7 +24,9 @@ Class {
 
 { #category : #adding }
 SoilIndex >> addDirtyPage: aPage [ 
-	
+	dirtyPages 
+		at: aPage offset 
+		ifAbsentPut: [ aPage ]
 ]
 
 { #category : #adding }
@@ -92,10 +94,10 @@ SoilIndex >> basicAt: key put: anObject [
 ]
 
 { #category : #'as yet unclassified' }
-SoilIndex >> cleanUpToVersion: version [
-	SoilIndexCleaner new 
+SoilIndex >> cleanUpToVersion: aNumberOrNil [ 
+		SoilIndexCleaner new 
 			index: self;
-			readVersion: version;
+			readVersion: aNumberOrNil;
 			clean.
 ]
 


### PR DESCRIPTION
this implements  #863  for the BTree: add tests and fix new page page allocation, 

The PR does not change aything outside of the BTree, the changes for SkipList are just moving two methods up in the hierarchy: #addDirtyPage: and #cleanUpToVersion: 

fixes #864