### PR TITLE
Some trivial cleanups

### DIFF
--- a/src/Soil-Core-Tests/SoilCleanCodeTest.class.st
+++ b/src/Soil-Core-Tests/SoilCleanCodeTest.class.st
@@ -27,6 +27,12 @@ SoilCleanCodeTest class >> cleanupWhiteSpaceTrimRight [
 		refactoring execute ]
 ]
 
+{ #category : #accessing }
+SoilCleanCodeTest class >> defaultTimeLimit [
+
+	^ 30 seconds
+]
+
 { #category : #running }
 SoilCleanCodeTest >> assertValidLintRule: aLintRule [
 	self assertValidLintRule: aLintRule withExceptions: #()

--- a/src/Soil-Core-Tests/SoilRecursiveHashTest.class.st
+++ b/src/Soil-Core-Tests/SoilRecursiveHashTest.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #SoilRecursiveHashTest,
 	#superclass : #TestCase,
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-Model'
 }
 
 { #category : #tests }

--- a/src/Soil-Core-Tests/SoilRecursiveHashTestObject.class.st
+++ b/src/Soil-Core-Tests/SoilRecursiveHashTestObject.class.st
@@ -9,7 +9,7 @@ Class {
 		'five',
 		'six'
 	],
-	#category : #'Soil-Core-Tests'
+	#category : #'Soil-Core-Tests-TestData'
 }
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilAutomaticTrackingStrategy.class.st
+++ b/src/Soil-Core/SoilAutomaticTrackingStrategy.class.st
@@ -9,7 +9,7 @@ SoilAutomaticTrackingStrategy >> markDirty: anObject [
 	"do nothing"
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #strategy }
 SoilAutomaticTrackingStrategy >> prepareCommit [ 
 	transaction objectMap do: [ :each | 
 		each hasChanged ifTrue: [ 
@@ -17,7 +17,7 @@ SoilAutomaticTrackingStrategy >> prepareCommit [
 	self serializeObjects 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #strategy }
 SoilAutomaticTrackingStrategy >> recordMaterialized: record materializer: materializer [
 	super recordMaterialized: record materializer: materializer.
 	record ensureFingerprint 

--- a/src/Soil-Core/SoilCommitStrategy.class.st
+++ b/src/Soil-Core/SoilCommitStrategy.class.st
@@ -8,7 +8,7 @@ Class {
 	#category : #'Soil-Core'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #public }
 SoilCommitStrategy >> beAutoMigrating [
 	autoMigration := true
 ]
@@ -34,17 +34,17 @@ SoilCommitStrategy >> isWritable [
 	self subclassResponsibility 
 ]
 
-{ #category : #public }
+{ #category : #strategy }
 SoilCommitStrategy >> markDirty: anObject [ 
 	self subclassResponsibility 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #strategy }
 SoilCommitStrategy >> prepareCommit [ 
 	self subclassResponsibility 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #strategy }
 SoilCommitStrategy >> recordMaterialized: record materializer: materializer [
 	(autoMigration and: [ materializer clusterCanBeMigrated ]) 
 		ifTrue: [ self addRecord: record. ].

--- a/src/Soil-Core/SoilGraphExporter.class.st
+++ b/src/Soil-Core/SoilGraphExporter.class.st
@@ -69,7 +69,7 @@ SoilGraphExporter >> export: aSoilObjectId [
 	self processLoop
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #actions }
 SoilGraphExporter >> exportOn: aStream [ 
 	stream := aStream.
 	self export

--- a/src/Soil-Core/SoilGraphImporter.class.st
+++ b/src/Soil-Core/SoilGraphImporter.class.st
@@ -101,11 +101,6 @@ SoilGraphImporter >> metaSegment [
 
 ]
 
-{ #category : #accessing }
-SoilGraphImporter >> newId [
-	^ newId
-]
-
 { #category : #'instance creation' }
 SoilGraphImporter >> newObjectIdFor: aSoilObjectId [ 
 	| current |

--- a/src/Soil-Core/SoilManualTrackingStrategy.class.st
+++ b/src/Soil-Core/SoilManualTrackingStrategy.class.st
@@ -9,7 +9,7 @@ SoilManualTrackingStrategy >> markDirty: anObject [
 	transaction addObjectToBeCommited: anObject 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #strategy }
 SoilManualTrackingStrategy >> prepareCommit [ 
 	self serializeObjects 
 ]

--- a/src/Soil-Core/SoilObjectId.class.st
+++ b/src/Soil-Core/SoilObjectId.class.st
@@ -99,7 +99,7 @@ SoilObjectId >> asSoilObjectProxy [
 		objectId: self
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tools }
 SoilObjectId >> findReferencesIn: aDatabase [
 	^ SoilReferenceFinder new
 		soil: aDatabase;
@@ -187,7 +187,7 @@ SoilObjectId >> setIndex: anInteger [
 	index := anInteger 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'recursive hash' }
 SoilObjectId >> soilRecursiveHashWith: aSet [ 
 	^ (segment soilRecursiveHashWith: aSet) bitXor: (index soilRecursiveHashWith: aSet)
 ]

--- a/src/Soil-Core/SoilObjectProxy.class.st
+++ b/src/Soil-Core/SoilObjectProxy.class.st
@@ -128,7 +128,7 @@ SoilObjectProxy >> soilRealObject [
 		object := transaction objectWithId: objectId ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #'recursive hash' }
 SoilObjectProxy >> soilRecursiveHashWith: aSet [ 
 	"proxies are identified by there object id. If proxies are exchanged the 
 	hash should stay the same as it refers to the same object"

--- a/src/Soil-Core/SoilReadOnlyStrategy.class.st
+++ b/src/Soil-Core/SoilReadOnlyStrategy.class.st
@@ -35,7 +35,7 @@ SoilReadOnlyStrategy >> markDirty: anObject [
 			signal ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #strategy }
 SoilReadOnlyStrategy >> prepareCommit [ 
 	ignoreWriteAttempts ifFalse: [ 
 		transaction objectMap do: [ :each | 
@@ -45,7 +45,7 @@ SoilReadOnlyStrategy >> prepareCommit [
 					signal ] ] ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #strategy }
 SoilReadOnlyStrategy >> recordMaterialized: record materializer: materializer [
 	super recordMaterialized: record materializer: materializer.
 	"if we want to find out what has changed we need to make a 

--- a/src/Soil-Core/SoilTransaction.class.st
+++ b/src/Soil-Core/SoilTransaction.class.st
@@ -486,7 +486,7 @@ SoilTransaction >> materializeRecord: record [
 	^ record 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #testing }
 SoilTransaction >> needsCommit [ 
 
 	^ self isWritable and: [ self hasChanges ]


### PR DESCRIPTION
- categorize uncategorized
- remove SoilGraphImporter>>#newId which accesses an ivar that does not exist (method not used)
- increase defaultTimeLimit for SoilCleanCodeTest