### PR TITLE
Index: Document #removeKey: and empty pages

### DIFF
--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -135,6 +135,8 @@ SoilBasicBTree >> pageClass [
 
 { #category : #removing }
 SoilBasicBTree >> removeKey: key ifAbsent: aBlock [
+	"Warning: Low level remove. If the page is empty after, the index will not work anymore, as we need minimal one key for search to work.
+	Caller has to remove the empty page!"
 
 	^ (self rootPage remove: key for: self)
 		  ifNil: [ aBlock value ]

--- a/src/Soil-Core/SoilBasicSkipList.class.st
+++ b/src/Soil-Core/SoilBasicSkipList.class.st
@@ -60,6 +60,22 @@ SoilBasicSkipList >> pageClass [
 ]
 
 { #category : #removing }
+SoilBasicSkipList >> removeKey: key ifAbsent: aBlock [
+	"Warning: Low level remove. If the page is empty after, the index will not work anymore, as we need minimal one key for search to work.
+	Caller has to remove the empty page!"
+	
+	| page index |
+	page := self newIterator 
+		find: key;
+		currentPage.
+	^ ((index := page indexOfKey: (self indexKey: key)) > 0)
+		ifTrue: [ 
+			self decreaseSize.
+			(page itemRemoveIndex: index) value ]
+		ifFalse: [ aBlock value ]
+]
+
+{ #category : #removing }
 SoilBasicSkipList >> removePage: aPage [
 	| iterator seen previousPage |
 	(aPage offset > 1) ifFalse: [ ^ aPage ].

--- a/src/Soil-Core/SoilIndex.class.st
+++ b/src/Soil-Core/SoilIndex.class.st
@@ -420,23 +420,19 @@ SoilIndex >> removeDirtyPage: aPage [
 ]
 
 { #category : #removing }
-SoilIndex >> removeKey: key [ 
+SoilIndex >> removeKey: key [
+	"Warning: Low level remove. If the page is empty after, the index will not work anymore, as we need minimal one key for search to work.
+	Caller has to remove the empty page!"
 	^ self
 		removeKey: key 
 		ifAbsent: [ KeyNotFound signalFor: key in: self ]
 ]
 
 { #category : #removing }
-SoilIndex >> removeKey: key ifAbsent: aBlock [
-	| page index |
-	page := self newIterator 
-		find: key;
-		currentPage.
-	^ ((index := page indexOfKey: (self indexKey: key)) > 0)
-		ifTrue: [ 
-			self decreaseSize.
-			(page itemRemoveIndex: index) value ]
-		ifFalse: [ aBlock value ]
+SoilIndex >> removeKey: key ifAbsent: aBlock [ 
+	"Warning: Low level remove. If the page is empty after, the index will not work anymore, as we need minimal one key for search to work.
+	Caller has to remove the empty page!"
+	^ self subclassResponsibility
 ]
 
 { #category : #removing }


### PR DESCRIPTION
This PR adds documentation to the index #removeKey: methods to explain that if the page gets empty, the index will not work anymore.

Maybe there is a way to have a basic remove and a remove: that would clean the page, but as Soil does not need that (but it needs instead control over page deletion for page reuse), I do not want to add that if we do not need it. 

fixes #850