### PR TITLE
Change the internal collection of a page from SortedCollection to Ord…

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreePageTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreePageTest.class.st
@@ -9,6 +9,7 @@ SoilBTreePageTest >> readPageFrom: aStream [
 	| page |
 	page := (SoilIndexPage readPageClassFrom: aStream) new.
 	page 
+		pageSize: 4096;
 		keySize: 8;
 		valueSize: 8.
 	^ page readFrom: aStream

--- a/src/Soil-Core-Tests/SoilSkipListPageTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListPageTest.class.st
@@ -9,6 +9,7 @@ SoilSkipListPageTest >> readPageFrom: aStream [
 	| page |
 	page := (SoilIndexPage readPageClassFrom: aStream) new.
 	page 
+		pageSize: 4096;
 		keySize: 8;
 		valueSize: 8.
 	^ page readFrom: aStream

--- a/src/Soil-Core/SoilIndex.class.st
+++ b/src/Soil-Core/SoilIndex.class.st
@@ -309,7 +309,9 @@ SoilIndex >> readPageClassFrom: aStream [
 SoilIndex >> readPageFrom: aStream [
 	| page |
 	page := (self readPageClassFrom: aStream) basicNew.
-	page initializeInIndex: self. 
+	page 
+		pageSize: self pageSize;
+		initializeInIndex: self. 
 	^ page readFrom: aStream 
 ]
 

--- a/src/Soil-Core/SoilIndexItemsPage.class.st
+++ b/src/Soil-Core/SoilIndexItemsPage.class.st
@@ -262,6 +262,16 @@ SoilIndexItemsPage >> presentItemCount [
 	^ (items reject: [ :each | each value isRemoved ]) size 
 ]
 
+{ #category : #testing }
+SoilIndexItemsPage >> rawCapacity [
+	| headerSize itemSize |
+	"Calculate the raw capacity for an empty page so we can figure
+	out how man items could be stored"
+	itemSize := self keySize + self valueSize.
+	headerSize := self headerSize + 2 "items size".
+	^ ((self pageSize - headerSize) / itemSize) floor 
+]
+
 { #category : #reading }
 SoilIndexItemsPage >> readItemsFrom: aStream [ 
 	| numberOfItems |

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -28,9 +28,32 @@ SoilSkipListPage class >> isAbstract [
 
 { #category : #adding }
 SoilSkipListPage >> addItem: anAssociation [
-	"Note: this can only be called for new items, client has to check first and update if an entry for the key is already there, different to SoilBTreePage>>#addItem:"
-	items add: anAssociation.
-	needWrite := true
+
+	needWrite := true.
+
+	items 
+		findBinaryIndex: [ :each |  anAssociation key - each key ] 
+		do: [:index | | removedItem |
+			"replace the found index with the new value and return 
+			the removed value"
+			removedItem := items at: index.
+			items at: index put: anAssociation.
+			^ removedItem ]
+		ifNone: [ :lower :upper |
+			"upper will be an index bigger than collection size if 
+			the element needs to be appended"
+			(upper > items size) ifTrue: [
+				items addLast: anAssociation.
+				^ nil ].
+			"if lower is greater than zero than lower and upper are 
+			valid indexes where we need to insert in between"
+			(lower > 0) ifTrue: [ 
+				items add: anAssociation afterIndex: lower.
+				^ nil ].
+			"lower will be zero if the element needs to be added to 
+			the front of the page"
+			items addFirst: anAssociation.
+			^ nil ]
 ]
 
 { #category : #accessing }
@@ -57,6 +80,10 @@ SoilSkipListPage >> initialize [
 	super initialize.
 	lastTransaction := 0.
 	needWrite := true.
+	self flag: #hack.
+	"this is a newly initialization for the skip list as long as the
+	BTree code has not been adjusted"
+	items := OrderedCollection new
 
 ]
 
@@ -81,6 +108,19 @@ SoilSkipListPage >> isLastPage [
 ]
 
 { #category : #accessing }
+SoilSkipListPage >> itemAt: key put: anObject [ 
+	self flag: #todo.
+	"this needs to be improved. For itemAt:put: we search twice for the index. This 
+	is to keep the assumption about replacing items. The way this is enforced might 
+	be a strategy object instead soonish"
+	items 
+		findBinaryIndex: [ :each |  key - each key ] 
+		do: [:ind | ind ]
+		ifNone: [ KeyNotFound signal: 'this method is just for replacing items' ].
+	^ self addItem: key -> anObject 
+]
+
+{ #category : #accessing }
 SoilSkipListPage >> level [ 
 	^ right size
 ]
@@ -100,6 +140,18 @@ SoilSkipListPage >> postCopy [
 SoilSkipListPage >> readFrom: aStream [ 
 	super readFrom: aStream.
 	self readLastTransactionFrom: aStream
+]
+
+{ #category : #reading }
+SoilSkipListPage >> readItemsFrom: aStream [ 
+	| numberOfItems |
+	"calculate the maximum number of items that can be stored in this
+	page so we spend that amount removing the need for the collection 
+	to grow"
+	items := OrderedCollection new: self rawCapacity.
+	numberOfItems := (aStream next: self itemsSizeSize) asInteger.
+	numberOfItems timesRepeat: [ 
+		items add: ((aStream next: self keySize) asInteger -> (aStream next: self valueSize) ) ]
 ]
 
 { #category : #reading }


### PR DESCRIPTION
…eredCollection:

Instead of  just adding elements and letting the SortedCollection sort elements we add manually the elements at the right position so the collection stays sorted. Reading elements from disk or writing does it in order so the semantics do not change. Searching stays the same as the binary search works also on OrderedCollection