### PR TITLE
Refactor #size

### DIFF
--- a/src/Soil-Core/SoilBTreeIterator.class.st
+++ b/src/Soil-Core/SoilBTreeIterator.class.st
@@ -40,16 +40,3 @@ SoilBTreeIterator >> lastPage [
 		 currentPage := self pageAt: currentPage lastItem value ].
 	^ currentPage
 ]
-
-{ #category : #accessing }
-SoilBTreeIterator >> size [ 
-	| headerPage |
-	"size in the header page is only correct if the current transaction
-	read version is bigger than the last modification of the page. If 
-	the header page is newer than the current transaction we need to scan
-	the index for the size"
-	headerPage := index headerPage.
-	^ (readVersion isNil or: [ headerPage lastTransaction > readVersion ]) 
-		ifTrue: [ super size] 
-		ifFalse: [ index size  ]
-]

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -201,11 +201,6 @@ SoilBasicBTree >> rootPage [
 	^ self store pageAt: 2
 ]
 
-{ #category : #accessing }
-SoilBasicBTree >> size [
-	^ self headerPage size
-]
-
 { #category : #splitting }
 SoilBasicBTree >> splitIndexPage: page [ 
 	| newPage |

--- a/src/Soil-Core/SoilBasicSkipList.class.st
+++ b/src/Soil-Core/SoilBasicSkipList.class.st
@@ -137,12 +137,6 @@ SoilBasicSkipList >> removePage: aPage [
 
 ]
 
-{ #category : #accessing }
-SoilBasicSkipList >> size [ 
-	^ self headerPage size
-	
-]
-
 { #category : #private }
 SoilBasicSkipList >> splitPage: aIterator forKey: aKey [
 	| newPage currentPage previousPage nextPageOffset nextPage |

--- a/src/Soil-Core/SoilIndex.class.st
+++ b/src/Soil-Core/SoilIndex.class.st
@@ -569,8 +569,7 @@ SoilIndex >> rewriteUsing: aBlock [
 
 { #category : #accessing }
 SoilIndex >> size [
-	"We iterate over all elements to get the size. Slow!"
-	^ self newIterator size 
+	^ self headerPage size
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -601,7 +601,12 @@ SoilIndexIterator >> reverseDo: aBlock [
 ]
 
 { #category : #accessing }
-SoilIndexIterator >> size [
+SoilIndexIterator >> size [ 
+	^ index size
+]
+
+{ #category : #accessing }
+SoilIndexIterator >> sizeViaIteration [
 	"We iterate over all elements to get the size. Slow!"
 	| sum |
 	sum := 0.

--- a/src/Soil-Core/SoilRestoringIndexIterator.class.st
+++ b/src/Soil-Core/SoilRestoringIndexIterator.class.st
@@ -102,3 +102,17 @@ SoilRestoringIndexIterator >> returnProxyForTransaction: aSoilTransaction [
 		objectRepository: aSoilTransaction;
 		yourself
 ]
+
+{ #category : #accessing }
+SoilRestoringIndexIterator >> size [ 
+	| headerPage |
+	"size in the header page is only correct if the current transaction
+	read version is bigger than the last modification of the page. If 
+	the header page is newer than the current transaction we need to scan
+	the index for the size"
+
+	headerPage := index headerPage.
+	^ (readVersion isNil or: [ headerPage lastTransaction > readVersion ]) 
+		ifTrue: [ self sizeViaIteration ] 
+		ifFalse: [ index size ]
+]

--- a/src/Soil-Core/SoilRestoringIndexIterator.class.st
+++ b/src/Soil-Core/SoilRestoringIndexIterator.class.st
@@ -102,16 +102,3 @@ SoilRestoringIndexIterator >> returnProxyForTransaction: aSoilTransaction [
 		objectRepository: aSoilTransaction;
 		yourself
 ]
-
-{ #category : #accessing }
-SoilRestoringIndexIterator >> size [ 
-	| headerPage |
-	"size in the header page is only correct if the current transaction
-	read version is bigger than the last modification of the page. If 
-	the header page is newer than the current transaction we need to scan
-	the index for the size"
-	headerPage := index headerPage.
-	^ (readVersion isNil or: [ headerPage lastTransaction > readVersion ]) 
-		ifTrue: [ self sizeViaIteration ] 
-		ifFalse: [ index size ]
-]

--- a/src/Soil-Core/SoilRestoringIndexIterator.class.st
+++ b/src/Soil-Core/SoilRestoringIndexIterator.class.st
@@ -102,3 +102,16 @@ SoilRestoringIndexIterator >> returnProxyForTransaction: aSoilTransaction [
 		objectRepository: aSoilTransaction;
 		yourself
 ]
+
+{ #category : #accessing }
+SoilRestoringIndexIterator >> size [ 
+	| headerPage |
+	"size in the header page is only correct if the current transaction
+	read version is bigger than the last modification of the page. If 
+	the header page is newer than the current transaction we need to scan
+	the index for the size"
+	headerPage := index headerPage.
+	^ (readVersion isNil or: [ headerPage lastTransaction > readVersion ]) 
+		ifTrue: [ self sizeViaIteration ] 
+		ifFalse: [ index size ]
+]

--- a/src/Soil-Core/SoilSkipListIterator.class.st
+++ b/src/Soil-Core/SoilSkipListIterator.class.st
@@ -114,16 +114,3 @@ SoilSkipListIterator >> levelAt: anInteger [
 SoilSkipListIterator >> printOn: aStream [ 
 	aStream << 'path: ' << levels asString
 ]
-
-{ #category : #accessing }
-SoilSkipListIterator >> size [ 
-	| headerPage |
-	"size in the header page is only correct if the current transaction
-	read version is bigger than the last modification of the page. If 
-	the header page is newer than the current transaction we need to scan
-	the index for the size"
-	headerPage := index headerPage.
-	^ (readVersion isNil or: [ headerPage lastTransaction > readVersion ]) 
-		ifTrue: [ super size] 
-		ifFalse: [ index size  ]
-]


### PR DESCRIPTION
- the forward of size to the iterator in SoilIndex is overridden in both subclasses to read from headerpage, do that here
- The size in SoilIndexIterator should not be the slow one, as this is very confusing when we fall bacl to the slow case. It is overridden in all subclasses. Use index size here
- add esxplizit #sizeViaIteration
- Move size that accesses readVersion to SoilRestoringIndexIterator

This still has the problem that the #size is different if called via the index vs. the iterator. A next refactoring could change it to *always* forward to the iterator from the index, as we do with many other methods