### PR TITLE
635-Check-if-we-need--SoilIndexPagereadHeaderFrom

### DIFF
--- a/src/Soil-Core/SoilAbstractBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilAbstractBTreeDataPage.class.st
@@ -155,8 +155,8 @@ SoilAbstractBTreeDataPage >> previous: anObject [
 ]
 
 { #category : #reading }
-SoilAbstractBTreeDataPage >> readFrom: aStream [
-	super readFrom: aStream.
+SoilAbstractBTreeDataPage >> readHeaderFrom: aStream [
+	super readHeaderFrom: aStream.
 	(version > 2) ifTrue: [ 
 		previous := (aStream next: self pointerSize) asInteger].
 	next := (aStream next: self pointerSize) asInteger

--- a/src/Soil-Core/SoilBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilBTreeDataPage.class.st
@@ -22,10 +22,3 @@ SoilBTreeDataPage >> initializeInIndex: aSoilSkipList [
 SoilBTreeDataPage >> latestVersion [
 	^ 3
 ]
-
-{ #category : #reading }
-SoilBTreeDataPage >> readFrom: aStream [ 
-	super readFrom: aStream.
-	self
-		readItemsFrom: aStream
-]

--- a/src/Soil-Core/SoilBTreeHeaderPage.class.st
+++ b/src/Soil-Core/SoilBTreeHeaderPage.class.st
@@ -99,15 +99,8 @@ SoilBTreeHeaderPage >> printOn: aStream [
 ]
 
 { #category : #reading }
-SoilBTreeHeaderPage >> readFrom: aStream [ 
-	super readFrom: aStream.
-	self 
-		readHeaderFrom: aStream;
-		readItemsFrom: aStream
-]
-
-{ #category : #reading }
 SoilBTreeHeaderPage >> readHeaderFrom: aStream [ 
+	super readHeaderFrom: aStream.
 	keySize := (aStream next: 2) asInteger.
 	valueSize := (aStream next: 2) asInteger.
 	lastPageOffset :=(aStream next: self pointerSize) asInteger.

--- a/src/Soil-Core/SoilBTreeIndexPage.class.st
+++ b/src/Soil-Core/SoilBTreeIndexPage.class.st
@@ -98,12 +98,6 @@ SoilBTreeIndexPage >> printOn: aStream [
 ]
 
 { #category : #reading }
-SoilBTreeIndexPage >> readFrom: aStream [ 
-	super readFrom: aStream.
-	self readItemsFrom: aStream
-]
-
-{ #category : #reading }
 SoilBTreeIndexPage >> readItemsFrom: aStream [ 
 	| numberOfItems |
 	"calculate the maximum number of items that can be stored in this

--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -82,8 +82,8 @@ SoilBTreePage >> pointerSize [
 ]
 
 { #category : #reading }
-SoilBTreePage >> readFrom: aStream [ 
-	super readFrom: aStream.
+SoilBTreePage >> readHeaderFrom: aStream [ 
+	super readHeaderFrom: aStream.
 	self readLastTransactionFrom: aStream
 ]
 
@@ -107,10 +107,4 @@ SoilBTreePage >> split: newPage [
 SoilBTreePage >> writeHeaderOn: aStream [ 
 	super writeHeaderOn: aStream.
 	aStream nextPutAll: (lastTransaction asByteArrayOfSize: 8)
-]
-
-{ #category : #writing }
-SoilBTreePage >> writeOn: aStream [ 
-	super writeOn: aStream.
-	self writeItemsOn: aStream
 ]

--- a/src/Soil-Core/SoilIndexItemsPage.class.st
+++ b/src/Soil-Core/SoilIndexItemsPage.class.st
@@ -365,6 +365,12 @@ SoilIndexItemsPage >> presentItemCount [
 ]
 
 { #category : #reading }
+SoilIndexItemsPage >> readFrom: aStream [ 
+	super readFrom: aStream.
+	self readItemsFrom: aStream
+]
+
+{ #category : #reading }
 SoilIndexItemsPage >> readItemsFrom: aStream [ 
 	| numberOfItems |
 	"calculate the maximum number of items that can be stored in this
@@ -424,4 +430,11 @@ SoilIndexItemsPage >> writeItemsOn: aStream [
 			nextPutAll: (assoc key asByteArrayOfSize: self keySize);
 			nextPutAll: (assoc value asByteArrayOfSize: self valueSize)].
 
+]
+
+{ #category : #writing }
+SoilIndexItemsPage >> writeOn: aStream [ 
+	super writeOn: aStream.
+	self writeItemsOn: aStream
+	
 ]

--- a/src/Soil-Core/SoilIndexPage.class.st
+++ b/src/Soil-Core/SoilIndexPage.class.st
@@ -145,6 +145,11 @@ SoilIndexPage >> printOn: aStream [
 { #category : #reading }
 SoilIndexPage >> readFrom: aStream [ 
 	needWrite := false.
+	self readHeaderFrom: aStream
+]
+
+{ #category : #reading }
+SoilIndexPage >> readHeaderFrom: aStream [ 
 	"we do not read the pageCode here as it was read already"
 	version := aStream next
 ]

--- a/src/Soil-Core/SoilSkipListDataPage.class.st
+++ b/src/Soil-Core/SoilSkipListDataPage.class.st
@@ -31,12 +31,10 @@ SoilSkipListDataPage >> latestVersion [
 	^ 3
 ]
 
-{ #category : #'instance creation' }
-SoilSkipListDataPage >> readFrom: aStream [ 
-	super readFrom: aStream.
-	self 
-		readLevelsFrom: aStream;
-		readItemsFrom: aStream
+{ #category : #reading }
+SoilSkipListDataPage >> readHeaderFrom: aStream [ 
+	super readHeaderFrom: aStream.
+	self readLevelsFrom: aStream
 ]
 
 { #category : #writing }

--- a/src/Soil-Core/SoilSkipListHeaderPage.class.st
+++ b/src/Soil-Core/SoilSkipListHeaderPage.class.st
@@ -152,16 +152,8 @@ SoilSkipListHeaderPage >> previous [
 ]
 
 { #category : #reading }
-SoilSkipListHeaderPage >> readFrom: aStream [ 
-	super readFrom: aStream.
-	self 
-		readHeaderFrom: aStream;
-		readLevelsFrom: aStream;
-		readItemsFrom: aStream
-]
-
-{ #category : #reading }
 SoilSkipListHeaderPage >> readHeaderFrom: aStream [
+	super readHeaderFrom: aStream.
 	keySize := (aStream next: 2) asInteger.
 	valueSize := (aStream next: 2) asInteger.
 	maxLevel := (aStream next: 2) asInteger.
@@ -172,7 +164,8 @@ SoilSkipListHeaderPage >> readHeaderFrom: aStream [
 		ifFalse: [ true ].
 	size := (version > 1) 
 		ifTrue: [ (aStream next: 6) asInteger ]
-		ifFalse: [ -1 ]
+		ifFalse: [ -1 ].
+	self readLevelsFrom: aStream
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -181,8 +181,8 @@ SoilSkipListPage >> previous [
 ]
 
 { #category : #reading }
-SoilSkipListPage >> readFrom: aStream [ 
-	super readFrom: aStream.
+SoilSkipListPage >> readHeaderFrom: aStream [ 
+	super readHeaderFrom: aStream.
 	self readLastTransactionFrom: aStream
 ]
 
@@ -264,11 +264,4 @@ SoilSkipListPage >> writeLevelsOn: aStream [
 			aStream nextPutAll: ((left at: n) asByteArrayOfSize: self leftSize) ] ].
 	1 to: self level do: [ :n |
 		aStream nextPutAll: ((right at: n) asByteArrayOfSize: self rightSize) ]
-]
-
-{ #category : #writing }
-SoilSkipListPage >> writeOn: aStream [ 
-	super writeOn: aStream.
-	self writeItemsOn: aStream
-	
 ]


### PR DESCRIPTION
This PR refactors index pages #readFrom: and #readHeaderFrom: to follow the existing structure we use for writing (#writeOn: and #writeHeaderOn:

- in addition, move the #writeItemsOn: sender up to SoilIndexItemsPage

closes #635