### PR TITLE
Iterator with duplicate keys: #removeKey: should remove all

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
@@ -901,15 +901,13 @@ SoilIndexIteratorTest >> testRemoveKeyDuplicate [
 	"removing non-existing keys raises KeyNotFound error"
 	self should: [ iterator removeKey: capacity + 1 ] raise: KeyNotFound.
 	"we add a second value for 1"
-	index at: 1 add: 1 asDummySoilObjectId.
-	result := index at: 1.
-	self assertCollection: result hasSameElements: {1 asDummySoilObjectId. 1 asDummySoilObjectId}.
+	index at: 1 add: 2 asDummySoilObjectId.
+	self assertCollection: (index at: 1) hasSameElements: {1 asDummySoilObjectId. 2 asDummySoilObjectId}.
 	result := iterator removeKey: 1.
-	self assertCollection: result hasSameElements: {1 asDummySoilObjectId}.
-	result := iterator removeKey: capacity.
-	self assertCollection: result hasSameElements: {capacity asDummySoilObjectId}.
+	self assertCollection: result hasSameElements: {1 asDummySoilObjectId. 2 asDummySoilObjectId}.
+	
 	"removing the key again raises KeyNotFound, too"
-	self should: [ iterator removeKey: capacity ] raise: KeyNotFound
+	self should: [ iterator removeKey: 1 ] raise: KeyNotFound
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -583,7 +583,7 @@ SoilIndexIterator >> removeKey: key value: value ifAbsent: aBlock [
 SoilIndexIterator >> removeKeyAll: key ifAbsent: aBlock [
 	"we remove all the entries for key"
 	| all |
-	all := self at: key.
+	all := index at: key ifAbsent: aBlock.
 	all do: [ :each | self removeKey: key value: each ].
 	^all
 ]


### PR DESCRIPTION
The PR implements on the level of the iterator to remove all key-value pairs on removeKey: when in duplicate key mode.

(after this is merged, we can see if we can turn the SoillInteratorTest into a 4-way Matrix test uniqkeys yes/no and BTree/SkipList

closes  #1014 (as there is another issue for removeKey: on the index level)