### PR TITLE
generate fingerprint only if not already there. clusters can be cache…

### DIFF
--- a/src/Soil-Core/SoilAutomaticTrackingStrategy.class.st
+++ b/src/Soil-Core/SoilAutomaticTrackingStrategy.class.st
@@ -20,5 +20,5 @@ SoilAutomaticTrackingStrategy >> prepareCommit [
 { #category : #'as yet unclassified' }
 SoilAutomaticTrackingStrategy >> recordMaterialized: record materializer: materializer [
 	super recordMaterialized: record materializer: materializer.
-	record makeFingerprint 
+	record ensureFingerprint 
 ]

--- a/src/Soil-Core/SoilPersistentClusterVersion.class.st
+++ b/src/Soil-Core/SoilPersistentClusterVersion.class.st
@@ -22,14 +22,15 @@ SoilPersistentClusterVersion >> asNewClusterVersion [
 		previousVersionRecord: self
 ]
 
+{ #category : #accessing }
+SoilPersistentClusterVersion >> ensureFingerprint [
+	fingerprint ifNil: [ 
+		fingerprint := object soilRecursiveHash ]
+]
+
 { #category : #testing }
 SoilPersistentClusterVersion >> hasChanged [
 	^ fingerprint ~= object soilRecursiveHash 
-]
-
-{ #category : #accessing }
-SoilPersistentClusterVersion >> makeFingerprint [
-	fingerprint := object soilRecursiveHash
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilReadOnlyStrategy.class.st
+++ b/src/Soil-Core/SoilReadOnlyStrategy.class.st
@@ -51,5 +51,5 @@ SoilReadOnlyStrategy >> recordMaterialized: record materializer: materializer [
 	"if we want to find out what has changed we need to make a 
 	fingerprint even in read-only mode"
 	ignoreWriteAttempts ifFalse: [ 
-		record makeFingerprint ].
+		record ensureFingerprint ].
 ]


### PR DESCRIPTION
…d so no reason to create the fingerprint more than once