### PR TITLE
Index: reduce checks of #hasUniqueKeys

### DIFF
--- a/src/Soil-Core/SoilAbstractBTreeDataPage.class.st
+++ b/src/Soil-Core/SoilAbstractBTreeDataPage.class.st
@@ -151,9 +151,7 @@ SoilAbstractBTreeDataPage >> remove: aKey for: aBTree [
 SoilAbstractBTreeDataPage >> removeItem: anItem for: aBTree [
 	"remove and return the item"
 	| return keyIndex | 
-	keyIndex := aBTree hasUniqueKeys 
-		ifTrue: [ self itemIndexForKey: anItem key ] 
-		ifFalse: [ self itemIndexForKey: anItem key value: anItem value ]. 
+	keyIndex := self itemIndexForKey: anItem key value: anItem value. 
 	
 	keyIndex = 0 ifTrue: [ ^nil ]. "nothing found"
 	

--- a/src/Soil-Core/SoilBasicSkipList.class.st
+++ b/src/Soil-Core/SoilBasicSkipList.class.st
@@ -44,9 +44,7 @@ SoilBasicSkipList >> basicRemoveKey: key value: aValue ifAbsent: aBlock [
 		find: key;
 		currentPage.
 	
-	keyIndex := self hasUniqueKeys 
-		ifTrue: [ page itemIndexForKey: key ] 
-		ifFalse: [ page itemIndexForKey: key value: aValue ]. 
+	keyIndex := page itemIndexForKey: key value: aValue. 
 
 	
 	^ keyIndex > 0

--- a/src/Soil-Core/SoilIndexIterator.class.st
+++ b/src/Soil-Core/SoilIndexIterator.class.st
@@ -535,9 +535,7 @@ SoilIndexIterator >> removeKey: key value: value ifAbsent: aBlock [
 	self flag: #todo.
 	"this is a hack to be able to find the first occurrence but in a 
 	very inefficient way"
-	currentPageIndex := index hasUniqueKeys 
-		ifTrue: [ currentPage itemIndexForKey: indexKey ] 
-		ifFalse: [ currentPage itemIndexForKey: indexKey value: value ]. 
+	currentPageIndex := currentPage itemIndexForKey: indexKey value: value. 
 	currentKey := (currentPage items at: currentPageIndex ifAbsent: [ ^ aBlock value ]) key. 
 	
 	item :=  self restoreItem: (currentPage itemAtIndex: currentPageIndex).


### PR DESCRIPTION
For some cases we do a hasUniqueKeys check where it is not needed: we have key and value for both cases