### PR TITLE
Do not set transation in SoilIndexedDictionary>>#soilBasicSerialize:

### DIFF
--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -230,9 +230,7 @@ SoilIndexedDictionary >> size [
 ]
 
 { #category : #serializing }
-SoilIndexedDictionary >> soilBasicSerialize: aSerializer [ 
-	transaction ifNil: [ 
-		transaction := aSerializer transaction ].
+SoilIndexedDictionary >> soilBasicSerialize: aSerializer [
 	super soilBasicSerialize: aSerializer.
 	aSerializer registerIndexId: id
 ]


### PR DESCRIPTION
When serializing a SoilIndexedDictionary, we get the transaction from the serializer, but this is not needed:

- transaction is in soilTransientInstVars, so it will not be serialized
- on loading, SoilIndexedDictionary>>#soilLoadedIn: will set the transaction

fixes #935