### PR TITLE
Now that we have intentional readOnlyNess and effective readOnlyNess …

### DIFF
--- a/src/Soil-Core-Tests/SoilTransactionTest.class.st
+++ b/src/Soil-Core-Tests/SoilTransactionTest.class.st
@@ -44,7 +44,7 @@ SoilTransactionTest >> testCheckpointAndContinue [
 	tx := soil newTransaction.
 	tx root: Object new.
 	tx commitAndContinue.
-	self deny: tx hasModifications.
+	self deny: tx needsCommit .
 	 
 	
 ]

--- a/src/Soil-Core/SoilCommitStrategy.class.st
+++ b/src/Soil-Core/SoilCommitStrategy.class.st
@@ -14,7 +14,7 @@ SoilCommitStrategy >> beAutoMigrating [
 ]
 
 { #category : #testing }
-SoilCommitStrategy >> hasModifications [ 
+SoilCommitStrategy >> hasChanges [ 
 	self subclassResponsibility 
 ]
 
@@ -30,7 +30,7 @@ SoilCommitStrategy >> isAutoMigrating [
 ]
 
 { #category : #testing }
-SoilCommitStrategy >> isReadOnly [ 
+SoilCommitStrategy >> isWritable [
 	self subclassResponsibility 
 ]
 

--- a/src/Soil-Core/SoilMetadata.class.st
+++ b/src/Soil-Core/SoilMetadata.class.st
@@ -101,7 +101,7 @@ SoilMetadata >> soil: aSoil [
 
 { #category : #counting }
 SoilMetadata >> transactionCommitted: aSoilTransaction [ 
-	aSoilTransaction hasModifications ifTrue: [ 
+	aSoilTransaction needsCommit ifTrue: [ 
 		self lastModified: DateAndTime now  ]
 ]
 

--- a/src/Soil-Core/SoilMetrics.class.st
+++ b/src/Soil-Core/SoilMetrics.class.st
@@ -201,7 +201,7 @@ SoilMetrics >> transactionAborted: aSoilTransaction [
 { #category : #counting }
 SoilMetrics >> transactionCommitted: aSoilTransaction [ 
 	super transactionCommitted: aSoilTransaction. 
-	aSoilTransaction hasModifications 
+	aSoilTransaction needsCommit 
 		ifTrue: [ transactionsCommittedWrite := transactionsCommittedWrite + 1 ]
 		ifFalse: [ transactionsCommittedReadOnly := transactionsCommittedReadOnly + 1 ]
 ]

--- a/src/Soil-Core/SoilReadOnlyStrategy.class.st
+++ b/src/Soil-Core/SoilReadOnlyStrategy.class.st
@@ -13,7 +13,7 @@ SoilReadOnlyStrategy >> errorOnWriteAttempts [
 ]
 
 { #category : #testing }
-SoilReadOnlyStrategy >> hasModifications [ 
+SoilReadOnlyStrategy >> hasChanges [ 
 	^ false 
 ]
 
@@ -23,8 +23,8 @@ SoilReadOnlyStrategy >> ignoreWriteAttempts [
 ]
 
 { #category : #testing }
-SoilReadOnlyStrategy >> isReadOnly [ 
-	^ true 
+SoilReadOnlyStrategy >> isWritable [
+	^ false
 ]
 
 { #category : #public }

--- a/src/Soil-Core/SoilReadWriteStrategy.class.st
+++ b/src/Soil-Core/SoilReadWriteStrategy.class.st
@@ -24,7 +24,7 @@ SoilReadWriteStrategy >> errorOnWriteAttempts [
 ]
 
 { #category : #testing }
-SoilReadWriteStrategy >> hasModifications [ 
+SoilReadWriteStrategy >> hasChanges [ 
 	^ records notNil and: [ records notEmpty ]
 ]
 
@@ -45,8 +45,8 @@ SoilReadWriteStrategy >> initialize [
 ]
 
 { #category : #testing }
-SoilReadWriteStrategy >> isReadOnly [
-	^ false 
+SoilReadWriteStrategy >> isWritable [
+	^ true
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilTransaction.class.st
+++ b/src/Soil-Core/SoilTransaction.class.st
@@ -112,7 +112,7 @@ SoilTransaction >> basicCommit [
 	commitStrategy prepareCommit.
 	"if there are no records to commit we can just return and don't allocate any
 	resources"
-	self hasModifications ifFalse: [ 
+	self needsCommit ifFalse: [ 
 		soil notificationHandler transactionCommitted: self.
 		^ self ].
 	"only one transactions is allowed at a time. We use the critical block of the database
@@ -354,18 +354,18 @@ SoilTransaction >> findRecords: aBlock [
 ]
 
 { #category : #testing }
-SoilTransaction >> hasJournalEntries [ 
-	
-	^ journal notNil and: [ journal size > 1 ]
-]
-
-{ #category : #testing }
-SoilTransaction >> hasModifications [ 
+SoilTransaction >> hasChanges [ 
 	"before committing a transaction collects changes in the journal. While committing
 	recordsToCommit gets populated. We want to ask for modifications regardless of the 
 	phase of the transaction so we check both"
-	^ commitStrategy hasModifications or: [ 
+	^ commitStrategy hasChanges or: [ 
 			self hasJournalEntries ]
+]
+
+{ #category : #testing }
+SoilTransaction >> hasJournalEntries [ 
+	
+	^ journal notNil and: [ journal size > 1 ]
 ]
 
 { #category : #accessing }
@@ -418,7 +418,7 @@ SoilTransaction >> isPersistent: anObject [
 
 { #category : #testing }
 SoilTransaction >> isReadOnly [ 
-	^ commitStrategy isReadOnly 
+	^ self isWritable not
 ]
 
 { #category : #testing }
@@ -428,6 +428,11 @@ SoilTransaction >> isRoot: anObject [
 	^ (objectMap 
 		at: anObject theNonSoilProxy 
 		ifAbsent: nil) notNil
+]
+
+{ #category : #testing }
+SoilTransaction >> isWritable [
+	^ commitStrategy isWritable
 ]
 
 { #category : #accessing }
@@ -451,7 +456,7 @@ SoilTransaction >> makeNewVersion: classDescription [
 { #category : #api }
 SoilTransaction >> makeRoot: anObject [ 
 	| objectId |
-	self isReadOnly ifTrue: [ 
+	self isWritable ifFalse: [ 
 		SoilWriteOnReadOnlyTransaction new 
 			object: anObject;
 			signal ].
@@ -480,6 +485,12 @@ SoilTransaction >> materializeRecord: record [
 		materializer: materializer.
 		
 	^ record 
+]
+
+{ #category : #'as yet unclassified' }
+SoilTransaction >> needsCommit [ 
+
+	^ self isWritable and: [ self hasChanges ]
 ]
 
 { #category : #'instance creation' }

--- a/src/Soil-Core/SoilTransactionManager.class.st
+++ b/src/Soil-Core/SoilTransactionManager.class.st
@@ -33,7 +33,7 @@ SoilTransactionManager >> addTransaction: aSoilTransaction [
 { #category : #'commit/abort' }
 SoilTransactionManager >> commitAndContinueTransaction: aTransaction [ 	
 	aTransaction basicCommit.
-	aTransaction hasModifications ifTrue: [ 
+	aTransaction needsCommit ifTrue: [ 
 		soil checkpoint ].
 	aTransaction continue
 ]
@@ -42,7 +42,7 @@ SoilTransactionManager >> commitAndContinueTransaction: aTransaction [
 SoilTransactionManager >> commitTransaction: aTransaction [ 	
 	| modified |
 	aTransaction basicCommit.
-	modified := aTransaction hasModifications.
+	modified := aTransaction needsCommit .
 	aTransaction basicAbort.
 	self removeTransaction: aTransaction.
 	modified ifTrue: [ 


### PR DESCRIPTION
…(a writable transaction with no changes) we need to separate that

- a transaction should be read-only (isReadOnly)
- a transaction has changes (hasChanges)
- a transaction that needs commit (is writable and has changes)