### PR TITLE
Added basic Windows file lock support

### DIFF
--- a/src/Soil-File-Tests/SoilWindowsFileLockTest.class.st
+++ b/src/Soil-File-Tests/SoilWindowsFileLockTest.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : 'WindowsFileLockTest',
+	#name : 'SoilWindowsFileLockTest',
 	#superclass : 'TestCase',
 	#instVars : [
 		'testFile',
@@ -10,14 +10,14 @@ Class {
 }
 
 { #category : 'running' }
-WindowsFileLockTest >> setUp [
+SoilWindowsFileLockTest >> setUp [
 	super setUp.
 	testFile := 'soil-winlock-test.tmp' asFileReference.
 	testFile ensureDelete
 ]
 
 { #category : 'running' }
-WindowsFileLockTest >> tearDown [
+SoilWindowsFileLockTest >> tearDown [
 	stream ifNotNil: [
 		[ stream close ] on: Error do: [ :ex | "ignore close errors" ] ].
 	testFile ifNotNil: [
@@ -26,39 +26,23 @@ WindowsFileLockTest >> tearDown [
 ]
 
 { #category : 'tests' }
-WindowsFileLockTest >> testErrorDescriptions [
+SoilWindowsFileLockTest >> testErrorDescriptions [
 	"Test error description helper method"
 
 	OSPlatform current isWindows ifFalse: [ ^ self skip ].
 
 	"Test known error codes"
-	self assert: (WindowsFileLock errorDescription: 5) equals: 'Access denied'.
-	self assert: (WindowsFileLock errorDescription: 6) equals: 'Invalid file handle'.
-	self assert: (WindowsFileLock errorDescription: 33) equals: 'Lock violation (region already locked)'.
-	self assert: (WindowsFileLock errorDescription: 158) equals: 'Region not locked'.
+	self assert: (SoilWindowsFileLock errorDescription: 5) equals: 'Access denied'.
+	self assert: (SoilWindowsFileLock errorDescription: 6) equals: 'Invalid file handle'.
+	self assert: (SoilWindowsFileLock errorDescription: 33) equals: 'Lock violation (region already locked)'.
+	self assert: (SoilWindowsFileLock errorDescription: 158) equals: 'Region not locked'.
 
 	"Test unknown error code"
-	self assert: ((WindowsFileLock errorDescription: 9999) includesSubstring: 'Unknown error')
+	self assert: ((SoilWindowsFileLock errorDescription: 9999) includesSubstring: 'Unknown error')
 ]
 
 { #category : 'tests' }
-WindowsFileLockTest >> testFdatasyncEntireFile [
-	"Test fdatasync on Windows (should call same as fsync)"
-
-	OSPlatform current isWindows ifFalse: [ ^ self skip ].
-
-	stream := testFile binaryWriteStream.
-	stream nextPutAll: 'Testing fdatasync on Windows!'.
-	stream flush.
-
-	"Call fdatasync - should not raise an error"
-	self shouldnt: [ stream fileStream fdatasync ] raise: Error.
-
-	stream close
-]
-
-{ #category : 'tests' }
-WindowsFileLockTest >> testFlushFileBuffersDirect [
+SoilWindowsFileLockTest >> testFlushFileBuffersDirect [
 	"Test FlushFileBuffers FFI call directly"
 
 	| result |
@@ -69,14 +53,14 @@ WindowsFileLockTest >> testFlushFileBuffersDirect [
 	stream flush.
 
 	"Call FlushFileBuffers directly"
-	result := WindowsFileLock flushFileBuffers: stream fileStream fileHandle.
+	result := SoilWindowsFileLock flushFileBuffers: stream fileStream fileHandle.
 
 	"Should return true (non-zero) on success"
 	self assert: result
 ]
 
 { #category : 'tests' }
-WindowsFileLockTest >> testFsyncEntireFile [
+SoilWindowsFileLockTest >> testFsyncEntireFile [
 	"Test fsync on Windows using FlushFileBuffers"
 
 	OSPlatform current isWindows ifFalse: [ ^ self skip ].
@@ -92,7 +76,7 @@ WindowsFileLockTest >> testFsyncEntireFile [
 ]
 
 { #category : 'tests' }
-WindowsFileLockTest >> testLockAndUnlockEntireFile [
+SoilWindowsFileLockTest >> testLockAndUnlockEntireFile [
 	"Test locking and unlocking the entire file (length = 0)"
 
 	OSPlatform current isWindows ifFalse: [ ^ self skip ].
@@ -102,14 +86,14 @@ WindowsFileLockTest >> testLockAndUnlockEntireFile [
 	stream flush.
 
 	"Lock entire file"
-	self assert: (WindowsFileLock lock: stream fileStream fileHandle from: 0 length: 0).
+	self assert: (SoilWindowsFileLock lock: stream fileStream fileHandle from: 0 length: 0).
 
 	"Unlock entire file"
-	self assert: (WindowsFileLock unlock: stream fileStream fileHandle from: 0 length: 0)
+	self assert: (SoilWindowsFileLock unlock: stream fileStream fileHandle from: 0 length: 0)
 ]
 
 { #category : 'tests' }
-WindowsFileLockTest >> testLockAndUnlockRange [
+SoilWindowsFileLockTest >> testLockAndUnlockRange [
 	"Test locking and unlocking a specific byte range"
 
 	OSPlatform current isWindows ifFalse: [ ^ self skip ].
@@ -119,14 +103,14 @@ WindowsFileLockTest >> testLockAndUnlockRange [
 	stream flush.
 
 	"Lock bytes 7 to 14 (the word 'Windows')"
-	self assert: (WindowsFileLock lock: stream fileStream fileHandle from: 7 length: 7).
+	self assert: (SoilWindowsFileLock lock: stream fileStream fileHandle from: 7 length: 7).
 
 	"Unlock the same range"
-	self assert: (WindowsFileLock unlock: stream fileStream fileHandle from: 7 length: 7)
+	self assert: (SoilWindowsFileLock unlock: stream fileStream fileHandle from: 7 length: 7)
 ]
 
 { #category : 'tests' }
-WindowsFileLockTest >> testLockExclusive [
+SoilWindowsFileLockTest >> testLockExclusive [
 	"Test exclusive lock"
 
 	OSPlatform current isWindows ifFalse: [ ^ self skip ].
@@ -136,14 +120,14 @@ WindowsFileLockTest >> testLockExclusive [
 	stream flush.
 
 	"Lock with exclusive flag"
-	self assert: (WindowsFileLock lock: stream fileStream fileHandle from: 0 length: 100 exclusive: true).
+	self assert: (SoilWindowsFileLock lock: stream fileStream fileHandle from: 0 length: 100 exclusive: true).
 
 	"Unlock"
-	self assert: (WindowsFileLock unlock: stream fileStream fileHandle from: 0 length: 100)
+	self assert: (SoilWindowsFileLock unlock: stream fileStream fileHandle from: 0 length: 100)
 ]
 
 { #category : 'tests' }
-WindowsFileLockTest >> testLockOrErrorSuccess [
+SoilWindowsFileLockTest >> testLockOrErrorSuccess [
 	"Test lockOrError with successful lock"
 
 	OSPlatform current isWindows ifFalse: [ ^ self skip ].
@@ -154,15 +138,15 @@ WindowsFileLockTest >> testLockOrErrorSuccess [
 
 	"Should not raise an error"
 	self shouldnt: [
-		WindowsFileLock lockOrError: stream fileStream fileHandle from: 0 length: 100 exclusive: true ]
+		SoilWindowsFileLock lockOrError: stream fileStream fileHandle from: 0 length: 100 exclusive: true ]
 		raise: Error.
 
 	"Clean up"
-	WindowsFileLock unlock: stream fileStream fileHandle from: 0 length: 100
+	SoilWindowsFileLock unlock: stream fileStream fileHandle from: 0 length: 100
 ]
 
 { #category : 'tests' }
-WindowsFileLockTest >> testLockShared [
+SoilWindowsFileLockTest >> testLockShared [
 	"Test shared lock"
 
 	OSPlatform current isWindows ifFalse: [ ^ self skip ].
@@ -172,14 +156,14 @@ WindowsFileLockTest >> testLockShared [
 	stream flush.
 
 	"Lock with shared flag"
-	self assert: (WindowsFileLock lock: stream fileStream fileHandle from: 0 length: 100 exclusive: false).
+	self assert: (SoilWindowsFileLock lock: stream fileStream fileHandle from: 0 length: 100 exclusive: false).
 
 	"Unlock"
-	self assert: (WindowsFileLock unlock: stream fileStream fileHandle from: 0 length: 100)
+	self assert: (SoilWindowsFileLock unlock: stream fileStream fileHandle from: 0 length: 100)
 ]
 
 { #category : 'tests' }
-WindowsFileLockTest >> testMultipleLocks [
+SoilWindowsFileLockTest >> testMultipleLocks [
 	"Test locking multiple non-overlapping ranges"
 
 	OSPlatform current isWindows ifFalse: [ ^ self skip ].
@@ -189,24 +173,24 @@ WindowsFileLockTest >> testMultipleLocks [
 	stream flush.
 
 	"Lock range 0-9"
-	self assert: (WindowsFileLock lock: stream fileStream fileHandle from: 0 length: 10).
+	self assert: (SoilWindowsFileLock lock: stream fileStream fileHandle from: 0 length: 10).
 
 	"Lock range 10-19 (non-overlapping)"
-	self assert: (WindowsFileLock lock: stream fileStream fileHandle from: 10 length: 10).
+	self assert: (SoilWindowsFileLock lock: stream fileStream fileHandle from: 10 length: 10).
 
 	"Unlock both ranges"
-	self assert: (WindowsFileLock unlock: stream fileStream fileHandle from: 0 length: 10).
-	self assert: (WindowsFileLock unlock: stream fileStream fileHandle from: 10 length: 10)
+	self assert: (SoilWindowsFileLock unlock: stream fileStream fileHandle from: 0 length: 10).
+	self assert: (SoilWindowsFileLock unlock: stream fileStream fileHandle from: 10 length: 10)
 ]
 
 { #category : 'tests' }
-WindowsFileLockTest >> testWinOverlappedStructure [
+SoilWindowsFileLockTest >> testWinOverlappedStructure [
 	"Test WinOverlapped structure initialization and field access"
 
 	| overlapped |
 	OSPlatform current isWindows ifFalse: [ ^ self skip ].
 
-	overlapped := WinOverlapped new.
+	overlapped := SoilWinOverlappedStruct new.
 
 	"Test field setters and getters"
 	overlapped offset: 16r12345678.

--- a/src/Soil-File/BinaryFileStream.extension.st
+++ b/src/Soil-File/BinaryFileStream.extension.st
@@ -1,33 +1,6 @@
 Extension { #name : 'BinaryFileStream' }
 
 { #category : '*Soil-File' }
-BinaryFileStream >> fdatasync [
-	"Flush data (but not necessarily metadata) to disk. Platform-independent implementation."
-
-	OSPlatform current isWindows
-		ifTrue: [ self fsyncWindows ]
-		ifFalse: [ self fdatasyncUnix ]
-]
-
-{ #category : '*Soil-File' }
-BinaryFileStream >> fdatasync: fd [
-	^ self 
-		ffiCall: #(int fdatasync(int fd))
-		module: LibC
-]
-
-{ #category : '*Soil-File' }
-BinaryFileStream >> fdatasyncUnix [
-	"Unix/Linux/MacOS implementation of fdatasync using POSIX API"
-
-	| fd err |
-	fd := self fileno.
-	err := self fdatasync: fd.
-	(err = 0) ifFalse: [
-		Error signal: 'fdatasync(', fd printString, ') failed with error code: ', err printString ]
-]
-
-{ #category : '*Soil-File' }
 BinaryFileStream >> fileHandle [
 
 	^ handle pointerAt: 9
@@ -91,9 +64,9 @@ BinaryFileStream >> fsyncWindows [
 	"Windows implementation of fsync using FlushFileBuffers API"
 
 	| result errorCode |
-	result := WindowsFileLock flushFileBuffers: self fileHandle.
+	result := SoilWindowsFileLock flushFileBuffers: self fileHandle.
 	result ifFalse: [
-			errorCode := WindowsFileLock getLastError.
+			errorCode := SoilWindowsFileLock getLastError.
 			Error signal:
 				'FlushFileBuffers failed with error code: '
 				, errorCode printString ]

--- a/src/Soil-File/SoilWinOverlappedStruct.class.st
+++ b/src/Soil-File/SoilWinOverlappedStruct.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : 'WinOverlapped',
+	#name : 'SoilWinOverlappedStruct',
 	#superclass : 'FFIStructure',
 	#classVars : [
 		'OFFSET_HEVENT',
@@ -13,7 +13,7 @@ Class {
 }
 
 { #category : 'field definition' }
-WinOverlapped class >> fieldsDesc [
+SoilWinOverlappedStruct class >> fieldsDesc [
 	"self rebuildFieldAccessors"
 
 	^ #(
@@ -26,72 +26,72 @@ WinOverlapped class >> fieldsDesc [
 ]
 
 { #category : 'accessing - structure variables' }
-WinOverlapped >> hEvent [
+SoilWinOverlappedStruct >> hEvent [
 	"This method was automatically generated"
 	^ExternalData fromHandle: (handle pointerAt: OFFSET_HEVENT) type: ExternalType void asPointerType
 ]
 
 { #category : 'accessing - structure variables' }
-WinOverlapped >> hEvent: anObject [
+SoilWinOverlappedStruct >> hEvent: anObject [
 	"This method was automatically generated"
 	handle pointerAt: OFFSET_HEVENT put: anObject getHandle.
 ]
 
 { #category : 'initialization' }
-WinOverlapped >> initialize [
+SoilWinOverlappedStruct >> initialize [
 	super initialize
 ]
 
 { #category : 'accessing - structure variables' }
-WinOverlapped >> internal [
+SoilWinOverlappedStruct >> internal [
 	"This method was automatically generated"
 	^handle unsignedLongLongAt: OFFSET_INTERNAL
 ]
 
 { #category : 'accessing - structure variables' }
-WinOverlapped >> internal: anObject [
+SoilWinOverlappedStruct >> internal: anObject [
 	"This method was automatically generated"
 	handle unsignedLongLongAt: OFFSET_INTERNAL put: anObject
 ]
 
 { #category : 'accessing - structure variables' }
-WinOverlapped >> internalHigh [
+SoilWinOverlappedStruct >> internalHigh [
 	"This method was automatically generated"
 	^handle unsignedLongLongAt: OFFSET_INTERNALHIGH
 ]
 
 { #category : 'accessing - structure variables' }
-WinOverlapped >> internalHigh: anObject [
+SoilWinOverlappedStruct >> internalHigh: anObject [
 	"This method was automatically generated"
 	handle unsignedLongLongAt: OFFSET_INTERNALHIGH put: anObject
 ]
 
 { #category : 'accessing - structure variables' }
-WinOverlapped >> offset [
+SoilWinOverlappedStruct >> offset [
 	"This method was automatically generated"
 	^handle unsignedLongAt: OFFSET_OFFSET
 ]
 
 { #category : 'accessing - structure variables' }
-WinOverlapped >> offset: anObject [
+SoilWinOverlappedStruct >> offset: anObject [
 	"This method was automatically generated"
 	handle unsignedLongAt: OFFSET_OFFSET put: anObject
 ]
 
 { #category : 'accessing - structure variables' }
-WinOverlapped >> offsetHigh [
+SoilWinOverlappedStruct >> offsetHigh [
 	"This method was automatically generated"
 	^handle unsignedLongAt: OFFSET_OFFSETHIGH
 ]
 
 { #category : 'accessing - structure variables' }
-WinOverlapped >> offsetHigh: anObject [
+SoilWinOverlappedStruct >> offsetHigh: anObject [
 	"This method was automatically generated"
 	handle unsignedLongAt: OFFSET_OFFSETHIGH put: anObject
 ]
 
 { #category : 'printing' }
-WinOverlapped >> printOn: aStream [
+SoilWinOverlappedStruct >> printOn: aStream [
 	"Append to the argument, aStream, the names and values of all the record's variables."
 
 	aStream nextPutAll: self class name; nextPutAll: ' ( '; cr.

--- a/src/Soil-File/SoilWindowsFileLock.class.st
+++ b/src/Soil-File/SoilWindowsFileLock.class.st
@@ -1,5 +1,5 @@
 Class {
-	#name : 'WindowsFileLock',
+	#name : 'SoilWindowsFileLock',
 	#superclass : 'Object',
 	#classVars : [
 		'ERROR_ACCESS_DENIED',
@@ -16,7 +16,7 @@ Class {
 }
 
 { #category : 'testing' }
-WindowsFileLock class >> canLock: fileHandle from: start length: length exclusive: exclusive [
+SoilWindowsFileLock class >> canLock: fileHandle from: start length: length exclusive: exclusive [
 	"Windows doesn't have a direct 'test lock' API like F_GETLK.
 	We attempt to lock and immediately unlock if successful."
 
@@ -28,7 +28,7 @@ WindowsFileLock class >> canLock: fileHandle from: start length: length exclusiv
 ]
 
 { #category : 'private - error handling' }
-WindowsFileLock class >> errorDescription: errorCode [
+SoilWindowsFileLock class >> errorDescription: errorCode [
 	"Return a human-readable description for Windows error codes"
 
 	errorCode = ERROR_ACCESS_DENIED ifTrue: [ ^ 'Access denied' ].
@@ -41,21 +41,21 @@ WindowsFileLock class >> errorDescription: errorCode [
 ]
 
 { #category : 'private - ffi' }
-WindowsFileLock class >> flushFileBuffers: hFile [
+SoilWindowsFileLock class >> flushFileBuffers: hFile [
 	"Flush all file buffers to disk using Windows API"
 
 	^ self ffiCall: #(bool FlushFileBuffers(void* hFile)) module: #kernel32
 ]
 
 { #category : 'private - ffi' }
-WindowsFileLock class >> getCurrentProcessId [
+SoilWindowsFileLock class >> getCurrentProcessId [
 	"Get the current process ID using Windows API"
 
 	^ self ffiCall: #(uint GetCurrentProcessId()) module: #kernel32
 ]
 
 { #category : 'private - ffi' }
-WindowsFileLock class >> getFileHandle: stream [
+SoilWindowsFileLock class >> getFileHandle: stream [
 	"Extract Windows HANDLE from a BinaryFileStream.
 	For buffered streams (ZnBufferedWriteStream), get the wrapped file stream first."
 
@@ -65,14 +65,14 @@ WindowsFileLock class >> getFileHandle: stream [
 ]
 
 { #category : 'private - ffi' }
-WindowsFileLock class >> getLastError [
+SoilWindowsFileLock class >> getLastError [
 	"Get Windows error code"
 
 	^ self ffiCall: #(uint GetLastError()) module: #kernel32
 ]
 
 { #category : 'class initialization' }
-WindowsFileLock class >> initialize [
+SoilWindowsFileLock class >> initialize [
 	"Windows API constants"
 
 	LOCKFILE_EXCLUSIVE_LOCK := 16r00000002.
@@ -88,7 +88,7 @@ WindowsFileLock class >> initialize [
 ]
 
 { #category : 'accessing locking' }
-WindowsFileLock class >> lock: fileHandle from: start length: length [
+SoilWindowsFileLock class >> lock: fileHandle from: start length: length [
 
 	^ self
 		lock: fileHandle
@@ -98,7 +98,7 @@ WindowsFileLock class >> lock: fileHandle from: start length: length [
 ]
 
 { #category : 'accessing locking' }
-WindowsFileLock class >> lock: fileHandle from: start length: length exclusive: exclusive [
+SoilWindowsFileLock class >> lock: fileHandle from: start length: length exclusive: exclusive [
 	"Lock file region, returning true on success, false on failure.
 	For detailed error information, use lockOrError:from:length:exclusive:"
 
@@ -107,7 +107,7 @@ WindowsFileLock class >> lock: fileHandle from: start length: length exclusive: 
 	"fileHandle is already a Windows HANDLE (ExternalAddress)"
 
 	"Create and initialize OVERLAPPED structure"
-	overlapped := WinOverlapped new.
+	overlapped := SoilWinOverlappedStruct new.
 	overlapped offset: (start bitAnd: 16rFFFFFFFF).
 	overlapped offsetHigh: (start bitShift: -32).
 	overlapped hEvent: ExternalAddress null.
@@ -138,7 +138,7 @@ WindowsFileLock class >> lock: fileHandle from: start length: length exclusive: 
 ]
 
 { #category : 'private - ffi' }
-WindowsFileLock class >> lockFileEx: hFile flags: dwFlags bytesLow: nNumberOfBytesToLockLow bytesHigh: nNumberOfBytesToLockHigh overlapped: lpOverlapped [
+SoilWindowsFileLock class >> lockFileEx: hFile flags: dwFlags bytesLow: nNumberOfBytesToLockLow bytesHigh: nNumberOfBytesToLockHigh overlapped: lpOverlapped [
 
 	^ self
 		ffiCall: #(bool LockFileEx(
@@ -147,12 +147,12 @@ WindowsFileLock class >> lockFileEx: hFile flags: dwFlags bytesLow: nNumberOfByt
 			uint 0,
 			uint nNumberOfBytesToLockLow,
 			uint nNumberOfBytesToLockHigh,
-			WinOverlapped *lpOverlapped))
+			SoilWinOverlappedStruct *lpOverlapped))
 		module: #kernel32
 ]
 
 { #category : 'accessing locking' }
-WindowsFileLock class >> lockOrError: fileHandle from: start length: length exclusive: exclusive [
+SoilWindowsFileLock class >> lockOrError: fileHandle from: start length: length exclusive: exclusive [
 	"Lock file region, raising an error with detailed information on failure"
 
 	| success errorCode errorDesc lockType |
@@ -170,7 +170,7 @@ WindowsFileLock class >> lockOrError: fileHandle from: start length: length excl
 ]
 
 { #category : 'accessing locking' }
-WindowsFileLock class >> unlock: fileHandle from: start length: length [
+SoilWindowsFileLock class >> unlock: fileHandle from: start length: length [
 	"Unlock file region, returning true on success, false on failure.
 	For detailed error information, use unlockOrError:from:length:"
 
@@ -179,7 +179,7 @@ WindowsFileLock class >> unlock: fileHandle from: start length: length [
 	"fileHandle is already a Windows HANDLE (ExternalAddress)"
 
 	"Create and initialize OVERLAPPED structure"
-	overlapped := WinOverlapped new.
+	overlapped := SoilWinOverlappedStruct new.
 	overlapped offset: (start bitAnd: 16rFFFFFFFF).
 	overlapped offsetHigh: (start bitShift: -32).
 	overlapped hEvent: ExternalAddress null.
@@ -204,7 +204,7 @@ WindowsFileLock class >> unlock: fileHandle from: start length: length [
 ]
 
 { #category : 'private - ffi' }
-WindowsFileLock class >> unlockFileEx: hFile bytesLow: nNumberOfBytesToUnlockLow bytesHigh: nNumberOfBytesToUnlockHigh overlapped: lpOverlapped [
+SoilWindowsFileLock class >> unlockFileEx: hFile bytesLow: nNumberOfBytesToUnlockLow bytesHigh: nNumberOfBytesToUnlockHigh overlapped: lpOverlapped [
 
 	^ self
 		ffiCall: #(bool UnlockFileEx(
@@ -212,12 +212,12 @@ WindowsFileLock class >> unlockFileEx: hFile bytesLow: nNumberOfBytesToUnlockLow
 			uint 0,
 			uint nNumberOfBytesToUnlockLow,
 			uint nNumberOfBytesToUnlockHigh,
-			WinOverlapped *lpOverlapped))
+			SoilWinOverlappedStruct *lpOverlapped))
 		module: #kernel32
 ]
 
 { #category : 'accessing locking' }
-WindowsFileLock class >> unlockOrError: fileHandle from: start length: length [
+SoilWindowsFileLock class >> unlockOrError: fileHandle from: start length: length [
 	"Unlock file region, raising an error with detailed information on failure"
 
 	| success errorCode errorDesc |

--- a/src/Soil-File/WinPlatform.extension.st
+++ b/src/Soil-File/WinPlatform.extension.st
@@ -2,5 +2,5 @@ Extension { #name : 'WinPlatform' }
 
 { #category : '*Soil-File' }
 WinPlatform >> flockClass [
-	^ WindowsFileLock
+	^ SoilWindowsFileLock
 ]


### PR DESCRIPTION
Added basic Windows file lock support. 
Soil-File-Tests and Soil-Serializer-Tests are all green on Windows (not Soil-Core-Tests ). I think it would be a good starting point.

## Summary
- Implemented Windows file locking using `LockFileEx` and `UnlockFileEx` Windows APIs
- Added `SoilWindowsFileLock` class to handle Windows-specific file locking operations
- Created `SoilWinOverlappedStruct` FFI structure for Windows OVERLAPPED API
- Extended `BinaryFileStream` with platform-independent `fsync` methods
- Added comprehensive test suite with `SoilWindowsFileLockTest` covering lock/unlock, fsync, and error handling scenarios
- Extended `WinPlatform` to use `SoilWindowsFileLock` class for file locking operations

## Test results
- [x] Run `SoilWindowsFileLockTest` on Windows to verify all file locking scenarios
- [x] Soil-File-Tests: all tests are green
- [x] Soil-Serializer-Tests: all tests are green
- FAIL: Soil-Core-Tests: some tests fail because of file ensure/deletion code is not compatible on Windows.
