### PR TITLE
Move subclasses of SoilApplicationMigration to test package

### DIFF
--- a/src/Soil-Core-Tests/SoilTestApplicationMigrationFull.class.st
+++ b/src/Soil-Core-Tests/SoilTestApplicationMigrationFull.class.st
@@ -1,29 +1,29 @@
 Class {
-	#name : #SoilTestApplicationMigrationHalf,
+	#name : #SoilTestApplicationMigrationFull,
 	#superclass : #SoilApplicationMigration,
-	#category : #'Soil-Core-Migration'
+	#category : #'Soil-Core-Tests-TestData'
 }
 
 { #category : #accessing }
-SoilTestApplicationMigrationHalf >> v1: transaction [
+SoilTestApplicationMigrationFull >> v1: transaction [
 	<applicationVersion: 1 auto: true>
 	transaction root: SoilPersistentDictionary new
 ]
 
 { #category : #accessing }
-SoilTestApplicationMigrationHalf >> v2: transaction [
+SoilTestApplicationMigrationFull >> v2: transaction [
 	<applicationVersion: 2 auto: true>
 	transaction root at: #two put: 2.
 ]
 
 { #category : #accessing }
-SoilTestApplicationMigrationHalf >> v3: transaction [
-	<applicationVersion: 3 auto: false>
+SoilTestApplicationMigrationFull >> v3: transaction [
+	<applicationVersion: 3 auto: true>
 	transaction root at: #three put: 3
 ]
 
 { #category : #accessing }
-SoilTestApplicationMigrationHalf >> v4: transaction [
+SoilTestApplicationMigrationFull >> v4: transaction [
 	<applicationVersion: 4 auto: true>
 	transaction root at: #four put: 4
 ]

--- a/src/Soil-Core-Tests/SoilTestApplicationMigrationHalf.class.st
+++ b/src/Soil-Core-Tests/SoilTestApplicationMigrationHalf.class.st
@@ -1,29 +1,29 @@
 Class {
-	#name : #SoilTestApplicationMigrationFull,
+	#name : #SoilTestApplicationMigrationHalf,
 	#superclass : #SoilApplicationMigration,
-	#category : #'Soil-Core-Migration'
+	#category : #'Soil-Core-Tests-TestData'
 }
 
 { #category : #accessing }
-SoilTestApplicationMigrationFull >> v1: transaction [
+SoilTestApplicationMigrationHalf >> v1: transaction [
 	<applicationVersion: 1 auto: true>
 	transaction root: SoilPersistentDictionary new
 ]
 
 { #category : #accessing }
-SoilTestApplicationMigrationFull >> v2: transaction [
+SoilTestApplicationMigrationHalf >> v2: transaction [
 	<applicationVersion: 2 auto: true>
 	transaction root at: #two put: 2.
 ]
 
 { #category : #accessing }
-SoilTestApplicationMigrationFull >> v3: transaction [
-	<applicationVersion: 3 auto: true>
+SoilTestApplicationMigrationHalf >> v3: transaction [
+	<applicationVersion: 3 auto: false>
 	transaction root at: #three put: 3
 ]
 
 { #category : #accessing }
-SoilTestApplicationMigrationFull >> v4: transaction [
+SoilTestApplicationMigrationHalf >> v4: transaction [
 	<applicationVersion: 4 auto: true>
 	transaction root at: #four put: 4
 ]


### PR DESCRIPTION
This PR just moves SoilTestApplicationMigrationFull and SoilTestApplicationMigrationHalf to the test package, as they are just used by the tests