### PR TITLE
if read-only is in check mode we need to collect with fingerprint.

### DIFF
--- a/src/Soil-Core/SoilObjectId.class.st
+++ b/src/Soil-Core/SoilObjectId.class.st
@@ -187,6 +187,11 @@ SoilObjectId >> setIndex: anInteger [
 	index := anInteger 
 ]
 
+{ #category : #'as yet unclassified' }
+SoilObjectId >> soilRecursiveHashWith: aSet [ 
+	^ (segment soilRecursiveHashWith: aSet) bitXor: (index soilRecursiveHashWith: aSet)
+]
+
 { #category : #comparing }
 SoilObjectId >> soilSizeInMemory [
 	"recursive #sizeInMemory for Soil. 

--- a/src/Soil-Core/SoilReadOnlyStrategy.class.st
+++ b/src/Soil-Core/SoilReadOnlyStrategy.class.st
@@ -39,3 +39,12 @@ SoilReadOnlyStrategy >> prepareCommit [
 					object: each object;
 					signal ] ] ]
 ]
+
+{ #category : #'as yet unclassified' }
+SoilReadOnlyStrategy >> recordMaterialized: record materializer: materializer [
+	super recordMaterialized: record materializer: materializer.
+	"if we want to find out what has changed we need to make a 
+	fingerprint even in read-only mode"
+	ignoreWriteAttempts ifFalse: [ 
+		record makeFingerprint ].
+]


### PR DESCRIPTION
Added faster hash for SoilObjectId