### PR TITLE
BehaviorDescription #soilSizeInMemory 

### DIFF
--- a/src/Soil-Core-Tests/SoilClusterVersionTest.class.st
+++ b/src/Soil-Core-Tests/SoilClusterVersionTest.class.st
@@ -13,10 +13,11 @@ SoilClusterVersionTest >> testPersistentClusterVersionMemory [
 		bytes: #[ 9 8 7 6 5 4 3 2 1];
 		behaviorDescriptions: ({ 1 . 2 . 3 } collect: [ : each | SoilBehaviorDescription new 
 			objectId: each asSoilObjectId;
-			version: 10 atRandom ]);
+			version: 10 atRandom;
+			initializeFromBehavior: Point]);
 		references: ({ 4 . 5 . 6 } collect: #asSoilObjectId).
-		
-	self assert: record soilSizeInMemory equals: 224
+	
+	self assert: record soilSizeInMemory equals: 1104
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/Array.extension.st
+++ b/src/Soil-Core/Array.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #Array }
+
+{ #category : #'*Soil-Core' }
+Array >> soilSizeInMemory [
+	^ self sizeInMemory + (self sum: #soilSizeInMemory)
+]

--- a/src/Soil-Core/OrderedCollection.extension.st
+++ b/src/Soil-Core/OrderedCollection.extension.st
@@ -3,6 +3,5 @@ Extension { #name : #OrderedCollection }
 { #category : #'*Soil-Core' }
 OrderedCollection >> soilSizeInMemory [
 	^ self sizeInMemory 
-		+ array sizeInMemory 
-		+ self sum: #soilSizeInMemory
+		+ array soilSizeInMemory
 ]

--- a/src/Soil-Core/SoilFreePage.class.st
+++ b/src/Soil-Core/SoilFreePage.class.st
@@ -62,15 +62,15 @@ SoilFreePage >> isDirty [
 ]
 
 { #category : #testing }
-SoilFreePage >> isFreePage [
-	^ true
-]
-
-{ #category : #testing }
 SoilFreePage >> isEmpty [ 
 	"a free page is always empty. This way we can make a free page 
 	not (yet) removed traversable in a scan"
 	^ true 
+]
+
+{ #category : #testing }
+SoilFreePage >> isFreePage [
+	^ true
 ]
 
 { #category : #testing }

--- a/src/Soil-Serializer-Tests/SoilBehaviorDescriptionTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilBehaviorDescriptionTest.class.st
@@ -1,0 +1,13 @@
+Class {
+	#name : #SoilBehaviorDescriptionTest,
+	#superclass : #TestCase,
+	#category : #'Soil-Serializer-Tests'
+}
+
+{ #category : #tests }
+SoilBehaviorDescriptionTest >> testSoilSizeInMemory [
+	| instance |
+	instance := SoilBehaviorDescription for: Point.
+			
+	self assert: instance soilSizeInMemory equals: 184
+]

--- a/src/Soil-Serializer/SoilBehaviorDescription.class.st
+++ b/src/Soil-Serializer/SoilBehaviorDescription.class.st
@@ -190,6 +190,17 @@ SoilBehaviorDescription >> printOn: aStream [
 	aStream << 'behavior: ' << behaviorIdentifier asString
 ]
 
+{ #category : #comparing }
+SoilBehaviorDescription >> soilSizeInMemory [
+	^ self sizeInMemory 
+		+ instVarNames soilSizeInMemory
+		+ behaviorIdentifier soilSizeInMemory
+		+ objectId soilSizeInMemory 
+		+ classLayout soilSizeInMemory
+		+ version soilSizeInMemory
+		"objectClass is shared"
+]
+
 { #category : #accessing }
 SoilBehaviorDescription >> version [
 	^ version


### PR DESCRIPTION
Another improvement for #soilSizeInMemory

As SoilPersistentClusterVersion has instances of SoilBehaviorDescriptions (while it writes the ID to disk when serialized), we have to count the space of the SoilBehaviorDescription instances, too.
- add soilSizeInMemory to Array (and update OrderedCollection)
- implement soilSizeInMemory for SoilBehaviorDescription
- tests