### PR TITLE
Avoid executing #initialize on object creation: SoilObjectId, SoilObjectProxy, SoilBehaviorDescription

### DIFF
--- a/src/Soil-Core/SoilObjectId.class.st
+++ b/src/Soil-Core/SoilObjectId.class.st
@@ -54,7 +54,7 @@ SoilObjectId class >> root [
 SoilObjectId class >> segment: segmentId index: index [
 	(segmentId = 0 and: [ index = 0 ]) ifTrue: [ ^ self removed ].
 	(segmentId = 1 and: [ index = 1 ]) ifTrue: [ ^ self root ].
-	^ self new 
+	^ self basicNew
 		segment: segmentId index: index
 ]
 
@@ -91,7 +91,7 @@ SoilObjectId >> asSoilObjectId [
 
 { #category : #converting }
 SoilObjectId >> asSoilObjectProxy [
-	^ SoilObjectProxy new 
+	^ SoilObjectProxy basicNew 
 		objectId: self
 ]
 
@@ -116,12 +116,6 @@ SoilObjectId >> index [
 { #category : #accessing }
 SoilObjectId >> index: anInteger [
 	index := anInteger 
-]
-
-{ #category : #initialization }
-SoilObjectId >> initialize [ 
-	super initialize.
-	segment := 1
 ]
 
 { #category : #testing }

--- a/src/Soil-Serializer/SoilBehaviorDescription.class.st
+++ b/src/Soil-Serializer/SoilBehaviorDescription.class.st
@@ -24,7 +24,7 @@ Class {
 
 { #category : #'instance creation' }
 SoilBehaviorDescription class >> for: aClass [ 
-	^ self new 
+	^ self basicNew 
 		initializeFromBehavior: aClass
 ]
 


### PR DESCRIPTION
This PR avoids executing #intialize for some often instantiated classes
- SoilObjectId
- SoilObjectProxy
- SoilBehaviorDescription