### PR TITLE
Serializer: Use the slot API for reading Ivars

### DIFF
--- a/src/Soil-Serializer/EphemeronLayout.extension.st
+++ b/src/Soil-Serializer/EphemeronLayout.extension.st
@@ -20,6 +20,6 @@ EphemeronLayout >> soilBasicSerialize: anObject with: serializer [
 	basicSize := anObject basicSize.
 
 	serializer nextPutLengthEncodedInteger: basicSize.
-	description instVarNames do: [:ivarName | (anObject instVarNamed: ivarName) soilSerialize: serializer ].
+	description instVarNames do: [:ivarName | ((anObject class slotNamed: ivarName) read: anObject) theNonSoilProxy soilSerialize: serializer ].
 	1 to: basicSize do: [:i | (anObject basicAt: i) soilSerialize: serializer ]
 ]

--- a/src/Soil-Serializer/PointerLayout.extension.st
+++ b/src/Soil-Serializer/PointerLayout.extension.st
@@ -5,7 +5,7 @@ PointerLayout >> soilBasicSerialize: anObject with: serializer [
 	| description |
 	description := serializer serializeBehaviorDescriptionFor: anObject.
 
-	description instVarNames do: [:ivarName | (anObject instVarNamed: ivarName) theNonSoilProxy soilSerialize: serializer ]
+	description instVarNames do: [:ivarName | ((anObject class slotNamed: ivarName) read: anObject) theNonSoilProxy soilSerialize: serializer ]
 ]
 
 { #category : #'*Soil-Serializer' }

--- a/src/Soil-Serializer/VariableLayout.extension.st
+++ b/src/Soil-Serializer/VariableLayout.extension.st
@@ -24,6 +24,6 @@ VariableLayout >> soilBasicSerialize: anObject with: serializer [
 	basicSize := anObject basicSize.
 
 	serializer nextPutLengthEncodedInteger: basicSize.
-	description instVarNames do: [:ivarName | (anObject instVarNamed: ivarName) soilSerialize: serializer ].
+	description instVarNames do: [:ivarName | ((anObject class slotNamed: ivarName) read: anObject) theNonSoilProxy soilSerialize: serializer ].
 	1 to: basicSize do: [:i | (anObject basicAt: i) soilSerialize: serializer ]
 ]

--- a/src/Soil-Serializer/WeakLayout.extension.st
+++ b/src/Soil-Serializer/WeakLayout.extension.st
@@ -20,6 +20,6 @@ WeakLayout >> soilBasicSerialize: anObject with: serializer [
 	basicSize := anObject basicSize.
 
 	serializer nextPutLengthEncodedInteger: basicSize.
-	description instVarNames do: [:ivarName | (anObject instVarNamed: ivarName) soilSerialize: serializer ].
+	description instVarNames do: [:ivarName | ((anObject class slotNamed: ivarName) read: anObject) theNonSoilProxy soilSerialize: serializer ].
 	1 to: basicSize do: [:i | (anObject basicAt: i) soilSerialize: serializer ]
 ]


### PR DESCRIPTION
In the end this is an inlining: This avoids some block creations and message sends.