### PR TITLE
soilRecursiveHash: use offsets to read ivars if possible

### DIFF
--- a/src/Soil-Core/EphemeronLayout.extension.st
+++ b/src/Soil-Core/EphemeronLayout.extension.st
@@ -6,19 +6,16 @@ EphemeronLayout >> soilRecursiveHash: anObject with: aSet [
 	(aSet includes: anObject) ifTrue: [ ^ 0 ].
 	aSet add: anObject.
 	hash := anObject basicIdentityHash bitXor: slotScope basicIdentityHash.
-	slots := self allSlots.
 	host hasSoilTransientInstVars 
-		ifTrue: [  
+		ifTrue: [
+			slots := self allSlots.
 			transient := host soilTransientInstVars.
 			1 to: slots size do: [ :n | | slot |
 				slot := slots at: n.
 				(transient includes: slot name) ifFalse: [  
-				hash := hash bitXor: ((slot read: anObject) soilRecursiveHashWith: aSet) * n ] ].
-			^ hash ]
+				hash := hash bitXor: ((slot read: anObject) soilRecursiveHashWith: aSet) * n ] ] ]
 		ifFalse: [ 
-			1 to: slots size do: [ :n | | slot |
-				slot := slots at: n. 
-				hash := hash bitXor: ((slot read: anObject) soilRecursiveHashWith: aSet) * n ].
-			^ hash ]
-
+			1 to: anObject class instSize do: [ :n | 
+				hash := hash bitXor: ((anObject instVarAt: n) soilRecursiveHashWith: aSet) * n ]].
+		^ hash
 ]

--- a/src/Soil-Core/FixedLayout.extension.st
+++ b/src/Soil-Core/FixedLayout.extension.st
@@ -6,19 +6,18 @@ FixedLayout >> soilRecursiveHash: anObject with: aSet [
 	(aSet includes: anObject) ifTrue: [ ^ 0 ].
 	aSet add: anObject.
 	hash := anObject basicIdentityHash bitXor: slotScope basicIdentityHash.
-	slots := self allSlots.
+	
 	host hasSoilTransientInstVars 
 		ifTrue: [  
+			slots := self allSlots.
 			transient := host soilTransientInstVars.
 			1 to: slots size do: [ :n | | slot |
 				slot := slots at: n.
 				(transient includes: slot name) ifFalse: [  
-				hash := hash bitXor: ((slot read: anObject) soilRecursiveHashWith: aSet) * n ] ].
-			^ hash ]
+				hash := hash bitXor: ((slot read: anObject) soilRecursiveHashWith: aSet) * n ] ]]
 		ifFalse: [ 
-			1 to: slots size do: [ :n | | slot |
-				slot := slots at: n. 
-				hash := hash bitXor: ((slot read: anObject) soilRecursiveHashWith: aSet) * n ].
-			^ hash ]
+			1 to: anObject class instSize do: [ :n | 
+				hash := hash bitXor: ((anObject instVarAt: n) soilRecursiveHashWith: aSet) * n ]].
+		^ hash
 
 ]


### PR DESCRIPTION
soilRecursiveHash:with: for FixedLayout can use indexes for reading if there are no transient instvars. Avoids creating the allSlots array