### PR TITLE
987-SkipList-with-duplicate-keys-missing-removeKeyvalue-and-removeKey-that-removes-all 

### DIFF
--- a/src/Soil-Core-Tests/SoilSkipListTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListTest.class.st
@@ -676,7 +676,7 @@ SoilSkipListTest >> testRemoveKey [
 	1 to: capacity do: [ :n | index at: n add: (n asByteArrayOfSize: 8) ].
 
 	removed := index removeKey: 20.
-	self assert: removed equals: (20 asByteArrayOfSize: 8).
+	self assertSoilDuplicate: removed equals: (20 asByteArrayOfSize: 8).
 
 	self assertSoilDuplicate: (index at: 1) equals: (1 asByteArrayOfSize: 8).
 	self assertSoilDuplicate: (index at: capacity) equals: (capacity asByteArrayOfSize: 8).

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -46,12 +46,6 @@ SoilBasicBTree >> basicRemoveKey: key ifAbsent: aBlock [
 ]
 
 { #category : #removing }
-SoilBasicBTree >> basicRemoveKey: key value: aValue [
-		"Warning: Low level remove. If the page is empty after, the index will not work anymore, as we need minimal one key for search to work. Caller has to remove the empty page!"
-	^ self basicRemoveKey: key value: aValue ifAbsent: nil
-]
-
-{ #category : #removing }
 SoilBasicBTree >> basicRemoveKey: key value: aValue ifAbsent: aBlock [
 	"Warning: Low level remove. If the page is empty after, the index will not work anymore, as we need minimal one key for search to work. Caller has to remove the empty page!"
 
@@ -196,36 +190,6 @@ SoilBasicBTree >> open [
 { #category : #'instance creation' }
 SoilBasicBTree >> pageClass [
 	^ SoilBTreeDataPage
-]
-
-{ #category : #removing }
-SoilBasicBTree >> removeKey: key value: aValue [
-	^ self
-		removeKey: key 
-		value: aValue
-		ifAbsent: [ KeyNotFound signalFor: key in: self ]
-]
-
-{ #category : #removing }
-SoilBasicBTree >> removeKey: key value: value ifAbsent: aBlock [
-	| return |
-
-	return := self basicRemoveKey: key value: value ifAbsent: aBlock.
-	
-	self dirtyPages copy do: [ :page |
-		"we can remove all empty pages"
-		(page isFreePage not and: [page isEmpty]) ifTrue: [  
-				self cleanPage: page ] ].
-	^return
-]
-
-{ #category : #removing }
-SoilBasicBTree >> removeKeyAll: key ifAbsent: aBlock [
-	"we remove all the entries for key"
-	| all |
-	all := self at: key ifAbsent: [^ aBlock value].
-	all do: [ :each | self basicRemoveKey: key value: each ifAbsent: aBlock ].
-	^all
 ]
 
 { #category : #removing }

--- a/src/Soil-Core/SoilBasicSkipList.class.st
+++ b/src/Soil-Core/SoilBasicSkipList.class.st
@@ -23,6 +23,8 @@ SoilBasicSkipList >> basicRemoveKey: key ifAbsent: aBlock [
 	Caller has to remove the empty page!"
 	
 	| page index |
+	self hasUniqueKeys ifFalse: [ ^ self removeKeyAll: key ifAbsent: aBlock ].
+	
 	page := self newIterator 
 		find: key;
 		currentPage.
@@ -30,6 +32,27 @@ SoilBasicSkipList >> basicRemoveKey: key ifAbsent: aBlock [
 		ifTrue: [ 
 			self decreaseSize.
 			(page itemRemoveIndex: index) value ]
+		ifFalse: [ aBlock value ]
+]
+
+{ #category : #removing }
+SoilBasicSkipList >> basicRemoveKey: key value: aValue ifAbsent: aBlock [
+	"Warning: Low level remove. If the page is empty after, the index will not work anymore, as we need minimal one key for search to work. Caller has to remove the empty page!"
+	| page keyIndex |
+	
+	page := self newIterator 
+		find: key;
+		currentPage.
+	
+	keyIndex := self hasUniqueKeys 
+		ifTrue: [ page itemIndexForKey: key ] 
+		ifFalse: [ page itemIndexForKey: key value: aValue ]. 
+
+	
+	^ keyIndex > 0
+		ifTrue: [ 
+			self decreaseSize.
+			(page itemRemoveIndex: keyIndex) value ]
 		ifFalse: [ aBlock value ]
 ]
 

--- a/src/Soil-Core/SoilIndex.class.st
+++ b/src/Soil-Core/SoilIndex.class.st
@@ -135,6 +135,17 @@ SoilIndex >> basicRemoveKey: key ifAbsent: aBlock [
 ]
 
 { #category : #removing }
+SoilIndex >> basicRemoveKey: key value: aValue [
+		"Warning: Low level remove. If the page is empty after, the index will not work anymore, as we need minimal one key for search to work. Caller has to remove the empty page!"
+	^ self basicRemoveKey: key value: aValue ifAbsent: nil
+]
+
+{ #category : #removing }
+SoilIndex >> basicRemoveKey: key value: aValue ifAbsent: aBlock [ 
+	^ self subclassResponsibility
+]
+
+{ #category : #removing }
 SoilIndex >> cleanPage: page [
 	page canBeRemoved ifFalse: [ ^self ].
 
@@ -277,6 +288,11 @@ SoilIndex >> initialize [
 ]
 
 { #category : #testing }
+SoilIndex >> isBTree [
+	^ self subclassResponsibility
+]
+
+{ #category : #testing }
 SoilIndex >> isEmpty [
 	^ self store headerPage isEmpty
 ]
@@ -310,6 +326,11 @@ SoilIndex >> last [
 { #category : #accessing }
 SoilIndex >> lastPage [
 	^ self newIterator lastPage
+]
+
+{ #category : #removing }
+SoilIndex >> legacyRemovePage: aPage [ 
+	^ self subclassResponsibility
 ]
 
 { #category : #public }
@@ -475,6 +496,36 @@ SoilIndex >> removeKey: key ifAbsent: aBlock [
 		(page isFreePage not and: [page isEmpty]) ifTrue: [  
 				self cleanPage: page ] ].
 	^return
+]
+
+{ #category : #removing }
+SoilIndex >> removeKey: key value: aValue [
+	^ self
+		removeKey: key 
+		value: aValue
+		ifAbsent: [ KeyNotFound signalFor: key in: self ]
+]
+
+{ #category : #removing }
+SoilIndex >> removeKey: key value: value ifAbsent: aBlock [
+	| return |
+
+	return := self basicRemoveKey: key value: value ifAbsent: aBlock.
+	
+	self dirtyPages copy do: [ :page |
+		"we can remove all empty pages"
+		(page isFreePage not and: [page isEmpty]) ifTrue: [  
+				self cleanPage: page ] ].
+	^return
+]
+
+{ #category : #removing }
+SoilIndex >> removeKeyAll: key ifAbsent: aBlock [
+	"we remove all the entries for key"
+	| all |
+	all := self at: key ifAbsent: [^ aBlock value].
+	all do: [ :each | self basicRemoveKey: key value: each ifAbsent: aBlock ].
+	^all
 ]
 
 { #category : #removing }


### PR DESCRIPTION
Implement removeKey: for duplicated keys of the SkipList the same as on the BTree:

- implement removeKey:value:
- clean empty pages after removeKey:value:
- implement removeKey: to remove all for duplicate keys

fixes #987