### PR TITLE
Serializer: CompiledMethod improvementeds

### DIFF
--- a/src/Soil-Serializer-Tests/SoilStandaloneSerializationTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilStandaloneSerializationTest.class.st
@@ -60,6 +60,8 @@ SoilStandaloneSerializationTest >> testSerializationCompiledMethodLayout [
 
 	self assert: materialized bytecodes equals: object bytecodes.
 	self assert: materialized literals equals: object literals.
+	"class binding has been re-looked up on materialize, too"
+	self assert: materialized classBinding equals: object classBinding.
 	self assert: materialized equals: object.
 	self
 		assert: materialized class classLayout class
@@ -81,6 +83,29 @@ SoilStandaloneSerializationTest >> testSerializationCompiledMethodLayoutCompiled
 	self assert: materialized bytecodes equals: object bytecodes.
  	self assert: materialized literals equals: object literals.
  	self assert: materialized class classLayout class equals: CompiledMethodLayout
+]
+
+{ #category : #'tests-layouts' }
+SoilStandaloneSerializationTest >> testSerializationCompiledMethodWithGlobal [
+
+	| object serialized materialized |
+	"We use CompiledMethod as an exampe of a class with a CompiledMethodLayout"
+	object := (Behavior>>#subclassDefinerClass) copy.
+
+	self
+		assert: object class classLayout class
+		equals: CompiledMethodLayout.
+	serialized := object soilSerialize.
+	materialized := serialized soilMaterialize.
+
+	self assert: materialized bytecodes equals: object bytecodes.
+	self assert: materialized literals equals: object literals.
+	"class binding has been re-looked up on materialize, too"
+	self assert: materialized classBinding equals: object classBinding.
+	self assert: materialized equals: object.
+	self
+		assert: materialized class classLayout class
+		equals: CompiledMethodLayout
 ]
 
 { #category : #'test-blocks' }

--- a/src/Soil-Serializer/LiteralVariable.extension.st
+++ b/src/Soil-Serializer/LiteralVariable.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : #LiteralVariable }
+
+{ #category : #'*Soil-Serializer' }
+LiteralVariable class >> soilTransientInstVars [
+	"We store LiteralVariables, but without the value. This way materialization can re-lookup by name"
+	^ #(value)
+]

--- a/src/Soil-Serializer/SoilMaterializer.class.st
+++ b/src/Soil-Serializer/SoilMaterializer.class.st
@@ -156,10 +156,20 @@ SoilMaterializer >> nextCompiledMethod11: aClass [
 
 	self registerObject: compiledMethod.
 
- 	"first the literals"	
- 	"for now we do store the class pointer in the last literal"	
- 	1 to: compiledMethod numLiterals do: [:i | 
- 				compiledMethod literalAt: i  put: self nextSoilObject ].			
+ 	"first the literals"
+	1 to: compiledMethod numLiterals do: [ :i |		
+		compiledMethod literalAt: i put: self nextSoilObject ].
+	
+	
+	"LiteralVariables have been restored as new instances pointing to nil, we now do a pass to re-lookup. We have to do this as a second pass as the last literal encodes the class name we have to use to re-lookup"
+	
+	1 to: compiledMethod numLiterals do: [ :i |	 | literal className class |	
+		className :=  (compiledMethod literalAt: compiledMethod numLiterals) name.
+		class := Smalltalk globals at: className.
+		literal := compiledMethod literalAt: i.
+		(literal isKindOf: LiteralVariable) ifTrue: [ 
+			compiledMethod literalAt: i put: (class lookupVar: literal name).
+			 ]  ].
 
  	"then the bytecodes, we ignore the trailer for now"
  	compiledMethod initialPC 
@@ -186,9 +196,19 @@ SoilMaterializer >> nextCompiledMethod12: aClass [
 	self registerObject: compiledMethod.
 
 	"first the literals"
-	"for now we do store the class pointer in the last literal"
-	1 to: compiledMethod numLiterals do: [ :i |
-	compiledMethod literalAt: i put: self nextSoilObject ].
+	1 to: compiledMethod numLiterals do: [ :i |		
+		compiledMethod literalAt: i put: self nextSoilObject ].
+	
+	
+	"LiteralVariables have been restored as new instances pointing to nil, we now do a pass to re-lookup. We have to do this as a second pass as the last literal encodes the class name we have to use to re-lookup"
+	
+	1 to: compiledMethod numLiterals do: [ :i |	 | literal className class |	
+		className :=  (compiledMethod literalAt: compiledMethod numLiterals) name.
+		class := Smalltalk globals at: className.
+		literal := compiledMethod literalAt: i.
+		(literal isKindOf: LiteralVariable) ifTrue: [ 
+			compiledMethod literalAt: i put: (class lookupVar: literal name).
+			 ]  ].
 
 	"then the bytecodes, we ignore the trailer for now"
 	compiledMethod initialPC 

--- a/src/Soil-Serializer/SoilSerializer.class.st
+++ b/src/Soil-Serializer/SoilSerializer.class.st
@@ -81,11 +81,12 @@ SoilSerializer >> nextPutCompiledMethod: aCompiledMethod [
 		nextPutByte: TypeCodeCompiledMethod;
 		nextPutInteger: aCompiledMethod header;
 		nextPutLengthEncodedInteger: bytecodesPlusTrailerSize.
-	"literals"
-	"for now we do store the class pointer in the last literal"
+	"we store all literals"
+	"LiteralVariable (and subclasses) do not store the value, we will re-lookup by name (or create an Undeclared) on materialization.
+	The classBinding (last literal) is a GlobalVariable, too"
 	1 to: aCompiledMethod numLiterals do: [ :i | 
 		(aCompiledMethod literalAt: i) soilSerialize: self ].
-	"variable part"
+	"variable part, we do *not* store the sourcePointer for now"
 	self nextPutBytesFrom: aCompiledMethod bytecodes
 	
 ]


### PR DESCRIPTION
Fix handling of LiteralVariable and the class binding in the last literal

- do not store the value of LiteralVariables On Materialize:

	- re-lookup class by name on materialize
	- re-lookup all Literal Vars by name in the class