### PR TITLE
Improve SoilPersistentDictionary>>#new:

### DIFF
--- a/src/Soil-Serializer/SoilPersistentDictionary.class.st
+++ b/src/Soil-Serializer/SoilPersistentDictionary.class.st
@@ -9,8 +9,15 @@ Class {
 }
 
 { #category : #'instance creation' }
+SoilPersistentDictionary class >> new [
+	^ self basicNew
+		initialize: 5;
+		yourself
+]
+
+{ #category : #'instance creation' }
 SoilPersistentDictionary class >> new: size [
-	^self new
+	^ self basicNew initialize: size
 ]
 
 { #category : #materializing }
@@ -91,8 +98,8 @@ SoilPersistentDictionary >> includesKey: key [
 ]
 
 { #category : #initialization }
-SoilPersistentDictionary >> initialize [
-	dict := Dictionary new
+SoilPersistentDictionary >> initialize: size [
+	dict := Dictionary new: size
 ]
 
 { #category : #testing }


### PR DESCRIPTION
Enhance SoilPersistentDictionary to follow the implementation of Dictionary for #new and #new:

We will now create the inner dictionary with the size specified. As #new: us used when materializing, this will avoid lots of growth operations of the inner dictionary