### PR TITLE
Improve soilSizeInMemory

### DIFF
--- a/src/Soil-Core-Tests/SoilClusterVersionTest.class.st
+++ b/src/Soil-Core-Tests/SoilClusterVersionTest.class.st
@@ -5,6 +5,21 @@ Class {
 }
 
 { #category : #tests }
+SoilClusterVersionTest >> testPersistentClusterVersionMemory [
+	| record |
+	record := SoilPersistentClusterVersion new
+		version: 12;
+		previousVersionPosition: 100;
+		bytes: #[ 9 8 7 6 5 4 3 2 1];
+		behaviorDescriptions: ({ 1 . 2 . 3 } collect: [ : each | SoilBehaviorDescription new 
+			objectId: each asSoilObjectId;
+			version: 10 atRandom ]);
+		references: ({ 4 . 5 . 6 } collect: #asSoilObjectId).
+		
+	self assert: record soilSizeInMemory equals: 224
+]
+
+{ #category : #tests }
 SoilClusterVersionTest >> testPersistentClusterVersionRoundtrip [
 	| record bytes read |
 	record := SoilPersistentClusterVersion new

--- a/src/Soil-Core/OrderedCollection.extension.st
+++ b/src/Soil-Core/OrderedCollection.extension.st
@@ -1,0 +1,8 @@
+Extension { #name : #OrderedCollection }
+
+{ #category : #'*Soil-Core' }
+OrderedCollection >> soilSizeInMemory [
+	^ self sizeInMemory 
+		+ array sizeInMemory 
+		+ self sum: #soilSizeInMemory
+]

--- a/src/Soil-Core/SoilPersistentClusterVersion.class.st
+++ b/src/Soil-Core/SoilPersistentClusterVersion.class.st
@@ -138,13 +138,13 @@ SoilPersistentClusterVersion >> shouldBeCommitted [
 SoilPersistentClusterVersion >> soilSizeInMemory [
 	^ self sizeInMemory 
 		+ objectId soilSizeInMemory 
-		+ (references sum: #soilSizeInMemory) 
+		+ references soilSizeInMemory
 		+ bytes sizeInMemory 
-		+ committed sizeInMemory 
+		"+ committed sizeInMemory" "boolean: shared"
 		+ previousVersionPosition sizeInMemory 
 		+ version sizeInMemory 
-		+ (behaviorDescriptions sum: #soilSizeInMemory) 
-		+ (indexIds sum: #sizeInMemory) 
+		+ behaviorDescriptions soilSizeInMemory
+		+ indexIds soilSizeInMemory
 		+ position sizeInMemory
-		+ changed sizeInMemory 
+		"+ changed sizeInMemory" "boolean: shared"
 ]


### PR DESCRIPTION
To correctly count the memory of OrdredCollections, this PR adds soilSizeInMemory there and uses it in SoilPersistentClusterVersion>>#soilSizeInMemory