### PR TITLE
983-Tests-SkipList-Duplicate-keys 

### DIFF
--- a/src/Soil-Core-Tests/SoilPersistentDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilPersistentDictionaryTest.class.st
@@ -134,6 +134,21 @@ SoilPersistentDictionaryTest >> testAtPut [
 ]
 
 { #category : #tests }
+SoilPersistentDictionaryTest >> testCollect [
+
+	| dict transaction |
+	transaction := soil newTransaction.
+	dict := SoilPersistentDictionary new.
+	transaction makeRoot: dict.
+	dict at: #test put: 'string'.
+	dict at: #test2 put: 'string2'.
+	transaction commit.
+		
+	self assert: ((dict collect: [ :each | each ] ) includes: 'string').
+	self assert: ((dict collect: [ :each | each ] ) includes: 'string2')
+]
+
+{ #category : #tests }
 SoilPersistentDictionaryTest >> testCommitAndRead [
 
 	| dict transaction materialized |
@@ -219,6 +234,21 @@ SoilPersistentDictionaryTest >> testKeys [
 		
 	self assert: (dict keys includes: 'test').
 	self assert: (dict keys includes: 'test2')
+]
+
+{ #category : #tests }
+SoilPersistentDictionaryTest >> testKeysAndValuesDo [
+
+	| dict transaction |
+	transaction := soil newTransaction.
+	dict := SoilPersistentDictionary new.
+	transaction makeRoot: dict.
+	dict at: #test put: 'string'.
+	dict at: #test2 put: 'string2'.
+	transaction commit.
+	dict keysAndValuesDo: [:key :value | 
+		self assert:(key beginsWith: #test).
+		self assert:(value beginsWith: 'string')]
 ]
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilSkipListTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListTest.class.st
@@ -1,11 +1,27 @@
 Class {
 	#name : #SoilSkipListTest,
-	#superclass : #TestCase,
+	#superclass : #ParametrizedTestCase,
 	#instVars : [
-		'index'
+		'index',
+		'uniqueKeys'
 	],
 	#category : #'Soil-Core-Tests-Index'
 }
+
+{ #category : #'building suites' }
+SoilSkipListTest class >> testParameters [
+	^ ParametrizedTestMatrix new
+		addCase: { #uniqueKeys -> true };
+		addCase: { #uniqueKeys -> false };
+		yourself
+]
+
+{ #category : #running }
+SoilSkipListTest >> assertSoilDuplicate: actual equals: expected [
+	uniqueKeys
+		ifTrue: [self assert: actual equals: expected  ]
+		ifFalse: [ self assertCollection: actual hasSameElements: {expected} ] 
+]
 
 { #category : #running }
 SoilSkipListTest >> setUp [ 
@@ -17,7 +33,8 @@ SoilSkipListTest >> setUp [
 		initializeHeaderPage;
 		maxLevel: 4;
 		keySize: 8;
-		valueSize: 8
+		valueSize: 8;
+		uniqueKeys: uniqueKeys
 ]
 
 { #category : #running }
@@ -64,7 +81,7 @@ SoilSkipListTest >> testAddFirstOverflowReload [
 		         initializeFilesystem.
 	"we should be able to do a lookup"
 	self
-		assert: ((index at: capacity) asByteArrayOfSize: 8)
+		assertSoilDuplicate: ((index at: capacity))
 		equals: (capacity asByteArrayOfSize: 8)
 ]
 
@@ -126,10 +143,10 @@ SoilSkipListTest >> testAddInBetweenOverwriting [
 	index at: n add: (n asByteArrayOfSize: 8) ].
 	self assert: index pages size equals: 1.
 	index at: 31 add: #[ 8 7 6 5 4 3 2 1 ].
-	self assert: index pages size equals: 1.
+	self assert: index pages size equals: (uniqueKeys ifTrue: [1] ifFalse: [2]).
 	page := index pageAt: 1.
-	self assert: page numberOfItems equals: 251.
-	self assert: (page items at: 16) value equals: #[ 8 7 6 5 4 3 2 1 ]
+	self assert: page numberOfItems equals: (uniqueKeys ifTrue: [251] ifFalse: [127]).
+	self assert: (page items at: (uniqueKeys ifTrue: [16] ifFalse: [17])) value equals: #[ 8 7 6 5 4 3 2 1 ]
 ]
 
 { #category : #tests }
@@ -160,7 +177,8 @@ SoilSkipListTest >> testAddRandom [
 		         initializeHeaderPage;
 		         maxLevel: 10;
 		         keySize: 512;
-		         valueSize: 512.
+		         valueSize: 512;
+					uniqueKeys: uniqueKeys.
 
 	numEntries := 20.
 	entries := Set new: numEntries.
@@ -177,7 +195,7 @@ SoilSkipListTest >> testAddRandom [
 
 	"can we find all the keys we added?"
 	entries do: [ :each |
-		self assert: (index at: each) equals: (each asByteArrayOfSize: 8) ].
+		self assertSoilDuplicate: (index at: each) equals: (each asByteArrayOfSize: 8) ].
 
 	"iterate index, all should be in entries"
 	index do: [ :each |
@@ -214,7 +232,7 @@ SoilSkipListTest >> testAt [
 
 	"we should be able to find the key that is on the second page"
 	self
-		assert: (index at: capacity + 1)
+		assertSoilDuplicate: (index at: capacity + 1)
 		equals: (capacity + 1 asByteArrayOfSize: 8).
 	self should: [ index at: capacity + 2 ] raise: KeyNotFound
 ]
@@ -253,7 +271,7 @@ SoilSkipListTest >> testFindKey [
 	| value |
 	1 to: 200 do: [ :n | index at: n add: (n asByteArrayOfSize: 8) ].
 	value := index find: 133.
-	self assert: value equals: (133 asByteArrayOfSize: 8)
+	self assertSoilDuplicate: value equals: (133 asByteArrayOfSize: 8)
 ]
 
 { #category : #tests }
@@ -264,7 +282,7 @@ SoilSkipListTest >> testFindKeyReverse [
 	index at: n add: (n asByteArrayOfSize: 8) ].
 	"skipList writePages."
 	value := index find: 133.
-	self assert: value equals: (133 asByteArrayOfSize: 8)
+	self assertSoilDuplicate: value equals: (133 asByteArrayOfSize: 8)
 ]
 
 { #category : #tests }
@@ -296,7 +314,11 @@ SoilSkipListTest >> testFreePageAdd [
 	1 to: 2500 do: [ :n | iterator at: n add: (n asByteArrayOfSize: 8) ].
 	self assert: index headerPage lastPageOffset equals: 10.
 	self assert: index headerPage firstFreePageIndex equals: 0.
-	500 to: 1500 do: [ :n | iterator removeKey: n ].
+	500 to: 1500 do: [ :n | 
+		uniqueKeys 
+			ifTrue: [ iterator removeKey: n  ] 
+			ifFalse: [ iterator removeKey: n value: (n asByteArrayOfSize: 8) ] 
+		].
 	self assert: index headerPage lastPageOffset equals: 10.
 	self assert: index headerPage firstFreePageIndex equals: 0.
 	index cleanUpToVersion: nil.
@@ -313,6 +335,7 @@ SoilSkipListTest >> testFreePageAdd [
 SoilSkipListTest >> testFreePageAddAndDelete [
 
 	| iterator |
+	uniqueKeys ifFalse: [ ^self ]. "test foruniqueKeys only"
 	iterator := index newIterator.
 	1 to: 280 do: [ :n | iterator at: n add: (n asByteArrayOfSize: 8) ].
 	self assert: index headerPage lastPageOffset equals: 2.
@@ -339,7 +362,10 @@ SoilSkipListTest >> testFreePageAddNested [
 	self assert: index headerPage lastPageOffset equals: 1286.
 	self assert: index headerPage firstFreePageIndex equals: 0.
 	"now we free more pages than a free page list has capacity"
-	10 to: 8990 do: [ :n | iterator removeKey: n ].
+	10 to: 8990 do: [ :n | 
+			uniqueKeys 
+			ifTrue: [ iterator removeKey: n  ] 
+			ifFalse: [ iterator removeKey: n value:  (n asByteArrayOfSize: 8)]].
 	index cleanUpToVersion: nil.
 	self assert: index headerPage firstFreePageIndex equals: 3.
 	self assert: (index store pageAt: 3) pageIndexes size equals: 1018.
@@ -367,7 +393,10 @@ SoilSkipListTest >> testFreePageReuse [
 	1 to: 2500 do: [ :n | iterator at: n add: (n asByteArrayOfSize: 8) ].
 	self assert: index headerPage lastPageOffset equals: 10.
 	self assert: index headerPage firstFreePageIndex equals: 0.
-	500 to: 1500 do: [ :n | iterator removeKey: n ].
+	500 to: 1500 do: [ :n | 
+			uniqueKeys 
+			ifTrue: [ iterator removeKey: n  ] 
+			ifFalse: [ iterator removeKey: n value:  (n asByteArrayOfSize: 8)]].
 	index cleanUpToVersion: nil.
 	self assert: index headerPage lastPageOffset equals: 10.
 	2501 to: 2750 do: [ :n |
@@ -388,7 +417,10 @@ SoilSkipListTest >> testFreePageReuseAtEndAppend [
 	1 to: 2500 do: [ :n | iterator at: n add: (n asByteArrayOfSize: 8) ].
 	self assert: index headerPage lastPageOffset equals: 10.
 	self assert: index headerPage firstFreePageIndex equals: 0.
-	500 to: 1500 do: [ :n | iterator removeKey: n ].
+	500 to: 1500 do: [ :n | 
+			uniqueKeys 
+			ifTrue: [ iterator removeKey: n  ] 
+			ifFalse: [ iterator removeKey: n value:  (n asByteArrayOfSize: 8)] ].
 	index cleanUpToVersion: nil.
 	self assert: index headerPage lastPageOffset equals: 10.
 	self
@@ -436,10 +468,10 @@ SoilSkipListTest >> testIndexRewritingWithCleaning [
 	1 to: capacity do: [ :n | index at: n add: SoilObjectId removed ].
 
 	index newPluggableRewriter cleanRemoved rewrite.
-	self assert: index headerPage lastPageOffset equals: 1.
-	self assert: (index pageAt: 1) items size equals: 1.
+	self assert: index headerPage lastPageOffset equals: (uniqueKeys ifTrue: [1] ifFalse: [2]).
+	self assert: (index pageAt: 1) items size equals: (uniqueKeys ifTrue: [1] ifFalse: [251]).
 	self
-		assert: (index at: capacity + 1)
+		assertSoilDuplicate: (index at: capacity + 1)
 		equals: (capacity + 1 asByteArrayOfSize: 8)
 ]
 
@@ -603,6 +635,8 @@ SoilSkipListTest >> testRecyclePage [
 SoilSkipListTest >> testRemoveAllFromPage [
 
 	| entries |
+	uniqueKeys ifFalse: [ ^self skip]. "To check: error with duplicate keys"
+	
 	"We test that after removing all entries from one page, #nextAssociation will continue to the next page"
 	index keySize: 1016. "huge keySize forces multiple pages"
 	entries := #( 104 247 56 281 61 286 66 337 308 1 400 272 347 335 45
@@ -614,7 +648,7 @@ SoilSkipListTest >> testRemoveAllFromPage [
 
 	"can we find all the keys we added?"
 	entries do: [ :each |
-		self assert: (index at: each) equals: (each asByteArrayOfSize: 8) ].
+		self assertSoilDuplicate: (index at: each) equals: (each asByteArrayOfSize: 8) ].
 	"#values iterates using #basicNextAssociation"
 	self assert: index values size equals: entries size.
 
@@ -635,13 +669,11 @@ SoilSkipListTest >> testRemoveKey [
 	removed := index removeKey: 20.
 	self assert: removed equals: (20 asByteArrayOfSize: 8).
 
-	self assert: (index at: 1) equals: (1 asByteArrayOfSize: 8).
-	self
-		assert: (index at: capacity)
-		equals: (capacity asByteArrayOfSize: 8).
+	self assertSoilDuplicate: (index at: 1) equals: (1 asByteArrayOfSize: 8).
+	self assertSoilDuplicate: (index at: capacity) equals: (capacity asByteArrayOfSize: 8).
 	self should: [ index at: 20 ] raise: KeyNotFound.
 	index at: 20 add: (20 asByteArrayOfSize: 8).
-	self assert: (index at: 20) equals: (20 asByteArrayOfSize: 8).
+	self assertSoilDuplicate: (index at: 20) equals: (20 asByteArrayOfSize: 8).
 
 	self should: [ index removeKey: capacity + 1 ] raise: KeyNotFound
 ]
@@ -715,4 +747,16 @@ SoilSkipListTest >> testVersionOneRoundtripAndCompact [
 		compact.
 	self assert: index headerPage version equals: 3.
 	self assert: (index headerPage instVarNamed: #size) equals: 9
+]
+
+{ #category : #accessing }
+SoilSkipListTest >> uniqueKeys [
+
+	^ uniqueKeys
+]
+
+{ #category : #accessing }
+SoilSkipListTest >> uniqueKeys: anObject [
+
+	uniqueKeys := anObject
 ]


### PR DESCRIPTION
- turn SoilSkipListTest into parametrize test.
- add two more tests  SoilPersistentDictionaryTest

added to backlog: testRemoveAllFromPage to check

fixes #983