### PR TITLE
soilRecursiveHash: add support for Slots in VariableLayout classes

### DIFF
--- a/src/Soil-Core/VariableLayout.extension.st
+++ b/src/Soil-Core/VariableLayout.extension.st
@@ -7,9 +7,23 @@ VariableLayout >> soilRecursiveHash: anObject with: aSet [
 	aSet add: anObject.
 
 	hash := anObject basicIdentityHash.
+	
 	1 to: anObject basicSize do: [ :idx |
 		"bitXor: all elements. Take the position in the collection into account in
 		order to detect if elements change position in the collection"
 		hash := hash bitXor: ((anObject basicAt: idx) soilRecursiveHashWith: aSet) * idx ].
+	
+	host hasSoilTransientInstVars 
+		ifTrue: [  | slots transient |
+			slots := self allSlots.
+			transient := host soilTransientInstVars.
+			1 to: slots size do: [ :n | | slot |
+				slot := slots at: n.
+				(transient includes: slot name) ifFalse: [  
+				hash := hash bitXor: ((slot read: anObject) soilRecursiveHashWith: aSet) * n ] ]]
+		ifFalse: [ 
+			1 to: anObject class instSize do: [ :n | 
+				hash := hash bitXor: ((anObject instVarAt: n) soilRecursiveHashWith: aSet) * n ]].
+	
 	^ hash 
 ]

--- a/src/Soil-Core/WeakLayout.extension.st
+++ b/src/Soil-Core/WeakLayout.extension.st
@@ -11,5 +11,18 @@ WeakLayout >> soilRecursiveHash: anObject with: aSet [
 	hash := anObject basicIdentityHash.
 	1 to: anObject basicSize do: [ :n |
 		hash := hash bitXor: ((anObject basicAt: n) soilRecursiveHashWith: aSet) * n ].
+	
+	host hasSoilTransientInstVars 
+		ifTrue: [  | slots transient |
+			slots := self allSlots.
+			transient := host soilTransientInstVars.
+			1 to: slots size do: [ :n | | slot |
+				slot := slots at: n.
+				(transient includes: slot name) ifFalse: [  
+				hash := hash bitXor: ((slot read: anObject) soilRecursiveHashWith: aSet) * n ] ]]
+		ifFalse: [ 
+			1 to: host instSize do: [ :n | 
+				hash := hash bitXor: ((anObject instVarAt: n) soilRecursiveHashWith: aSet) * n ]].
+	
 	^ hash 
 ]

--- a/src/Soil-Serializer/VariableLayout.extension.st
+++ b/src/Soil-Serializer/VariableLayout.extension.st
@@ -18,15 +18,14 @@ VariableLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer 
 
 { #category : #'*Soil-Serializer' }
 VariableLayout >> soilBasicSerialize: anObject with: serializer [
-	| description class basicSize|
+	| description basicSize|
 
 	description := serializer serializeBehaviorDescriptionFor: anObject.
-	class := anObject class.
 	basicSize := anObject basicSize.
 
 	serializer nextPutLengthEncodedInteger: basicSize.
-	class hasSoilTransientInstVars 
-		ifFalse: [1 to: class instSize do: [:index | (anObject instVarAt: index)  theNonSoilProxy soilSerialize: serializer] ]
-		ifTrue: [description instVarNames do: [:ivarName | ((class slotNamed: ivarName) read: anObject) theNonSoilProxy soilSerialize: serializer ] ].
+	host hasSoilTransientInstVars 
+		ifFalse: [1 to: host instSize do: [:index | (anObject instVarAt: index)  theNonSoilProxy soilSerialize: serializer] ]
+		ifTrue: [description instVarNames do: [:ivarName | ((host slotNamed: ivarName) read: anObject) theNonSoilProxy soilSerialize: serializer ] ].
 	1 to: basicSize do: [:i | (anObject basicAt: i) soilSerialize: serializer ]
 ]

--- a/src/Soil-Serializer/WeakLayout.extension.st
+++ b/src/Soil-Serializer/WeakLayout.extension.st
@@ -14,15 +14,14 @@ WeakLayout >> soilBasicMaterialize: aBehaviorDescription with: materializer [
 
 { #category : #'*Soil-Serializer' }
 WeakLayout >> soilBasicSerialize: anObject with: serializer [
-	| description class basicSize|
+	| description basicSize|
 
 	description := serializer serializeBehaviorDescriptionFor: anObject.
-	class := anObject class.
 	basicSize := anObject basicSize.
 
 	serializer nextPutLengthEncodedInteger: basicSize.
-	class hasSoilTransientInstVars 
-		ifFalse: [1 to: class instSize do: [:index | (anObject instVarAt: index)  theNonSoilProxy soilSerialize: serializer] ]
-		ifTrue: [description instVarNames do: [:ivarName | ((class slotNamed: ivarName) read: anObject) theNonSoilProxy soilSerialize: serializer ] ].
+	host hasSoilTransientInstVars 
+		ifFalse: [1 to: host instSize do: [:index | (anObject instVarAt: index)  theNonSoilProxy soilSerialize: serializer] ]
+		ifTrue: [description instVarNames do: [:ivarName | ((host slotNamed: ivarName) read: anObject) theNonSoilProxy soilSerialize: serializer ] ].
 	1 to: basicSize do: [:i | (anObject basicAt: i) soilSerialize: serializer ]
 ]


### PR DESCRIPTION
- add support for Slots in VariableLayout and WeakLayout (there are near no users, WeakMessageSend is one)
- use "host" instead of "anObject class" for serialization