### PR TITLE
More tests for duplicated keys / cleanup iterator #valuesAt:

### DIFF
--- a/src/Soil-Core-Tests/SoilBTreeTest.class.st
+++ b/src/Soil-Core-Tests/SoilBTreeTest.class.st
@@ -242,16 +242,15 @@ SoilBTreeTest >> testAddSecondOverflowReload [
 { #category : #'tests - duplicate' }
 SoilBTreeTest >> testAddingDuplicateKeyAcrossPages [
 
-	| elements iterator ids |
+	| elements ids |
 	index allowDuplicateKeys.
-	iterator := index newIterator.
-	1 to: 250 do: [ :n | iterator at: n add: n asDummySoilObjectId ].
+	1 to: 250 do: [ :n | index at: n add: n asDummySoilObjectId ].
 	ids := OrderedCollection new.
 	1 to: 6 do: [ :n |
 		ids add: n asDummySoilObjectId.
-		iterator at: 251 add: n asDummySoilObjectId ].
+		index at: 251 add: n asDummySoilObjectId ].
 	self assert: index size equals: 256.
-	elements := iterator valuesAt: 251.
+	elements := index at: 251.
 	self assertCollection: elements hasSameElements: ids
 ]
 
@@ -276,10 +275,9 @@ SoilBTreeTest >> testAddingDuplicateKeyAcrossPagesRemove [
 	self assert: index size equals: capacity*2.
 	
 	"we should be able to delete from the first page"
+	self assertCollection:  (index at: 1) includesAll: {1 asDummySoilObjectId}.
 	iterator := index newIterator.
-	self assertCollection:  (iterator at: 1) includesAll: {1 asDummySoilObjectId}.
-	iterator := index newIterator.
-	"removing the first. Fails"
+	"removing the first"
 	iterator removeKey: 1 value: 1 asDummySoilObjectId.
 	self assert: index size equals: capacity*2-1.
 ]

--- a/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexIteratorTest.class.st
@@ -128,6 +128,45 @@ SoilIndexIteratorTest >> testAddingDuplicateKeyAcrossPages [
 	self assertCollection: elements hasSameElements: ids
 ]
 
+{ #category : #'tests - duplicate keys' }
+SoilIndexIteratorTest >> testAddingDuplicateKeyAcrossPagesAndRemoveOverflow [
+	"test that if we overflow, we can remove all overflowed and after still lookup in the index"
+
+	| capacity elements iterator page ids idsInOverFlow |
+	capacity := index headerPage itemCapacity.
+	index allowDuplicateKeys.
+	iterator := index newIterator.
+	ids := OrderedCollection new.
+	1 to: capacity do: [ :n |
+		ids add: n asDummySoilObjectId.
+		iterator at: 1 add: n asDummySoilObjectId ].
+	
+	page := iterator currentPage.
+	
+	idsInOverFlow := OrderedCollection new.
+	1 to: capacity do: [ :n |
+		idsInOverFlow add: (capacity + n) asDummySoilObjectId.
+		iterator at: 1 add: (capacity + n) asDummySoilObjectId ].
+	
+	self deny: page identicalTo: iterator currentPage.
+	self assert: iterator size equals: capacity*2.
+	self assert: index size equals: capacity*2.
+	
+	"now we remove all from the overflow page"
+	idsInOverFlow do: [ :each |
+		 iterator removeKey: 1 value: each
+		 ].
+	
+	"we can override the first"
+	iterator at: 1 add: 1  asDummySoilObjectId.
+	"we can ask for all values and get the one added to the first page"
+	elements := iterator at: 1.
+	self assertCollection: elements hasSameElements: ids.
+	
+	"and remove the first"
+	iterator removeKey: 1 value: 1  asDummySoilObjectId.
+]
+
 { #category : #tests }
 SoilIndexIteratorTest >> testAssociationsDo [
 

--- a/src/Soil-Core-Tests/SoilSkipListTest.class.st
+++ b/src/Soil-Core-Tests/SoilSkipListTest.class.st
@@ -211,14 +211,13 @@ SoilSkipListTest >> testAddingDuplicateKeyAcrossPages [
 
 	| elements iterator ids |
 	index allowDuplicateKeys.
-	iterator := index newIterator.
-	1 to: 250 do: [ :n | iterator at: n add: n asDummySoilObjectId ].
+	1 to: 250 do: [ :n | index at: n add: n asDummySoilObjectId ].
 	ids := OrderedCollection new.
 	1 to: 6 do: [ :n |
 		ids add: n asDummySoilObjectId.
-		iterator at: 251 add: n asDummySoilObjectId ].
+		index at: 251 add: n asDummySoilObjectId ].
 	self assert: index size equals: 256.
-	elements := iterator valuesAt: 251.
+	elements := index at: 251.
 	self assertCollection: elements hasSameElements: ids
 ]
 

--- a/src/Soil-Core/SoilBasicBTree.class.st
+++ b/src/Soil-Core/SoilBasicBTree.class.st
@@ -47,12 +47,10 @@ SoilBasicBTree >> basicRemoveKey: key ifAbsent: aBlock [
 ]
 
 { #category : #removing }
-SoilBasicBTree >> basicRemoveKey: key value: aValue ifAbsent: aBlock [
+SoilBasicBTree >> basicRemoveKey: key value: value ifAbsent: aBlock [
 	"Warning: Low level remove. If the page is empty after, the index will not work anymore, as we need minimal one key for search to work. Caller has to remove the empty page!"
 
-	^ (self rootPage removeItem: key -> aValue for: self)
-		  ifNil: [ aBlock value ]
-		  ifNotNil: [ :removedItem | removedItem value ]
+	^ self basicRemoveItem: key->value ifAbsent: aBlock
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -310,24 +310,6 @@ SoilIndexIterator >> isEmpty [
  		  	(self restoreItem: each) isNil ]]
 ]
 
-{ #category : #private }
-SoilIndexIterator >> itemsAt: key [ 
-	"still need to restore."
-	| assoc items |
-	currentKey := index indexKey: key.
-	self findPageFor: currentKey.
-	currentPageIndex := currentPage indexOfKey: currentKey.
-	assoc := self previousAssociation.
-	[ assoc notNil and: [ assoc key = key ] ] whileTrue: [ 
-		assoc := self previousAssociation ].
-	assoc := self nextAssociation.
-	items := OrderedCollection new.
-	[ assoc notNil and: [ assoc key = key ] ] whileTrue: [ 
-	   items add: assoc.
-	   assoc := self nextAssociation ].
-	^ items 
-]
-
 { #category : #accessing }
 SoilIndexIterator >> last [
 	^ self lastAssociation value
@@ -626,9 +608,4 @@ SoilIndexIterator >> values [
 	self do: [ :each |
 		values add: each ].
 	^ values
-]
-
-{ #category : #enumerating }
-SoilIndexIterator >> valuesAt: key [
-	^ (self itemsAt: key) collect: #value
 ]


### PR DESCRIPTION
- simplify SoilBasicBTree>>#basicRemoveKey:value:ifAbsent:
- testAddingDuplicateKeyAcrossPages on level of index should not use iterator
- add iterator level testAddingDuplicateKeyAcrossPagesAndRemoveOverflow
- remove unused iterator valuesAt: / itemsAt: