### PR TITLE
tiny simplification for SoilIndexedDictionary>>#at:put:

### DIFF
--- a/src/Soil-Core/SoilIndexedDictionary.class.st
+++ b/src/Soil-Core/SoilIndexedDictionary.class.st
@@ -53,8 +53,7 @@ SoilIndexedDictionary >> at: key put: anObject [
 
 	| objectId oldValue |
 	objectId := transaction makeRoot: anObject.
-	(self newIterator at: key add: objectId) ifNotNil: [ :value |
-		oldValue := value ].
+	oldValue := self newIterator at: key add: objectId.
 
 	transaction addJournalEntry: (SoilAddKeyEntry new
 			 segment: [ self segment ];


### PR DESCRIPTION
as oldValue is a temp, it will be nil anyway thus the nil check is not needed