### PR TITLE
Fix SoilBackupVisitor to copy full version history for all segments

### DIFF
--- a/src/Soil-Core-Tests/SoilBackupTest.class.st
+++ b/src/Soil-Core-Tests/SoilBackupTest.class.st
@@ -160,6 +160,39 @@ SoilBackupTest >> testBackupOldVersion [
 ]
 
 { #category : #tests }
+SoilBackupTest >> testBackupPreservesFullVersionHistoryForRegularObjects [
+	"A backup must be a faithful copy of the source database - including full MVCC
+	history for regular objects (segment 1), not just behavior descriptions
+	(segment 0). Before the fix, SoilBackupVisitor only copied the current version
+	of regular clusters (via resetPreviousVersion), so an old readVersion became
+	unreadable (or silently returned nil/wrong data) after restore."
+	| tx tx2 visitor tx3 |
+	tx := soil newTransaction.
+	tx root: (SoilTestGraphRoot new nested: (SoilTestNestedObject new label: #versionOne) ).
+	tx makeRoot: tx root nested.
+	tx commit.
+
+	self assert: soil control databaseVersion equals: 1.
+
+	tx2 := soil newTransaction.
+	tx2 root nested label: #versionTwo.
+	tx2 markDirty: tx2 root nested.
+	tx2 commit.
+
+	backupSoil := Soil createOnPath: self path, #backup.
+	visitor := SoilBackupVisitor new
+		target: backupSoil;
+		backup: soil.
+	backupSoil close; open.
+
+	"the backup itself (a normal, unversioned full backup) must still be able to
+	answer a historical read for version 1, exactly like the source database can"
+	tx3 := backupSoil newTransactionForVersion: 1.
+	[ self assert: tx3 root nested label equals: #versionOne ]
+		ensure: [ tx3 abort ]
+]
+
+{ #category : #tests }
 SoilBackupTest >> testBackupTheBackup [
 	| tx visitor dict secondBackup txn |
 	dict := (SoilIndexedDictionary newWithBackend: SoilSkipList)

--- a/src/Soil-Core/SoilBackupVisitor.class.st
+++ b/src/Soil-Core/SoilBackupVisitor.class.st
@@ -169,13 +169,11 @@ SoilBackupVisitor >> visitObjectSegment: aSoilObjectSegment [
 { #category : #visiting }
 SoilBackupVisitor >> visitPersistentClusterVersion: aSoilPersistentClusterVersion [ 
 	super visitPersistentClusterVersion: aSoilPersistentClusterVersion.
-	(aSoilPersistentClusterVersion objectId segment == 0)
-		ifTrue: [ 
-			"as there could be very old objects we need to copy all  versions of 
-			the behavior descriptions"
-			self copyAllClusterVersions: aSoilPersistentClusterVersion  ]
-		ifFalse: [  
-			self copySourceCluster: (self makeCopy: aSoilPersistentClusterVersion) ].
-
-	^ aSoilPersistentClusterVersion 
+	"A backup must be a faithful copy of the source database, including full
+	MVCC history - not just the current version. This applies to every segment,
+	not only the meta segment (behavior descriptions): any object can have
+	readers with an old readVersion that need historical versions to still be
+	readable after a restore, exactly like behavior descriptions do."
+	self copyAllClusterVersions: aSoilPersistentClusterVersion.
+	^ aSoilPersistentClusterVersion
 ]


### PR DESCRIPTION
visitPersistentClusterVersion: only copied the full MVCC version chain for the meta segment (behavior descriptions), and copied just the current version for regular object segments. A backup must be a byte-identical copy of the source database, including history that old readers (readVersion-based snapshot isolation) still depend on - not just the latest version. copyAllClusterVersions: was already segment-agnostic, so the fix removes the special-casing and always copies the full chain.

Added SoilBackupTest>>testBackupPreservesFullVersionHistoryForRegularObjects, which commits two versions of an object, takes a backup, and asserts that a transaction opened against the backup at version 1 still reads the old value. Fails against the previous code (returns nil/broken data), passes against the fix. Full SoilBackupTest suite: 8/8 passing.