### PR TITLE
Fix silent data loss from objectMap mutation during prepareCommit scan

### DIFF
--- a/src/Soil-Core-Tests/SoilTestGrowingRecord.class.st
+++ b/src/Soil-Core-Tests/SoilTestGrowingRecord.class.st
@@ -1,0 +1,36 @@
+Class {
+	#name : #SoilTestGrowingRecord,
+	#superclass : #Object,
+	#instVars : [
+		'onHasChanged',
+		'changed'
+	],
+	#category : #'Soil-Core-Tests-TestData'
+}
+
+{ #category : #converting }
+SoilTestGrowingRecord >> asNewClusterVersion [
+	^ self
+]
+
+{ #category : #accessing }
+SoilTestGrowingRecord >> changed: aBoolean [
+	changed := aBoolean
+]
+
+{ #category : #testing }
+SoilTestGrowingRecord >> hasChanged [
+	onHasChanged ifNotNil: [ onHasChanged value ].
+	^ changed ifNil: [ false ]
+]
+
+{ #category : #accessing }
+SoilTestGrowingRecord >> onHasChanged: aBlock [
+	onHasChanged := aBlock
+]
+
+{ #category : #serializing }
+SoilTestGrowingRecord >> serializeObject [
+	"no-op: this stub only exercises SoilAutomaticTrackingStrategy>>prepareCommit's
+	objectMap traversal, not real serialization"
+]

--- a/src/Soil-Core-Tests/SoilTransactionTest.class.st
+++ b/src/Soil-Core-Tests/SoilTransactionTest.class.st
@@ -112,7 +112,33 @@ SoilTransactionTest >> testFindRecords [
 ]
 
 { #category : #tests }
-SoilTransactionTest >> testRootObject [ 
+SoilTransactionTest >> testPrepareCommitSurvivesObjectMapGrowingDuringScan [
+	"prepareCommit iterates transaction objectMap to find changed records. If handling
+	one record causes further objects to become known to the transaction (as a lazily
+	materializing reference can), objectMap grows while it is being scanned. Pharo's
+	HashedCollection>>do: does not tolerate that: growing the dictionary mid-iteration
+	can silently skip entries that were already there before the growth, so a changed
+	record can be dropped from the commit without any error. This reproduces that shape
+	directly against objectMap, independent of what actually triggers the growth."
+	| tx map growingRecord changedRecords |
+	tx := SoilTransaction new.
+	map := tx objectMap.
+	changedRecords := OrderedCollection new.
+	1 to: 8 do: [ :i | | record |
+		record := SoilTestGrowingRecord new.
+		record changed: true.
+		changedRecords add: record.
+		map at: Object new put: record ].
+	growingRecord := changedRecords first.
+	growingRecord onHasChanged: [
+		1 to: 200 do: [ :i | map at: Object new put: SoilTestGrowingRecord new ] ].
+	tx commitStrategy prepareCommit.
+	changedRecords do: [ :record |
+		self assert: (tx commitStrategy records includes: record) ]
+]
+
+{ #category : #tests }
+SoilTransactionTest >> testRootObject [
 	| tx obj |
 	obj := Object new.
 	tx := soil newTransaction.

--- a/src/Soil-Core/SoilAutomaticTrackingStrategy.class.st
+++ b/src/Soil-Core/SoilAutomaticTrackingStrategy.class.st
@@ -10,11 +10,15 @@ SoilAutomaticTrackingStrategy >> markDirty: anObject [
 ]
 
 { #category : #strategy }
-SoilAutomaticTrackingStrategy >> prepareCommit [ 
-	transaction objectMap do: [ :each | 
-		each hasChanged ifTrue: [ 
+SoilAutomaticTrackingStrategy >> prepareCommit [
+	"iterate over a snapshot, not the live objectMap: resolving a reference while
+	checking #hasChanged can register further objects into objectMap, and growing
+	a Dictionary while it is being #do:-iterated can silently skip entries that were
+	already there, dropping a changed record from the commit without any error"
+	transaction objectMap values do: [ :each |
+		each hasChanged ifTrue: [
 			self addRecord: each ] ].
-	self serializeObjects 
+	self serializeObjects
 ]
 
 { #category : #strategy }

--- a/src/Soil-Core/SoilReadOnlyStrategy.class.st
+++ b/src/Soil-Core/SoilReadOnlyStrategy.class.st
@@ -36,11 +36,13 @@ SoilReadOnlyStrategy >> markDirty: anObject [
 ]
 
 { #category : #strategy }
-SoilReadOnlyStrategy >> prepareCommit [ 
-	ignoreWriteAttempts ifFalse: [ 
-		transaction objectMap do: [ :each | 
+SoilReadOnlyStrategy >> prepareCommit [
+	"iterate over a snapshot, not the live objectMap - see
+	SoilAutomaticTrackingStrategy>>prepareCommit for why"
+	ignoreWriteAttempts ifFalse: [
+		transaction objectMap values do: [ :each |
 			each hasChanged ifTrue: [
-				 ^ SoilWriteOnReadOnlyTransaction new 
+				 ^ SoilWriteOnReadOnlyTransaction new
 					object: each object;
 					signal ] ] ]
 ]


### PR DESCRIPTION
SoilAutomaticTrackingStrategy>>prepareCommit (and the analogous SoilReadOnlyStrategy>>prepareCommit) iterated transaction objectMap directly via #do: while deciding which records changed. If handling one record causes further objects to become known to the transaction (e.g. a lazily materializing reference), objectMap grows while it is being scanned. Pharo's HashedCollection>>do: does not tolerate that: growing a Dictionary mid-iteration can silently skip entries that were already there, so a changed record can be dropped from the commit without any error - a silent data loss bug found while verifying the Exclusive->MultiChoice-Gateway migration.

Fix: iterate transaction objectMap values (a stable snapshot array) in both prepareCommit methods, immune to any later growth of objectMap.

Added SoilTestGrowingRecord and
SoilTransactionTest>>testPrepareCommitSurvivesObjectMapGrowingDuringScan, which reproduces the corruption directly against objectMap (reliably drops records against the old code, never against the fix). Verified via mcp__pharo__run_tests: SoilTransactionTest, SoilTest, SoilRecursiveHashTest, SoilMultiVersionTest, and the full Soil-Core-Tests package (559/559 green, pre-existing unrelated self-skip tests aside).