### PR TITLE
BTree: recycle empty index pages

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreeDuplicateTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeDuplicateTest.class.st
@@ -355,9 +355,9 @@ SoilBTreeDuplicateTest >> testFreePageAddNested [
 	self assert: (index store pageAt: 5) pageIndexes size equals: 1018.
 	"as there were more than free list capacity there is a next free
 	list page"
-	self assert: (index store pageAt: 5) next equals: 1030.
-	nestedFreeIndexes := (index store pageAt: 1030) pageIndexes copy
-		                     copyWith: 1030.
+	self assert: (index store pageAt: 5) next equals: 1025.
+	nestedFreeIndexes := (index store pageAt: 1025) pageIndexes copy
+		                     copyWith: 1025.
 	"we fill the index with enough elements to use all free pages including the nested 
 	ones"
 	1 to: 15 * 1018 do: [ :n |

--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -330,11 +330,10 @@ SoilBTreeTest >> testFreePageAddNested [
 	index cleanUpToVersion: nil.
 	self assert: index headerPage firstFreePageIndex equals: 5.
 	self assert: (index store pageAt: 5) pageIndexes size equals: 1018.
-	"as there were more than free list capacity there is a next free
-	list page"
-	self assert: (index store pageAt: 5) next equals: 1030.
-	nestedFreeIndexes := (index store pageAt: 1030) pageIndexes copy
-		                     copyWith: 1030.
+	"as there were more than free list capacity there is a next free list page"
+	self assert: (index store pageAt: 5) next equals: 1025.
+	nestedFreeIndexes := (index store pageAt: 1025) pageIndexes copy
+		                     copyWith: 1025.
 	"we fill the index with enough elements to use all free pages including the nested 
 	ones"
 	1 to: 15 * 1018 do: [ :n |

--- a/src/Soil-Core-Tests/SoilCleanCodeTest.class.st
+++ b/src/Soil-Core-Tests/SoilCleanCodeTest.class.st
@@ -202,7 +202,7 @@ SoilCleanCodeTest >> testNoUnusedClasses [
 	self skip.
 	found := self packageToCheck definedClasses reject: [ :class | class isUsed]. 
 	
-	knownviolations := #( ).
+	knownviolations := #(SoilSkipListDictionary SoilBTreeDictionary).
 	found := found reject: [:class | knownviolations includes: class name  ].
 	
 	self 

--- a/src/Soil-Core/SoilBTreeIndexPage.class.st
+++ b/src/Soil-Core/SoilBTreeIndexPage.class.st
@@ -88,7 +88,8 @@ SoilBTreeIndexPage >> latestVersion [
 
 { #category : #testing }
 SoilBTreeIndexPage >> needsCleanup [
-	^ false
+	"We can recycle empty index pages"
+	^ self isEmpty
 ]
 
 { #category : #printing }

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -146,6 +146,12 @@ SoilBasicBTree >> removePage: aPage [
 	| previousPage |
 	(aPage offset > 1) ifFalse: [ ^ aPage ].
 
+	
+	aPage isIndexPage ifTrue: [ 
+		"index pages have no prev or next and are empty when we reach here"
+		store removePageAt: aPage offset.
+		^ aPage ].
+
 	"We use the iterator to find the previousPage, to support old format without backlink"
 	previousPage := aPage latestVersion > 2
 		ifTrue: [self pageAt: aPage previous ]
@@ -160,8 +166,7 @@ SoilBasicBTree >> removePage: aPage [
 	"now remove all keys, this will update the index pages"
 	
 	aPage items reverseDo: [ :item | item ifNotNil: [self removeKey: item key]  ].
-	
-	"finally remove the page from the store"
+	"remove the page from the store"
 	store removePageAt: aPage offset.
 	^ aPage 
 ]


### PR DESCRIPTION
We did not recycle empty index pages. But adding that is fairly easy: The page is empty when we can recycle.

- change #needsCleanup
- add a case for index pages in removePage: (no pref or next pointer to update)

The test testFreePageAddNested shows that we recycle more more pages (overal pages allocated is smaller).

Additional trivial change:
testNoUnusedClasses: add the deprecated classe as knownviolations