### PR TITLE
introduced basicAt:version: that can be used to do a raw read on the …

### DIFF
--- a/src/Soil-Core/SoilObjectRepository.class.st
+++ b/src/Soil-Core/SoilObjectRepository.class.st
@@ -72,14 +72,6 @@ SoilObjectRepository >> at: objectid version: version [
 ]
 
 { #category : #accessing }
-SoilObjectRepository >> basicAt: objectid version: version [ 
-	| segment |
-	segment := self segmentAt: objectid segment.
-	^ (segment basicAt: objectid index version: version)
-		ifNotNil: [ :record | record objectId: objectid ]
-]
-
-{ #category : #accessing }
 SoilObjectRepository >> cacheSegmentAt: index upTo: limit [ 
 	(index = 0) 
 		ifTrue: [ metaSegment := metaSegment asCachedSegment weight: limit ]

--- a/src/Soil-Core/SoilVisitor.class.st
+++ b/src/Soil-Core/SoilVisitor.class.st
@@ -39,11 +39,12 @@ SoilVisitor >> initialize [
 
 { #category : #api }
 SoilVisitor >> processLoop [ 
-	| objectId |
+	| objectId record |
 	[ toBeProcessed isEmpty ] whileFalse: [  
 		objectId := toBeProcessed  removeFirst.
-		self visit: (soil objectRepository 
-			basicAt: objectId version: self databaseVersion ) ]
+		record := (soil objectRepository segmentAt: objectId segment) 
+			basicAt: objectId index version: self databaseVersion.
+		self visit: (record objectId: objectId) ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
…segment. This is useful for e.g. the backup visitor in a cached segment database so that the backup does not fill the cache for no reason