### PR TITLE
Index: refactor #cleanRemoved to pass the index

### DIFF
--- a/src/Soil-Core/SoilBTreeHeaderPage.class.st
+++ b/src/Soil-Core/SoilBTreeHeaderPage.class.st
@@ -21,6 +21,11 @@ SoilBTreeHeaderPage class >> pageCode [
 	^ 3
 ]
 
+{ #category : #testing }
+SoilBTreeHeaderPage >> canBeRemoved [ 
+	^ false
+]
+
 { #category : #utilities }
 SoilBTreeHeaderPage >> decreaseSize [
  	size := size - 1.

--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -35,6 +35,13 @@ SoilBTreePage >> bTreeAssertion [
 	items isEmpty ifFalse: [ self assert:  self hasUnderflow not  ]
 ]
 
+{ #category : #removing }
+SoilBTreePage >> cleanRemovedIn: index [
+	(items select: [ :each | each value isRemoved ])
+		do: [:removedItem | self remove: removedItem key for: index].
+	needWrite := true
+]
+
 { #category : #private }
 SoilBTreePage >> find: aKey with: aBTree [ 
 	^ self subclassResponsibility

--- a/src/Soil-Core/SoilBTreeRootPage.class.st
+++ b/src/Soil-Core/SoilBTreeRootPage.class.st
@@ -20,7 +20,7 @@ SoilBTreeRootPage >> initialize [
 	self addItem: 0 -> 1 "headPage id"
 ]
 
-{ #category : #searching }
+{ #category : #adding }
 SoilBTreeRootPage >> insertItem: item for: iterator [
 	| foundItem return newIndexPage1 newIndexPage2 |
 	

--- a/src/Soil-Core/SoilIndex.class.st
+++ b/src/Soil-Core/SoilIndex.class.st
@@ -93,6 +93,11 @@ SoilIndex >> basicAt: key put: anObject [
 		put: anObject 
 ]
 
+{ #category : #removing }
+SoilIndex >> cleanRemoved: aPage [
+	aPage cleanRemovedIn: self
+]
+
 { #category : #'as yet unclassified' }
 SoilIndex >> cleanUpToVersion: aNumberOrNil [ 
 		SoilIndexCleaner new 

--- a/src/Soil-Core/SoilIndexCleaner.class.st
+++ b/src/Soil-Core/SoilIndexCleaner.class.st
@@ -44,8 +44,9 @@ SoilIndexCleaner >> cleanPage: page [
 				addDirtyPage: (index recyclePage: page) ]
 		ifFalse: [ 
 			"just clean the page"
-			page cleanRemoved.
-			index addDirtyPage: page ]
+			index 
+				cleanRemoved: page;
+				addDirtyPage: page ]
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilIndexItemsPage.class.st
+++ b/src/Soil-Core/SoilIndexItemsPage.class.st
@@ -55,10 +55,9 @@ SoilIndexItemsPage >> canBeRemoved [
 	^ self presentItemCount isZero
 ]
 
-{ #category : #running }
-SoilIndexItemsPage >> cleanRemoved [
-	items removeAllSuchThat: [ :each | each value isRemoved ].
-	needWrite := true
+{ #category : #removing }
+SoilIndexItemsPage >> cleanRemovedIn: index [
+	self subclassResponsibility
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -40,6 +40,18 @@ SoilSkipListPage >> biggestKey [
 		ifFalse: [ self lastKey ]
 ]
 
+{ #category : #removing }
+SoilSkipListPage >> cleanRemoved [
+	items removeAllSuchThat: [ :each | each value isRemoved ].
+	needWrite := true
+]
+
+{ #category : #removing }
+SoilSkipListPage >> cleanRemovedIn: index [
+	"index not needed for the SkipList"
+	self cleanRemoved
+]
+
 { #category : #initialization }
 SoilSkipListPage >> initialize [ 
 	super initialize.


### PR DESCRIPTION
Refactor #cleanRemoved. For the BTree, we can not just remove the entries from the page as we have to update the index page. The Btree pages already implement remove:for:, this PR uses it to clean the removed entries


- implement #canBeRemoved for the Btree header page to return false