### PR TITLE
#compact for Btree: push up to SoilIndex

### DIFF
--- a/src/Soil-Core/SoilBTree.class.st
+++ b/src/Soil-Core/SoilBTree.class.st
@@ -37,12 +37,6 @@ SoilBTree >> keySize: anInteger [
 	keySize := anInteger
 ]
 
-{ #category : #reindexing }
-SoilBTree >> newPluggableRewriter [
-	^ SoilPluggableIndexRewriter new 
-		index: self
-]
-
 { #category : #accessing }
 SoilBTree >> path [
 

--- a/src/Soil-Core/SoilIndex.class.st
+++ b/src/Soil-Core/SoilIndex.class.st
@@ -107,6 +107,12 @@ SoilIndex >> close [
 	store := nil
 ]
 
+{ #category : #private }
+SoilIndex >> compact [ 
+	"Rewrite index file without removed items"
+	self rewriteUsing: [ :item | item ]
+]
+
 { #category : #utilities }
 SoilIndex >> decreaseSize [
 	self headerPage decreaseSize.
@@ -263,6 +269,12 @@ SoilIndex >> newPage [
 	^ self subclassResponsibility
 ]
 
+{ #category : #reindexing }
+SoilIndex >> newPluggableRewriter [
+	^ SoilPluggableIndexRewriter new 
+		index: self
+]
+
 { #category : #accessing }
 SoilIndex >> pageAt: anInteger [ 
 	^ self store pageAt: anInteger 
@@ -346,6 +358,17 @@ SoilIndex >> reopen [
 { #category : #enumerating }
 SoilIndex >> reverseDo: aBlock [
 	self newIterator reverseDo: aBlock
+]
+
+{ #category : #initialization }
+SoilIndex >> rewriteUsing: aBlock [
+	"write new index file and add all items. Use aBlock to 
+	enable converting items"
+	self newPluggableRewriter
+		indexBlock: [ :idx | idx  ];
+		itemBlock: aBlock;
+		cleanRemoved;
+		run
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -72,6 +72,11 @@ SoilIndexedDictionary >> basicAt: aString ifAbsent: aBlock [
 	^ self newIterator at: aString ifAbsent: aBlock
 ]
 
+{ #category : #rewriting }
+SoilIndexedDictionary >> compact [ 
+	index wrapped compact
+]
+
 { #category : #initialization }
 SoilIndexedDictionary >> createIndex [
 	^ self subclassResponsibility
@@ -250,6 +255,11 @@ SoilIndexedDictionary >> removeKey: key ifAbsent: aBlock [
 SoilIndexedDictionary >> reverseDo: aBlock [
  	self newIterator reverseDo: [ :objectId | 
  				aBlock value: objectId ]
+]
+
+{ #category : #rewriting }
+SoilIndexedDictionary >> rewriteUsing: aBlock [
+	index wrapped rewriteUsing: aBlock
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilSkipList.class.st
+++ b/src/Soil-Core/SoilSkipList.class.st
@@ -27,12 +27,6 @@ SoilSkipList >> close [
 	keySize := nil
 ]
 
-{ #category : #private }
-SoilSkipList >> compact [ 
-	"Rewrite index file without removed items"
-	self rewriteUsing: [ :item | item ]
-]
-
 { #category : #deleting }
 SoilSkipList >> destroy [
 	path ensureDelete 
@@ -92,12 +86,6 @@ SoilSkipList >> newHeaderPage [
 		pageSize: self pageSize
 ]
 
-{ #category : #reindexing }
-SoilSkipList >> newPluggableRewriter [
-	^ SoilPluggableIndexRewriter new 
-		index: self
-]
-
 { #category : #'opening/closing' }
 SoilSkipList >> open [
 	self isOpen ifTrue: [ self error: 'Index already open' ].
@@ -114,18 +102,6 @@ SoilSkipList >> path [
 SoilSkipList >> path: aStringOrFileReference [
 
 	path := aStringOrFileReference asFileReference 
-]
-
-{ #category : #initialization }
-SoilSkipList >> rewriteUsing: aBlock [
-	"write new index file and add all items. Use aBlock to 
-	enable converting items"
-	SoilPluggableIndexRewriter new 
-		index: self;
-		indexBlock: [ :idx | idx  ];
-		itemBlock: aBlock;
-		cleanRemoved;
-		run
 ]
 
 { #category : #converting }

--- a/src/Soil-Core/SoilSkipListDictionary.class.st
+++ b/src/Soil-Core/SoilSkipListDictionary.class.st
@@ -10,20 +10,10 @@ Class {
 	#category : #'Soil-Core-Index-SkipList'
 }
 
-{ #category : #rewriting }
-SoilSkipListDictionary >> compact [ 
-	index wrapped compact
-]
-
 { #category : #initialization }
 SoilSkipListDictionary >> createIndex [ 
 	^ SoilSkipList new
 		initializeHeaderPage;
 		valueSize: 8;
 		yourself
-]
-
-{ #category : #rewriting }
-SoilSkipListDictionary >> rewriteUsing: aBlock [
-	index wrapped rewriteUsing: aBlock
 ]


### PR DESCRIPTION
To unify SkipList and BTree dictionary further, this PR pushes #rewriteUsing: and #compact up from SkipListDictionary to SoilIndex.

In addition, it pushed #newPluggableRewriter up to the SoilIndex and uses it in #rewriteUsing:

In another step we should think if we still need this api as we have now a dedicated  #rewrite and #cleanRemoved on the rewriter.