### PR TITLE
Fix testSerializationByteLayout for Pharo14

### DIFF
--- a/src/Soil-Serializer-Tests/SoilStandaloneSerializationTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilStandaloneSerializationTest.class.st
@@ -21,7 +21,7 @@ SoilStandaloneSerializationTest >> setUp [
 SoilStandaloneSerializationTest >> testSerializationByteLayout [
 	| object serialized materialized |
 	"We use SocketAddress as an exampe of a class with a ByteLayout but not specially encoded"
-	object := #[127 0 0 1] asSocketAddress.
+	object := SocketAddress fromDottedString: '127.0.0.1'.
 	
 	self assert: object class classLayout class equals: ByteLayout.
 	serialized := object soilSerialize.


### PR DESCRIPTION
I opended an issue tracker entry for the missing dreprecation.

Here is a fix that uses the SocketAddress class side method instead (which is a bit nicer as it uses a norml IP number string anyway).

fixes #933