### PR TITLE
Fix main soilSizeInMemory

### DIFF
--- a/src/Soil-Core-Tests/SoilClusterVersionTest.class.st
+++ b/src/Soil-Core-Tests/SoilClusterVersionTest.class.st
@@ -17,7 +17,7 @@ SoilClusterVersionTest >> testPersistentClusterVersionMemory [
 			initializeFromBehavior: Point]);
 		references: ({ 4 . 5 . 6 } collect: #asSoilObjectId).
 		
-	self assert: record soilSizeInMemory equals: 344
+	self assert: record soilSizeInMemory equals: 1128
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/OrderedCollection.extension.st
+++ b/src/Soil-Core/OrderedCollection.extension.st
@@ -3,6 +3,5 @@ Extension { #name : #OrderedCollection }
 { #category : #'*Soil-Core' }
 OrderedCollection >> soilSizeInMemory [
 	^ self sizeInMemory 
-		+ array sizeInMemory 
-		+ (self sum: #soilSizeInMemory)
+		+ array soilSizeInMemory
 ]


### PR DESCRIPTION
for main, as we have Array>>#soilSizeInMemory, we do not need to do the sum in OrderedCollection, but can just call soilSizeInMemory

fix test, it is bigger in main as the test has BehaviorDescriptions (not ids) in the setup for the SoilPersistentClusterVersion (to discuss)