### PR TITLE
BTree: uniqueKeys in Header

### DIFF
--- a/src/Soil-Core/SoilBTreeHeaderPage.class.st
+++ b/src/Soil-Core/SoilBTreeHeaderPage.class.st
@@ -11,7 +11,8 @@ Class {
 	#instVars : [
 		'firstFreePageIndex',
 		'size',
-		'lastPageOffset'
+		'lastPageOffset',
+		'uniqueKeys'
 	],
 	#category : #'Soil-Core-Index-BTree'
 }
@@ -46,12 +47,8 @@ SoilBTreeHeaderPage >> firstFreePageIndex: anObject [
 
 { #category : #utilities }
 SoilBTreeHeaderPage >> headerSize [
-	^ super headerSize  
-		+ 2 "valueSize"
-		+ 2 "keySize"
-		+ self pointerSize "lastPageIndex"
-		+ self pointerSize "lastFreePageIndex"
-		+ 6 "size"
+	^ super headerSize 
+		+ 19 "keySize(2), valueSize(2), lastPageIndex(4), lastFreePageIndex(4) size(6) uniqueKeys(1)" 
 ]
 
 { #category : #utilities }
@@ -64,7 +61,8 @@ SoilBTreeHeaderPage >> increaseSize [
 SoilBTreeHeaderPage >> initialize [ 
 	super initialize.
 	firstFreePageIndex := 0.
-	size := 0
+	size := 0.
+	uniqueKeys := true
 ]
 
 { #category : #testing }
@@ -103,12 +101,21 @@ SoilBTreeHeaderPage >> printOn: aStream [
 { #category : #reading }
 SoilBTreeHeaderPage >> readFrom: aStream [ 
 	super readFrom: aStream.
+	self 
+		readHeaderFrom: aStream;
+		readItemsFrom: aStream
+]
+
+{ #category : #reading }
+SoilBTreeHeaderPage >> readHeaderFrom: aStream [ 
 	keySize := (aStream next: 2) asInteger.
 	valueSize := (aStream next: 2) asInteger.
 	lastPageOffset :=(aStream next: self pointerSize) asInteger.
 	firstFreePageIndex :=(aStream next: 4) asInteger.
 	size := (aStream next: 6) asInteger.
-	self readItemsFrom: aStream
+	uniqueKeys := (version > 2) 
+		ifTrue: [ aStream next = 1 ]
+		ifFalse: [ true ].
 ]
 
 { #category : #accessing }
@@ -123,7 +130,7 @@ SoilBTreeHeaderPage >> size: anInteger [
 
 { #category : #accessing }
 SoilBTreeHeaderPage >> uniqueKeys [
-	^ true 
+	^ uniqueKeys
 ]
 
 { #category : #accessing }
@@ -140,4 +147,8 @@ SoilBTreeHeaderPage >> writeHeaderOn: aStream [
 		nextPutAll: (lastPageOffset asByteArrayOfSize: self pointerSize);
 		nextPutAll: (firstFreePageIndex asByteArrayOfSize: 4);
 		nextPutAll: (self size asByteArrayOfSize: 6).
+		(version > 2) ifTrue: [ 
+			 (uniqueKeys isNil or: [ uniqueKeys ])
+				ifTrue: [ aStream nextPut:  1 ]
+				ifFalse: [ aStream nextPut: 0 ] ].
 ]


### PR DESCRIPTION
This PR adds the uniqueKeys store/load for the BTree Headerpage.

Note: this does not yet implement the uniqueKeys, just storing an loading the flag