### PR TITLE
Prevent Soil object and PersistentDatabaseJournal to be stored in a f…

### DIFF
--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -221,6 +221,12 @@ Soil >> findRecord: aBlock [
 		ensure: [ tx abort ]
 ]
 
+{ #category : #hooks }
+Soil >> fuelAccept: aGeneralMapper [
+	"We do not want to serialize a complete database to fuel"
+	^ aGeneralMapper visitSubstitution: self by: nil
+]
+
 { #category : #'memory space' }
 Soil >> garbageCollect [
 	Error signal: 'garbage collect is not ready to be used, yet'.
@@ -431,9 +437,11 @@ Soil >> path: aString [
 
 { #category : #printing }
 Soil >> printOn: aStream [ 
+	aStream << 'Soil ['.
+	self isOpen 
+		ifTrue: [ self control databaseVersion printString ]
+		ifFalse: [ #closed ].
 	aStream 
-		<< 'Soil ['
-		<< self control databaseVersion printString
 		<< '] '
 		<< self path pathString
 ]

--- a/src/Soil-Core/SoilPersistentDatabaseJournal.class.st
+++ b/src/Soil-Core/SoilPersistentDatabaseJournal.class.st
@@ -127,6 +127,12 @@ SoilPersistentDatabaseJournal >> fragmentFiles [
 			yourself ]
 ]
 
+{ #category : #hooks }
+SoilPersistentDatabaseJournal >> fuelAccept: aGeneralMapper [
+	"We don't want to store all available journals to fuel"
+	^ aGeneralMapper visitSubstitution: self by: nil
+]
+
 { #category : #queries }
 SoilPersistentDatabaseJournal >> historyOfObjectId: aSoilObjectId [ 
 	| history objectEntries transactionStart |

--- a/src/Soil-Core/SoilUnresolvedProxy.class.st
+++ b/src/Soil-Core/SoilUnresolvedProxy.class.st
@@ -24,3 +24,9 @@ SoilUnresolvedProxy >> objectId: anObject [
 
 	objectId := anObject
 ]
+
+{ #category : #printing }
+SoilUnresolvedProxy >> printOn: aStream [ 
+	aStream << 'unresolved proxy '.
+	objectId printOn: aStream 
+]


### PR DESCRIPTION
…uel dump.

printOn: should not be used with objects that depend on the database open