### PR TITLE
Speedup serializer for classes with no soilTransientInstVars

### DIFF
--- a/src/Soil-Serializer/Class.extension.st
+++ b/src/Soil-Serializer/Class.extension.st
@@ -1,6 +1,14 @@
 Extension { #name : #Class }
 
 { #category : #'*Soil-Serializer' }
+Class >> hasSoilTransientInstVars [
+	"does the hierarchy have any transient vars?"
+	self soilTransientInstVars notEmpty ifTrue: [ ^true ].
+	self allSuperclassesDo: [ :class | class soilTransientInstVars notEmpty ifTrue: [ ^true ] ].
+	^ false
+]
+
+{ #category : #'*Soil-Serializer' }
 Class >> soilBasicSerialize: serializer [
 
 	serializer nextPutClass: self

--- a/src/Soil-Serializer/EphemeronLayout.extension.st
+++ b/src/Soil-Serializer/EphemeronLayout.extension.st
@@ -21,7 +21,7 @@ EphemeronLayout >> soilBasicSerialize: anObject with: serializer [
 	basicSize := anObject basicSize.
 
 	serializer nextPutLengthEncodedInteger: basicSize.
-	(class soilTransientInstVars size == 0) 
+	class hasSoilTransientInstVars
 		ifTrue: [1 to: class instSize do: [:index | (anObject instVarAt: index)  theNonSoilProxy soilSerialize: serializer] ]
 		ifFalse: [description instVarNames do: [:ivarName | ((class slotNamed: ivarName) read: anObject) theNonSoilProxy soilSerialize: serializer ] ].
 	1 to: basicSize do: [:i | (anObject basicAt: i) soilSerialize: serializer ]

--- a/src/Soil-Serializer/Object.extension.st
+++ b/src/Soil-Serializer/Object.extension.st
@@ -36,6 +36,7 @@ Object >> soilMaterialized: materializer [
 
 { #category : #'*Soil-Serializer' }
 Object class >> soilPersistentInstVars [
+	"return the persistent var names of the hierachy"
 	^ self allInstVarNames difference: self soilTransientInstVars 
 ]
 

--- a/src/Soil-Serializer/PointerLayout.extension.st
+++ b/src/Soil-Serializer/PointerLayout.extension.st
@@ -6,9 +6,9 @@ PointerLayout >> soilBasicSerialize: anObject with: serializer [
 	description := serializer serializeBehaviorDescriptionFor: anObject.
 	class := anObject class.
 
-	(class soilTransientInstVars size == 0) 
-		ifTrue: [1 to: class instSize do: [:index | (anObject instVarAt: index)  theNonSoilProxy soilSerialize: serializer] ]
-		ifFalse: [description instVarNames do: [:ivarName | ((class slotNamed: ivarName) read: anObject) theNonSoilProxy soilSerialize: serializer ] ]
+	class hasSoilTransientInstVars 
+		ifFalse: [1 to: class instSize do: [:index | (anObject instVarAt: index)  theNonSoilProxy soilSerialize: serializer] ]
+		ifTrue: [description instVarNames do: [:ivarName | ((class slotNamed: ivarName) read: anObject) theNonSoilProxy soilSerialize: serializer ] ]
 ]
 
 { #category : #'*Soil-Serializer' }

--- a/src/Soil-Serializer/VariableLayout.extension.st
+++ b/src/Soil-Serializer/VariableLayout.extension.st
@@ -25,8 +25,8 @@ VariableLayout >> soilBasicSerialize: anObject with: serializer [
 	basicSize := anObject basicSize.
 
 	serializer nextPutLengthEncodedInteger: basicSize.
-	(class soilTransientInstVars size == 0) 
-		ifTrue: [1 to: class instSize do: [:index | (anObject instVarAt: index)  theNonSoilProxy soilSerialize: serializer] ]
-		ifFalse: [description instVarNames do: [:ivarName | ((class slotNamed: ivarName) read: anObject) theNonSoilProxy soilSerialize: serializer ] ].
+	class hasSoilTransientInstVars 
+		ifFalse: [1 to: class instSize do: [:index | (anObject instVarAt: index)  theNonSoilProxy soilSerialize: serializer] ]
+		ifTrue: [description instVarNames do: [:ivarName | ((class slotNamed: ivarName) read: anObject) theNonSoilProxy soilSerialize: serializer ] ].
 	1 to: basicSize do: [:i | (anObject basicAt: i) soilSerialize: serializer ]
 ]

--- a/src/Soil-Serializer/WeakLayout.extension.st
+++ b/src/Soil-Serializer/WeakLayout.extension.st
@@ -21,8 +21,8 @@ WeakLayout >> soilBasicSerialize: anObject with: serializer [
 	basicSize := anObject basicSize.
 
 	serializer nextPutLengthEncodedInteger: basicSize.
-	(class soilTransientInstVars size == 0) 
-		ifTrue: [1 to: class instSize do: [:index | (anObject instVarAt: index)  theNonSoilProxy soilSerialize: serializer] ]
-		ifFalse: [description instVarNames do: [:ivarName | ((class slotNamed: ivarName) read: anObject) theNonSoilProxy soilSerialize: serializer ] ].
+	class hasSoilTransientInstVars 
+		ifFalse: [1 to: class instSize do: [:index | (anObject instVarAt: index)  theNonSoilProxy soilSerialize: serializer] ]
+		ifTrue: [description instVarNames do: [:ivarName | ((class slotNamed: ivarName) read: anObject) theNonSoilProxy soilSerialize: serializer ] ].
 	1 to: basicSize do: [:i | (anObject basicAt: i) soilSerialize: serializer ]
 ]


### PR DESCRIPTION
When there are no soilTransientInstVars, read the ivars per offset. fxes #1040