### PR TITLE
unskip SoilIndexedDictionaryTest>>#testAddToExistingNonEmptyList

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -172,9 +172,8 @@ SoilIndexedDictionaryTest >> testAddToExistingEmptyList [
 { #category : #tests }
 SoilIndexedDictionaryTest >> testAddToExistingNonEmptyList [
 	|  tx tx2 tx3 tx4 |
-	self skip.
-	"create skip list dictionary with a key ..."
-	"... and persist it"
+	"create indexed dictionary with a key ...
+	... and persist it"
 	tx := soil newTransaction.
 	tx root: dict.
 	dict at: #foo put: #one.


### PR DESCRIPTION
testAddToExistingNonEmptyList was skipped, but it is actually green for both btree and skiplist