### PR TITLE
SoilPersistentDictionaryTest: more tests

### DIFF
--- a/src/Soil-Core-Tests/SoilPersistentDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilPersistentDictionaryTest.class.st
@@ -29,6 +29,20 @@ SoilPersistentDictionaryTest >> tearDown [
 ]
 
 { #category : #tests }
+SoilPersistentDictionaryTest >> testAdd [
+
+	| dict transaction |
+	transaction := soil newTransaction.
+	dict := SoilPersistentDictionary new.
+	transaction makeRoot: dict.
+	
+	dict add: (#test -> 'string').
+	transaction commit.
+		
+	self assert: (dict at: #test) equals: 'string'
+]
+
+{ #category : #tests }
 SoilPersistentDictionaryTest >> testAnyOne [
 
 	| dict transaction |
@@ -142,6 +156,39 @@ SoilPersistentDictionaryTest >> testCommitAndRead [
 ]
 
 { #category : #tests }
+SoilPersistentDictionaryTest >> testDetectIfNone [
+
+	| dict transaction |
+	transaction := soil newTransaction.
+	dict := SoilPersistentDictionary new.
+	transaction makeRoot: dict.
+	
+	dict add: (#test -> 'string').
+	dict add: (#test2 -> 'string').
+	transaction commit.
+		
+	self assert: (dict detect: [:each | each = 'string'] ifNone: [ #error ]) equals: 'string'.
+	self assert: (dict detect: [:each | each = 'tt'] ifNone: [ #error ]) equals: #error
+
+]
+
+{ #category : #tests }
+SoilPersistentDictionaryTest >> testIncludesKey [
+
+	| dict transaction |
+	transaction := soil newTransaction.
+	dict := SoilPersistentDictionary new.
+	transaction makeRoot: dict.
+	
+	dict add: (#test -> 'string').
+	dict add: (#test2 -> 'string').
+	transaction commit.
+		
+	self deny: (dict includesKey: #test1).
+	self assert: (dict includesKey: #test2)
+]
+
+{ #category : #tests }
 SoilPersistentDictionaryTest >> testIsCollection [
 
 	| dict |
@@ -224,6 +271,21 @@ SoilPersistentDictionaryTest >> testRemoveKeyIfAbsent [
 	
 
 
+]
+
+{ #category : #tests }
+SoilPersistentDictionaryTest >> testSize [
+
+	| dict transaction |
+	transaction := soil newTransaction.
+	dict := SoilPersistentDictionary new.
+	transaction makeRoot: dict.
+	
+	dict add: (#test -> 'string').
+	dict add: (#test2 -> 'string').
+	transaction commit.
+		
+	self assert: (dict size) equals: 2
 ]
 
 { #category : #tests }

--- a/src/Soil-Serializer/SoilPersistentDictionary.class.st
+++ b/src/Soil-Serializer/SoilPersistentDictionary.class.st
@@ -25,11 +25,10 @@ SoilPersistentDictionary class >> soilTransientInstVars [
 
 { #category : #forwarded }
 SoilPersistentDictionary >> add: anAssociation [
-	| return |
 	transaction makeRoot: anAssociation value.
-	return := dict add: anAssociation.
+	dict add: anAssociation.
 	transaction markDirty: self.
-	^return
+	^anAssociation
 ]
 
 { #category : #forwarded }
@@ -65,11 +64,10 @@ SoilPersistentDictionary >> at: key ifPresent: aPresentBlock ifAbsent: anAbsentB
 
 { #category : #forwarded }
 SoilPersistentDictionary >> at: key put: value [
-	| return |
 	transaction ifNotNil: [:tr | tr makeRoot: value].
-	return := dict at: key put: value.
+	dict at: key put: value.
 	transaction ifNotNil: [:tr | tr markDirty: self].
-	^return
+	^value
 
 ]
 


### PR DESCRIPTION
- some more tests for SoilPersistentDictionaryTest
- simplify #add and #at:put: due to knowing the return value