### PR TITLE
Simple batch PR: comments, improve tests

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -149,7 +149,7 @@ SoilBTreeTest >> testAddFirstOverflow [
 { #category : #tests }
 SoilBTreeTest >> testAddRandom [
 
-	| numEntries entries |
+	| numEntries entries result |
 	"just some random adding and checking that we can find it. tree is configured to create lots of pages"
 	index
 		keySize: 512;
@@ -163,20 +163,28 @@ SoilBTreeTest >> testAddRandom [
 		| toAdd |
 		toAdd := (numEntries * 20) atRandom.
 		entries add: toAdd.
-		index at: toAdd add: (toAdd asByteArrayOfSize: 8) ].
+		index at: toAdd add: toAdd asDummySoilObjectId ].
 
 	"check size"
 	self assert: index size equals: entries asSet size.
 
 	"can we find all the keys we added?"
 	entries do: [ :each |
-		self assertSoilDuplicate: (index at: each) equals: (each asByteArrayOfSize: 8) ].
+		self assertSoilDuplicate: (index at: each) equals: each asDummySoilObjectId ].
 
 	"iterate index, all should be in entries"
+	
+	result := OrderedCollection new.
+	"we use do: to iterate over the index"
 	index do: [ :each |
-		self assert: each equals: (each asByteArrayOfSize: 8) ].
+		result add: each].
+	
+	entries := (entries collect: #asDummySoilObjectId).
+	result do: [ :each | self assert: (entries includes: each) ].
+	
 	index reverseDo: [ :each |
-		self assert: each equals: (each asByteArrayOfSize: 8) ]
+		result add: each].
+	result do: [ :each | self assert: (entries includes: each) ].
 ]
 
 { #category : #tests }
@@ -473,7 +481,9 @@ SoilBTreeTest >> testIndexRewriting [
 SoilBTreeTest >> testIndexRewritingWithCleaning [
 
 	| capacity |
-	index uniqueKeys ifFalse: [ self skip ]. "need to rewrite to not at at:add:"
+	"we are testing cleanup for iterator level remove
+	This test makes only sense for uniqueKeys as only here we can override a value with a removed ID using at:add:"
+	index uniqueKeys ifFalse: [ ^self ]. 
 	capacity := index firstPage itemCapacity.
 	1 to: capacity + 1 do: [ :n |
 	index at: n add: (n asByteArrayOfSize: 8) ].

--- a/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
@@ -66,7 +66,7 @@ SoilIndexIteratorTest >> tearDown [
 { #category : #tests }
 SoilIndexIteratorTest >> testAddRandom [
 
-	| iterator numEntries entries |
+	| iterator numEntries entries result |
 	"just some random adding and checking that we can find it, configured to create lots of pages"
 	
 	iterator := index newIterator.
@@ -78,7 +78,7 @@ SoilIndexIteratorTest >> testAddRandom [
 		| toAdd |
 		toAdd := (numEntries * 20) atRandom.
 		entries add: toAdd.
-		iterator at: toAdd add: (toAdd asByteArrayOfSize: 8) ].
+		iterator at: toAdd add: toAdd asDummySoilObjectId].
 
 	"check size"
 	self assert: iterator size equals: entries asSet size.
@@ -86,13 +86,19 @@ SoilIndexIteratorTest >> testAddRandom [
 
 	"can we find all the keys we added?"
 	entries do: [ :each |
-		self assertSoilDuplicate: (iterator at: each) equals: (each asByteArrayOfSize: 8) ].
+		self assertSoilDuplicate: (iterator at: each) equals: each asDummySoilObjectId ].
 
-	"iterate index, all should be in entries"
+	result := OrderedCollection new.
+	"we use do: to iterate over the index"
 	iterator do: [ :each |
-		self assert: each equals: (each asByteArrayOfSize: 8) ].
+		result add: each].
+	
+	entries := (entries collect: #asDummySoilObjectId).
+	result do: [ :each | self assert: (entries includes: each) ].
+
 	iterator reverseDo: [ :each |
-		self assert: each equals: (each asByteArrayOfSize: 8) ]
+		result add: each].
+	result do: [ :each | self assert: (entries includes: each) ].
 ]
 
 { #category : #'tests - duplicate keys' }
@@ -177,7 +183,17 @@ SoilIndexIteratorTest >> testAtAdd [
 		ifFalse: [ 
 			"with duplicate keys, we do not return the old value"
 			self assert: return equals: nil.
-			self assertCollection: (iterator at: 1) hasSameElements: {1 asDummySoilObjectId. 2 asDummySoilObjectId}]
+			self assertCollection: (iterator at: 1) hasSameElements: {1 asDummySoilObjectId. 2 asDummySoilObjectId}].
+		
+	return := iterator at: 1 add: 2 asDummySoilObjectId.
+	uniqueKeys 
+		ifTrue: [
+			self assert: return equals: 2 asDummySoilObjectId.
+			self assert: (iterator at: 1) equals: 2 asDummySoilObjectId]
+		ifFalse: [ 
+			"we replace, thus return is not nil"
+			self assert: return equals: 1 asDummySoilObjectId.
+			self assertCollection: (iterator at: 1) hasSameElements: {2 asDummySoilObjectId. 2 asDummySoilObjectId}].
 ]
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -77,7 +77,7 @@ SoilIndexedDictionaryTest >> testAddAndRemoveExistingList [
 
 { #category : #tests }
 SoilIndexedDictionaryTest >> testAddRandom [
-	| tx numEntries entries|
+	| tx numEntries entries result |
 	tx := soil newTransaction.
 	tx root: dict.
 	"just some random adding and checking that we can find it, configured to create lots of pages"
@@ -88,17 +88,27 @@ SoilIndexedDictionaryTest >> testAddRandom [
 	numEntries timesRepeat: [ | toAdd |
 		toAdd := (numEntries*20) atRandom.
 		entries add: toAdd.
-		dict at: toAdd  put: (toAdd asByteArrayOfSize: 8)].
+		dict at: toAdd  put: toAdd asDummySoilObjectId].
 	
 	"check size"
 	self assert: dict size equals: entries size.
 	
 	"can we find all the keys we added?"
-	entries do: [:each | self assert: (dict at: each ) equals: (each asByteArrayOfSize: 8)].
+	entries do: [:each | self assert: (dict at: each ) equals: each asDummySoilObjectId].
 	
 	"iterate index, all should be in entries"
-	dict do: [:each | self assert: each equals: (each asByteArrayOfSize: 8)].
-	dict reverseDo: [:each | self assert: each equals: (each asByteArrayOfSize: 8)]
+	
+	result := OrderedCollection new.
+	"we use do: to iterate over the index"
+	dict do: [ :each |
+		result add: each].
+	
+	entries := (entries collect: #asDummySoilObjectId).
+	result do: [ :each | self assert: (entries includes: each) ].
+	
+	dict reverseDo: [ :each |
+		result add: each].
+	result do: [ :each | self assert: (entries includes: each) ].
 ]
 
 { #category : #tests }
@@ -673,6 +683,31 @@ SoilIndexedDictionaryTest >> testNextCloseTo [
 	self assert: (tx2 root nextCloseTo: #'20') equals: #two.
 	"this is a bit odd, when looking with larger values we get the last one"
 	self assert: (tx2 root nextCloseTo: #'100') equals: #two
+]
+
+{ #category : #tests }
+SoilIndexedDictionaryTest >> testRecoverAddedKeys [
+	| tx tx2 blockedTx |
+	"We test that added keys are not shown in a prior transaction"
+	tx := soil newTransaction.
+	tx root: dict.
+	dict 
+		at: #testkey1 put: 'one';
+		at: #testkey2 put: 'two';
+		at: #testkey3 put: 'three'.
+	tx commit.
+	
+	blockedTx := soil newTransaction.
+	"open a second transaction ..."
+	tx2 := soil newTransaction.
+	self assert: (tx2 root at: #testkey1) equals: 'one'.
+	tx2 root 
+		at: #testkey4 put: 'four'.
+	tx2 commit.
+	"and test last, note: keyorder"
+	self assert: (blockedTx root at: #testkey1) equals: 'one'.
+	self assert: (blockedTx root at: #testkey4 ifAbsent: #notThere) equals: #notThere
+
 ]
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilSkipListTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListTest.class.st
@@ -168,7 +168,7 @@ SoilSkipListTest >> testAddLastFitting [
 { #category : #tests }
 SoilSkipListTest >> testAddRandom [
 
-	| numEntries entries |
+	| numEntries entries result |
 	"just some random adding and checking that we can find it, configured to create lots of pages"
 	index 
 		maxLevel: 10;
@@ -183,20 +183,27 @@ SoilSkipListTest >> testAddRandom [
 		| toAdd |
 		toAdd := (numEntries * 20) atRandom.
 		entries add: toAdd.
-		index at: toAdd add: (toAdd asByteArrayOfSize: 8) ].
+		index at: toAdd add: toAdd asDummySoilObjectId ].
 
 	"check size"
 	self assert: index size equals: entries size.
 
 	"can we find all the keys we added?"
 	entries do: [ :each |
-		self assertSoilDuplicate: (index at: each) equals: (each asByteArrayOfSize: 8) ].
+		self assertSoilDuplicate: (index at: each) equals: each asDummySoilObjectId ].
 
 	"iterate index, all should be in entries"
+	result := OrderedCollection new.
+	"we use do: to iterate over the index"
 	index do: [ :each |
-		self assert: each equals: (each asByteArrayOfSize: 8) ].
+		result add: each].
+	
+	entries := (entries collect: #asDummySoilObjectId).
+	result do: [ :each | self assert: (entries includes: each) ].
+	
 	index reverseDo: [ :each |
-		self assert: each equals: (each asByteArrayOfSize: 8) ]
+		result add: each].
+	result do: [ :each | self assert: (entries includes: each) ].
 ]
 
 { #category : #tests }
@@ -457,7 +464,9 @@ SoilSkipListTest >> testIndexRewriting [
 SoilSkipListTest >> testIndexRewritingWithCleaning [
 
 	| capacity |
-	index uniqueKeys ifFalse: [ self skip ]. "need to rewrite to not at at:add:"
+	index uniqueKeys ifFalse: [ ^ self ]. 
+	"we are testing cleanup for iterator level remove
+	This test makes only sense for uniqueKeys as only here we can override a value with a removed ID using at:add:"
 	capacity := index firstPage itemCapacity.
 	1 to: capacity + 1 do: [ :n |
 	index at: n add: (n asByteArrayOfSize: 8) ].

--- a/src/Soil-Core/Array.extension.st
+++ b/src/Soil-Core/Array.extension.st
@@ -2,5 +2,7 @@ Extension { #name : #Array }
 
 { #category : #'*Soil-Core' }
 Array >> soilSizeInMemory [
+	"recursive #sizeInMemory for Soil. 
+	Note: only works for some objects, e.g. SoilPersistentClusterVersion"
 	^ self sizeInMemory + (self sum: #soilSizeInMemory)
 ]

--- a/src/Soil-Core/Object.extension.st
+++ b/src/Soil-Core/Object.extension.st
@@ -26,7 +26,9 @@ Object >> soilEmit [
 ]
 
 { #category : #'*Soil-Core' }
-Object >> soilSizeInMemory [ 
+Object >> soilSizeInMemory [
+	"recursive #sizeInMemory for Soil. 
+	Note: only works for some objects, e.g. SoilPersistentClusterVersion"
 	^ self sizeInMemory 
 ]
 

--- a/src/Soil-Core/OrderedCollection.extension.st
+++ b/src/Soil-Core/OrderedCollection.extension.st
@@ -2,6 +2,8 @@ Extension { #name : #OrderedCollection }
 
 { #category : #'*Soil-Core' }
 OrderedCollection >> soilSizeInMemory [
+	"recursive #sizeInMemory for Soil. 
+	Note: only works for some objects, e.g. SoilPersistentClusterVersion"
 	^ self sizeInMemory 
 		+ array soilSizeInMemory
 ]

--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -8,9 +8,7 @@ A SoilIndexedDictionary has to be created with a backend, for now we have SoilBT
 Keys are created with #asIndexKeyOfSize: with the keySize being configurable when creating the dictionary. 
 Values are SoilObjectId instances (8 byte). 
 
-The indexes store data on pages (currently 4kb) on disk. 
-
-Take care: SoilIndexedDictionary has to be a root object
+The indexes store data on pages (currently 4kb) on disk.
 "
 Class {
 	#name : #SoilIndexedDictionary,

--- a/src/Soil-Core/SoilObjectId.class.st
+++ b/src/Soil-Core/SoilObjectId.class.st
@@ -178,6 +178,8 @@ SoilObjectId >> setIndex: anInteger [
 
 { #category : #comparing }
 SoilObjectId >> soilSizeInMemory [
+	"recursive #sizeInMemory for Soil. 
+	Note: only works for some objects, e.g. SoilPersistentClusterVersion"
 	^ self sizeInMemory 
 		+ segment sizeInMemory 
 		+ index sizeInMemory 

--- a/src/Soil-Core/SoilPersistentClusterVersion.class.st
+++ b/src/Soil-Core/SoilPersistentClusterVersion.class.st
@@ -127,6 +127,8 @@ SoilPersistentClusterVersion >> shouldBeCommitted [
 
 { #category : #comparing }
 SoilPersistentClusterVersion >> soilSizeInMemory [
+	"recursive #sizeInMemory for Soil. 
+	Note: only works for some objects, e.g. SoilPersistentClusterVersion"
 	^ self sizeInMemory 
 		+ objectId soilSizeInMemory 
 		+ references soilSizeInMemory

--- a/src/Soil-Serializer/SoilBehaviorDescription.class.st
+++ b/src/Soil-Serializer/SoilBehaviorDescription.class.st
@@ -192,6 +192,8 @@ SoilBehaviorDescription >> printOn: aStream [
 
 { #category : #comparing }
 SoilBehaviorDescription >> soilSizeInMemory [
+	"recursive #sizeInMemory for Soil. 
+	Note: only works for some objects, e.g. SoilPersistentClusterVersion"
 	^ self sizeInMemory 
 		+ instVarNames soilSizeInMemory
 		+ behaviorIdentifier soilSizeInMemory


### PR DESCRIPTION
Some trivial small stuff from my backlog:

- add testRecoverAddedKeys, test for uniqkeys=true sometjhing broken with multiple keys
- Improve SoilIndexIteratorTest>>#testAtAdd
- unskip testIndexRewritingWithCleaning for duplicate keys (hard return) and explain why it makes no sense for uniqkeys=true 
- update SoilIndexedDictionary comment: remove note about root
- add comment for #soilSizeInMemory
- fix the assert of all #testAddRandom. do: iterates over the *values*, thus these where not testing anything