### PR TITLE
Unify  #itemAt:put:

### DIFF
--- a/src/Soil-Core/SoilIndexItemsPage.class.st
+++ b/src/Soil-Core/SoilIndexItemsPage.class.st
@@ -176,15 +176,15 @@ SoilIndexItemsPage >> itemAt: anInteger ifAbsent: aBlock [
 
 { #category : #accessing }
 SoilIndexItemsPage >> itemAt: key put: anObject [ 
-	self flag: #todo.
-	"this needs to be improved. For itemAt:put: we search twice for the index. This 
-	is to keep the assumption about replacing items. The way this is enforced might 
-	be a strategy object instead soonish"
 	items 
 		findBinaryIndex: [ :each |  key - each key ] 
-		do: [:ind | ind ]
+		do: [:ind | 	| removedItem |
+			removedItem := items at: ind.
+			items at: ind put: (key -> anObject).
+			needWrite := true.
+			^ removedItem ]
 		ifNone: [ KeyNotFound signal: 'this method is just for replacing items' ].
-	^ self addItem: key -> anObject 
+
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -118,24 +118,6 @@ SoilSkipListPage >> isLastPage [
 ]
 
 { #category : #accessing }
-SoilSkipListPage >> itemAt: key put: anObject [ 
-
-	self flag: #todo.
-	"this needs to be improved. For itemAt:put: we search twice for the index. This 
-	is to keep the assumption about replacing items. The way this is enforced might 
-	be a strategy object instead soonish"
-	items 
-		findBinaryIndex: [ :each |  key - each key ] 
-		do: [:ind | 	| removedItem |
-			removedItem := items at: ind.
-			items at: ind put: (key -> anObject).
-			needWrite := true.
-			^ removedItem ]
-		ifNone: [ KeyNotFound signal: 'this method is just for replacing items' ].
-
-]
-
-{ #category : #accessing }
 SoilSkipListPage >> left [
 	^ left
 ]


### PR DESCRIPTION
this move the #itemAt:put: of SkipList up to SoilIndexItemsPage, replacing the two-times searching version (which was calling addItem:).