### PR TITLE
Cleanup: SoilSkipListDictionary>>#soilBasicSerialize: not needed

### DIFF
--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -234,8 +234,7 @@ SoilIndexedDictionary >> soilBasicSerialize: aSerializer [
 	transaction ifNil: [ 
 		transaction := aSerializer transaction ].
 	super soilBasicSerialize: aSerializer.
-	aSerializer registerIndexId: id.
-
+	aSerializer registerIndexId: id
 ]
 
 { #category : #serializing }

--- a/src/Soil-Core/SoilSkipListDictionary.class.st
+++ b/src/Soil-Core/SoilSkipListDictionary.class.st
@@ -17,9 +17,3 @@ SoilSkipListDictionary >> createIndex [
 		valueSize: 8;
 		yourself
 ]
-
-{ #category : #serializing }
-SoilSkipListDictionary >> soilBasicSerialize: aSerializer [ 
-	super soilBasicSerialize: aSerializer.
-	aSerializer registerIndexId: id.
-]


### PR DESCRIPTION
SoilSkipListDictionary>>#soilBasicSerialize: just adds a #registerIndexId: after calling the super method. But

SoilIndexedDictionary>>soilBasicSerialize: already does it:

```
soilBasicSerialize: aSerializer 
	transaction ifNil: [ 
		transaction := aSerializer transaction ].
	super soilBasicSerialize: aSerializer.
	aSerializer registerIndexId: id
```