### PR TITLE
Deprecate SoilSkipListDictionary/SoilBTreeDictionary and update class comments

### DIFF
--- a/src/Soil-Core/SoilBTreeDictionary.class.st
+++ b/src/Soil-Core/SoilBTreeDictionary.class.st
@@ -1,13 +1,19 @@
 "
-This class implements the SoilIndexDictionary that uses a B+Tree.
+NOTE: Deprecated ! 
+Instead of using this class, create a SoilIndexedDictionary with a SoilBTree as a backend:
 
-See the superclass for more informaion about indexed dictionaries
+SoilIndexedDictionary newWithBackend: SoilBTree
 "
 Class {
 	#name : #SoilBTreeDictionary,
 	#superclass : #SoilIndexedDictionary,
-	#category : #'Soil-Core-Index-BTree'
+	#category : #'Soil-Core-Index-Deprecated'
 }
+
+{ #category : #testing }
+SoilBTreeDictionary class >> isDeprecated [ 
+	^true
+]
 
 { #category : #initialization }
 SoilBTreeDictionary >> initialize [ 

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -1,12 +1,16 @@
 "
 The SoilIndexedDictionary implements a Dictionary that uses an on-disk index.
 
+A SoilIndexedDictionary has to be created with a backend, for now we have SoilBTree and SoilSkipList
+
+	SoilIndexedDictionary newWithBackend: SoilSkipList
+
 Keys are created with #asIndexKeyOfSize: with the keySize being configurable when creating the dictionary. 
 Values are SoilObjectId instances (8 byte). 
 
 The indexes store data on pages (currently 4kb) on disk. 
 
-Take care: SoilIndexedDictionary needs a transaction before values can be added.
+Take care: SoilIndexedDictionary has to be a root object
 "
 Class {
 	#name : #SoilIndexedDictionary,
@@ -19,12 +23,6 @@ Class {
 	],
 	#category : #'Soil-Core-Index-Common'
 }
-
-{ #category : #testing }
-SoilIndexedDictionary class >> isAbstract [
-	<ignoreForCoverage>
-	^ self == SoilIndexedDictionary
-]
 
 { #category : #'instance creation' }
 SoilIndexedDictionary class >> newWithBackend: aClass [

--- a/src/Soil-Core/SoilSkipListDictionary.class.st
+++ b/src/Soil-Core/SoilSkipListDictionary.class.st
@@ -1,14 +1,19 @@
 "
-This class implements the SoilIndexDictionary that uses a Lined List as an index.
+NOTE: Deprecated ! 
+Instead of using this class, create a SoilIndexedDictionary with a SoilSkipList as a backend:
 
-See the superclass for more informaion about indexed dictionaries
-
+SoilIndexedDictionary newWithBackend: SoilSkipList
 "
 Class {
 	#name : #SoilSkipListDictionary,
 	#superclass : #SoilIndexedDictionary,
-	#category : #'Soil-Core-Index-SkipList'
+	#category : #'Soil-Core-Index-Deprecated'
 }
+
+{ #category : #testing }
+SoilSkipListDictionary class >> isDeprecated [ 
+	^true
+]
 
 { #category : #initialization }
 SoilSkipListDictionary >> initialize [ 


### PR DESCRIPTION
	- remove the #isAbstract from SoilIndexedDictionary
	- deprecated SoilSkipListDictionary and SoilBTreeDictionary
	- updates class comments
	- mention in SoilIndexedDictionary comment that we only support it as root object (fixes #822)