### PR TITLE
SoilIndexedDictionary with backend instead of subclasses

### DIFF
--- a/src/Soil-Core-Tests/SoilBackupTest.class.st
+++ b/src/Soil-Core-Tests/SoilBackupTest.class.st
@@ -162,7 +162,7 @@ SoilBackupTest >> testBackupOldVersion [
 { #category : #tests }
 SoilBackupTest >> testBackupTheBackup [
 	| tx visitor dict secondBackup txn |
-	dict := SoilSkipListDictionary  new
+	dict := (SoilIndexedDictionary newWithBackend: SoilSkipList)
 		keySize: 10;
 		maxLevel: 8;
 		yourself.
@@ -197,7 +197,7 @@ SoilBackupTest >> testBackupWithIndex [
 	| tx backup tx2 dict object |
 	tx := soil newTransaction.
 	
-	dict := SoilSkipListDictionary new 
+	dict := (SoilIndexedDictionary newWithBackend: SoilSkipList) 
 		keySize: 8;
 		maxLevel: 16.
 	tx root: dict.
@@ -221,7 +221,7 @@ SoilBackupTest >> testBackupWithIndexRemoval [
 	"removed keys in indexes get objectId 0:0. On backup time we only
 	need to copy the non-removed"
 	tx := soil newTransaction.
-	dict := SoilSkipListDictionary new 
+	dict := (SoilIndexedDictionary newWithBackend: SoilSkipList)
 		keySize: 8;
 		maxLevel: 16.
 		tx root: dict.

--- a/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
+++ b/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
@@ -28,7 +28,7 @@ SoilDatabaseJournalTest >> fillDatabase [
 	tx root: SoilTestClusterRoot new.
 	tx commit.
 	tx := soil newTransaction.
-	dict := SoilSkipListDictionary new 
+	dict := (SoilIndexedDictionary newWithBackend: SoilSkipList) 
 		maxLevel: 8;
 		keySize: 10.
 	tx makeRoot: dict.

--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -4,29 +4,29 @@ Class {
 	#instVars : [
 		'soil',
 		'dict',
-		'classToTest'
+		'backend'
 	],
 	#category : #'Soil-Core-Tests-Index'
 }
 
-{ #category : #tests }
+{ #category : #'building suites' }
 SoilIndexedDictionaryTest class >> testParameters [
 	^ ParametrizedTestMatrix new
-		addCase: { #classToTest -> SoilSkipListDictionary };
-		addCase: { #classToTest -> SoilBTreeDictionary };
+		addCase: { #backend -> SoilSkipList };
+		addCase: { #backend -> SoilBTree };
 		yourself
 ]
 
 { #category : #accessing }
-SoilIndexedDictionaryTest >> classToTest [
+SoilIndexedDictionaryTest >> backend [
 
-	^ classToTest
+	^ backend
 ]
 
 { #category : #accessing }
-SoilIndexedDictionaryTest >> classToTest: anObject [
+SoilIndexedDictionaryTest >> backend: anObject [
 
-	classToTest := anObject
+	backend := anObject
 ]
 
 { #category : #accessing }
@@ -41,7 +41,7 @@ SoilIndexedDictionaryTest >> setUp [
 	soil 
 		destroy;
 		initializeFilesystem.
-	dict := classToTest new
+	dict := (SoilIndexedDictionary newWithBackend: backend)
 		keySize: 10;
 		maxLevel: 8; "ignored for BTree"
 		yourself
@@ -447,7 +447,7 @@ SoilIndexedDictionaryTest >> testFreePageAfterReopen [
 	tx4 root removeKey: 223.
 	tx4 commit.
 	tx5 := soil newTransaction.
-	(classToTest = SoilSkipListDictionary ) ifTrue: [ 
+	(backend = SoilSkipList ) ifTrue: [ 
 		self deny: (tx5 root index wrapped store headerPage right includes: 2) ].
 ]
 
@@ -519,7 +519,7 @@ SoilIndexedDictionaryTest >> testFreePages [
 	tx root: dict.
 	1 to: 1300 do: [ :n | dict at: n put: n asString ].
 	tx commit.
-	(classToTest = SoilBTreeDictionary) 
+	(backend = SoilBTree) 
 		ifTrue:  [ self assert: indexManager indexes anyOne pages size equals: 12]
 		ifFalse: [ self assert: indexManager indexes anyOne pages size equals: 6].
 		
@@ -529,7 +529,7 @@ SoilIndexedDictionaryTest >> testFreePages [
 	tx2 commit.
 	index := indexManager indexes anyOne.
 	self deny: index headerPage firstFreePageIndex isZero.
-	(classToTest = SoilBTreeDictionary) 
+	(backend = SoilBTree) 
 		ifTrue:  [ self assert: index firstFreePage pageIndexes size equals: 5 ]
 		ifFalse: [ self assert: index firstFreePage pageIndexes size equals: 1 ]
 ]
@@ -748,12 +748,12 @@ SoilIndexedDictionaryTest >> testRemovePagesConcurrent [
 	tx4 := soil newTransaction.
 	300 to: 500 do: [ :n | tx2 root removeKey: n ].
 	tx2 commit.
-	(classToTest = SoilBTreeDictionary) 
+	(backend = SoilBTree) 
 		ifTrue: [self assert: (index pages select: #needsCleanup) size equals: 3]
 		ifFalse: [self assert: (index pages select: #needsCleanup) size equals: 2].
 	501 to: 700 do: [ :n | tx3 root removeKey: n ].
 	tx3 commit.
-	(classToTest = SoilBTreeDictionary) 
+	(backend = SoilBTree) 
 		ifTrue: [self assert: (index pages select: #needsCleanup) size equals: 5]
 		ifFalse: [self assert: (index pages select: #needsCleanup) size equals: 3].
 	
@@ -778,7 +778,7 @@ SoilIndexedDictionaryTest >> testRemovePagesSequential [
 	"open a second transaction ..."
 	tx2 := soil newTransaction.
 	"we remove all keys from one page to make it empty"
-	(classToTest = SoilBTreeDictionary) 
+	(backend = SoilBTree) 
 		ifTrue: [339 to: 451 do: [ :n | tx2 root removeKey: n ]]
 		ifFalse: [ 300 to: 700 do: [ :n | tx2 root removeKey: n ]].
 	tx2 commit.
@@ -786,7 +786,7 @@ SoilIndexedDictionaryTest >> testRemovePagesSequential [
 	index := indexManager indexes anyOne.
 	self assert: index dirtyPages size equals: 0.
 	self assert: indexManager dirtyIndexes size equals: 0.
-	self assert: (index pages select: #needsWrite) size equals: (	(classToTest = SoilBTreeDictionary) ifTrue: [1] ifFalse: [0])
+	self assert: (index pages select: #needsWrite) size equals: ((backend = SoilBTree) ifTrue: [1] ifFalse: [0])
 	
 
 ]

--- a/src/Soil-Core-Tests/SoilTest.class.st
+++ b/src/Soil-Core-Tests/SoilTest.class.st
@@ -90,7 +90,7 @@ SoilTest >> testCheckpointEmptyRecordsToCommit [
 	tx root: root.
 	tx commitAndContinue.
 
-	skipList := SoilSkipListDictionary new keySize: 32; maxLevel: 8; yourself.
+	skipList := (SoilIndexedDictionary newWithBackend: SoilSkipList) keySize: 32; maxLevel: 8; yourself.
 	tx makeRoot: skipList.
 	tx root at: 123 put: skipList.
 
@@ -141,7 +141,7 @@ SoilTest >> testEnabledFsync [
 SoilTest >> testFindRecordWithIndex [ 
 	| tx skipList rec |
 	tx := soil newTransaction.
-	skipList := SoilSkipListDictionary new 
+	skipList := (SoilIndexedDictionary newWithBackend: SoilSkipList) 
 		maxLevel: 16;
 		keySize: 10.
 	tx root: { Dictionary new 

--- a/src/Soil-Core-Tests/SoilTransactionJournalTest.class.st
+++ b/src/Soil-Core-Tests/SoilTransactionJournalTest.class.st
@@ -19,7 +19,7 @@ SoilTransactionJournalTest >> fillDatabase [
 	tx root: SoilTestClusterRoot new.
 	tx commit.
 	tx := soil newTransaction.
-	dict := SoilSkipListDictionary new 
+	dict := (SoilIndexedDictionary newWithBackend: SoilSkipList) 
 		maxLevel: 8;
 		keySize: 10.
 	tx makeRoot: dict.
@@ -93,7 +93,7 @@ SoilTransactionJournalTest >> testNewRootObject [
 SoilTransactionJournalTest >> testNewRootSkipList [
 	| tx journal |
 	tx := soil newTransaction.
-	tx root: (SoilSkipListDictionary new
+	tx root: ((SoilIndexedDictionary newWithBackend: SoilSkipList)
 		maxLevel: 8;
 		keySize: 16;
 		yourself).

--- a/src/Soil-Core/SoilBTreeDictionary.class.st
+++ b/src/Soil-Core/SoilBTreeDictionary.class.st
@@ -10,9 +10,7 @@ Class {
 }
 
 { #category : #initialization }
-SoilBTreeDictionary >> createIndex [ 
-	^ SoilBTree new
-		initializeHeaderPage;
-		valueSize: 8;
-		yourself
+SoilBTreeDictionary >> initialize [ 
+	super initialize.
+	self createIndexWith: SoilBTree
 ]

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -26,6 +26,11 @@ SoilIndexedDictionary class >> isAbstract [
 	^ self == SoilIndexedDictionary
 ]
 
+{ #category : #'instance creation' }
+SoilIndexedDictionary class >> newWithBackend: aClass [
+	^ self new createIndexWith: aClass
+]
+
 { #category : #accessing }
 SoilIndexedDictionary class >> soilTransientInstVars [ 
 	^ #( index transaction segment)
@@ -69,6 +74,12 @@ SoilIndexedDictionary >> atIndex: anInteger [
 ]
 
 { #category : #accessing }
+SoilIndexedDictionary >> backend [
+	"return the backend used, which is the class of the index that we use"
+	^index class
+]
+
+{ #category : #accessing }
 SoilIndexedDictionary >> basicAt: aString ifAbsent: aBlock [ 
 	^ self newIterator at: aString ifAbsent: aBlock
 ]
@@ -79,8 +90,11 @@ SoilIndexedDictionary >> compact [
 ]
 
 { #category : #initialization }
-SoilIndexedDictionary >> createIndex [
-	^ self subclassResponsibility
+SoilIndexedDictionary >> createIndexWith: anIndexClass [
+	index := anIndexClass new
+		initializeHeaderPage;
+		valueSize: 8;
+		yourself
 ]
 
 { #category : #enumerating }
@@ -113,8 +127,7 @@ SoilIndexedDictionary >> index [
 { #category : #initialization }
 SoilIndexedDictionary >> initialize [ 
 	super initialize.
-	id := UUID new asString36.
-	index := self createIndex.
+	id := UUID new asString36
 ]
 
 { #category : #testing }
@@ -234,7 +247,8 @@ SoilIndexedDictionary >> soilBasicSerialize: aSerializer [
 	transaction ifNil: [ 
 		transaction := aSerializer transaction ].
 	super soilBasicSerialize: aSerializer.
-	aSerializer registerIndexId: id
+	aSerializer registerIndexId: id.
+
 ]
 
 { #category : #serializing }

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -247,8 +247,7 @@ SoilIndexedDictionary >> soilBasicSerialize: aSerializer [
 	transaction ifNil: [ 
 		transaction := aSerializer transaction ].
 	super soilBasicSerialize: aSerializer.
-	aSerializer registerIndexId: id.
-
+	aSerializer registerIndexId: id
 ]
 
 { #category : #serializing }

--- a/src/Soil-Core/SoilSkipListDictionary.class.st
+++ b/src/Soil-Core/SoilSkipListDictionary.class.st
@@ -11,9 +11,7 @@ Class {
 }
 
 { #category : #initialization }
-SoilSkipListDictionary >> createIndex [ 
-	^ SoilSkipList new
-		initializeHeaderPage;
-		valueSize: 8;
-		yourself
+SoilSkipListDictionary >> initialize [ 
+	super initialize.
+	self createIndexWith: SoilSkipList
 ]


### PR DESCRIPTION
This PR removes all references to SoilBTreeDictionary and SoilSkipListDictionary.

Instead, we use SoilIndexedDictionary and instantiate it using #newWithBackend: and the low level index as a parameter:

```
(SoilIndexedDictionary newWithBackend: SoilSkipList)
```

 SoilBTreeDictionary and SoilSkipListDictionary are still there and continue to work, which makes it easy to refactor clients.

fixes #920