### PR TITLE
Multikey remove when duplicated value cross page boundaries 

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -255,6 +255,35 @@ SoilBTreeTest >> testAddingDuplicateKeyAcrossPages [
 	self assertCollection: elements hasSameElements: ids
 ]
 
+{ #category : #'tests - duplicate' }
+SoilBTreeTest >> testAddingDuplicateKeyAcrossPagesRemove [
+		"we add so many douplicate keys that we spill over to another page.
+                  Then we delete one key-value from the first and last page. Tests that iterator delete can cross to the next page"
+
+	| capacity iterator page |
+	capacity := index headerPage itemCapacity.
+	index allowDuplicateKeys.
+	iterator := index newIterator.
+	
+	1 to: capacity do: [ :n |
+		iterator at: 1 add: n asDummySoilObjectId ].
+	page := iterator currentPage.
+	1 to: capacity do: [ :n |
+		iterator at: 1 add: (capacity + n) asDummySoilObjectId ].
+	
+	"we really added to a second page"
+	self deny: page identicalTo: iterator currentPage.
+	self assert: index size equals: capacity*2.
+	
+	"we should be able to delete from the first page"
+	iterator := index newIterator.
+	self assertCollection:  (iterator at: 1) includesAll: {1 asDummySoilObjectId}.
+	iterator := index newIterator.
+	"removing the first. Fails"
+	iterator removeKey: 1 value: 1 asDummySoilObjectId.
+	self assert: index size equals: capacity*2-1.
+]
+
 { #category : #tests }
 SoilBTreeTest >> testAt [
 

--- a/src/Soil-Core-Tests/SoilSkipListTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListTest.class.st
@@ -206,7 +206,7 @@ SoilSkipListTest >> testAddRandom [
 	result do: [ :each | self assert: (entries includes: each) ].
 ]
 
-{ #category : #tests }
+{ #category : #'tests - duplicate' }
 SoilSkipListTest >> testAddingDuplicateKeyAcrossPages [
 
 	| elements iterator ids |
@@ -220,6 +220,35 @@ SoilSkipListTest >> testAddingDuplicateKeyAcrossPages [
 	self assert: index size equals: 256.
 	elements := iterator valuesAt: 251.
 	self assertCollection: elements hasSameElements: ids
+]
+
+{ #category : #'tests - duplicate' }
+SoilSkipListTest >> testAddingDuplicateKeyAcrossPagesRemove [
+		"we add so many douplicate keys that we spill over to another page.
+                  Then we delete one key-value from the first and last page. Tests that iterator delete can cross to the next page"
+
+	| capacity iterator page |
+	capacity := index headerPage itemCapacity.
+	index allowDuplicateKeys.
+	iterator := index newIterator.
+	
+	1 to: capacity do: [ :n |
+		iterator at: 1 add: n asDummySoilObjectId ].
+	page := iterator currentPage.
+	1 to: capacity do: [ :n |
+		iterator at: 1 add: (capacity + n) asDummySoilObjectId ].
+	
+	"we really added to a second page"
+	self deny: page identicalTo: iterator currentPage.
+	self assert: index size equals: capacity*2.
+	
+	"we should be able to delete from the first page"
+	iterator := index newIterator.
+	self assertCollection:  (iterator at: 1) includesAll: {1 asDummySoilObjectId}.
+	iterator := index newIterator.
+	"removing the first. Fails"
+	iterator removeKey: 1 value: 1 asDummySoilObjectId.
+	self assert: index size equals: capacity*2-1.
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/SoilAbstractBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilAbstractBTreeDataPage.class.st
@@ -28,6 +28,14 @@ SoilAbstractBTreeDataPage >> find: aKey with: aBTree [
 
 ]
 
+{ #category : #private }
+SoilAbstractBTreeDataPage >> findItem: anItem with: aBTree [
+	"we found a data page, it is here or in a previous page"
+	^(items includes: anItem)
+		ifTrue: [ self ]
+		ifFalse: [ (self previousPageIn: aBTree) findItem: anItem with: aBTree]
+]
+
 { #category : #utilities }
 SoilAbstractBTreeDataPage >> headerSize [
 	^ super headerSize  
@@ -116,6 +124,11 @@ SoilAbstractBTreeDataPage >> previous [
 { #category : #accessing }
 SoilAbstractBTreeDataPage >> previous: anObject [
 	previous := anObject
+]
+
+{ #category : #accessing }
+SoilAbstractBTreeDataPage >> previousPageIn: btree [
+	^btree pageAt: previous
 ]
 
 { #category : #reading }

--- a/src/Soil-Core/SoilBTreeIndexPage.class.st
+++ b/src/Soil-Core/SoilBTreeIndexPage.class.st
@@ -26,6 +26,15 @@ SoilBTreeIndexPage >> find: aKey with: aBTree [
 	^ page find: aKey with: aBTree
 ]
 
+{ #category : #private }
+SoilBTreeIndexPage >> findItem: anItem with: aBTree [
+	| item page |
+	"we are looking for the first page that has the key, there we will continue linear search"
+	item := self findKey: anItem key.
+	page := aBTree pageAt: item value.
+	^ page findItem: anItem with: aBTree
+]
+
 { #category : #searching }
 SoilBTreeIndexPage >> findKey: aKey [
 	items

--- a/src/Soil-Core/SoilBTreeIterator.class.st
+++ b/src/Soil-Core/SoilBTreeIterator.class.st
@@ -32,6 +32,11 @@ SoilBTreeIterator >> findPageFor: indexKey [
 	^currentPage := index rootPage find: indexKey with: index
 ]
 
+{ #category : #private }
+SoilBTreeIterator >> findPageFor: indexKey value: anObject [
+	^currentPage := index rootPage findItem: indexKey->anObject with: index
+]
+
 { #category : #accessing }
 SoilBTreeIterator >> lastPage [
 	"follow the last index entry till reaching a data page"

--- a/src/Soil-Core/SoilBTreePage.class.st
+++ b/src/Soil-Core/SoilBTreePage.class.st
@@ -40,6 +40,11 @@ SoilBTreePage >> find: aKey with: aBTree [
 ]
 
 { #category : #private }
+SoilBTreePage >> findItem: anItem with: aBTree [ 
+	^ self subclassResponsibility
+]
+
+{ #category : #private }
 SoilBTreePage >> findItemBefore: aKey [
 	"like #itemBefore:, but comparung #<= like #find:with:"
 	| item |

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -241,6 +241,11 @@ SoilIndexIterator >> findPageFor: indexKey [
 	^ self subclassResponsibility
 ]
 
+{ #category : #private }
+SoilIndexIterator >> findPageFor: indexKey value: anObject [
+	^ self subclassResponsibility
+]
+
 { #category : #accessing }
 SoilIndexIterator >> first [
 	^ self firstAssociation value
@@ -543,8 +548,8 @@ SoilIndexIterator >> removeKey: key value: value ifAbsent: aBlock [
 	indexKey := index indexKey: key.
 	"We search for the data page for the key to update the value with a removed ID
 	and return the prior value just like #at: would do"
-	self findPageFor: indexKey.
-
+	self findPageFor: indexKey value: value.
+	
 	self flag: #todo.
 	"this is a hack to be able to find the first occurrence but in a 
 	very inefficient way"

--- a/src/Soil-Core/SoilSkipListIterator.class.st
+++ b/src/Soil-Core/SoilSkipListIterator.class.st
@@ -77,6 +77,17 @@ SoilSkipListIterator >> findPageFor: indexKey [
 	^ currentPage 
 ]
 
+{ #category : #private }
+SoilSkipListIterator >> findPageFor: indexKey value: anObject [
+	| page |
+	page := self findPageFor: indexKey.
+	
+	[(page items includes: indexKey->anObject) or: [page isHeaderPage] ] 
+		whileFalse: [ page := page previousPageIn: index].
+	
+	^currentPage := page
+]
+
 { #category : #accessing }
 SoilSkipListIterator >> index: aSoilSkipList [ 
 	super index: aSoilSkipList.

--- a/src/Soil-Core/SoilSkipListPage.class.st
+++ b/src/Soil-Core/SoilSkipListPage.class.st
@@ -127,6 +127,11 @@ SoilSkipListPage >> previous [
 	^ self leftAt: 1
 ]
 
+{ #category : #accessing }
+SoilSkipListPage >> previousPageIn: anIndex [
+	^anIndex pageAt: self previous
+]
+
 { #category : #reading }
 SoilSkipListPage >> readHeaderFrom: aStream [ 
 	super readHeaderFrom: aStream.


### PR DESCRIPTION
- add a #findPageFor:value: method to the iterator. It will lookup in the index using the key, which for both BTree and SkipList returns the *last* page where a duplicated key is stored. If we do not find the key->value there, we go the the priorPage until we find the item (or read the headerPage).

- Use this in removeKey:value: ifAbsent: 

testAddingDuplicateKeyAcrossPagesRemove is green for both BTree and SkipList


Fixes   #1006