### PR TITLE
Fix SoilFindRecordsVisitor aborting whole scan on one bad object

### DIFF
--- a/src/Soil-Core-Tests/SoilFindRecordsVisitorTest.class.st
+++ b/src/Soil-Core-Tests/SoilFindRecordsVisitorTest.class.st
@@ -1,0 +1,54 @@
+Class {
+	#name : #SoilFindRecordsVisitorTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'soil'
+	],
+	#category : #'Soil-Core-Tests-Visitor'
+}
+
+{ #category : #accessing }
+SoilFindRecordsVisitorTest >> path [
+	^ 'soil-tests' asFileReference
+]
+
+{ #category : #initialization }
+SoilFindRecordsVisitorTest >> setUp [
+	super setUp.
+	soil := Soil path: self path.
+	soil 
+		destroy;
+		initializeFilesystem
+]
+
+{ #category : #running }
+SoilFindRecordsVisitorTest >> tearDown [
+	super tearDown.
+	soil ifNotNil: [ soil close ]
+]
+
+{ #category : #tests }
+SoilFindRecordsVisitorTest >> testFindRecordsCollectsErrorInsteadOfAbortingOnCorruptedObject [
+	"A materialize error for one object during find:in: must not abort the whole
+	scan - the error should be collected and the scan should continue over the
+	remaining reachable objects instead of raising out of find:in:."
+	| tx objectsFile bytes visitor |
+	tx := soil newTransaction.
+	tx root: (SoilTestGraphRoot new nested: (SoilTestNestedObject new label: #hello)).
+	tx makeRoot: tx root nested.
+	tx commit.
+	soil close.
+
+	objectsFile := self path / 'segments' / '1' / 'objects'.
+	bytes := objectsFile binaryReadStream next: 30.
+	objectsFile delete.
+	objectsFile binaryWriteStream nextPutAll: bytes; close.
+
+	soil := Soil path: self path.
+	soil open.
+	tx := soil newTransaction.
+	visitor := SoilFindRecordsVisitor new.
+	visitor find: [ :r | true ] in: tx.
+	self assert: visitor errors isNotEmpty.
+	self assert: visitor records isNotEmpty
+]

--- a/src/Soil-Core/SoilFindRecordsVisitor.class.st
+++ b/src/Soil-Core/SoilFindRecordsVisitor.class.st
@@ -4,10 +4,16 @@ Class {
 	#instVars : [
 		'condition',
 		'records',
-		'numberOfRecords'
+		'numberOfRecords',
+		'errors'
 	],
 	#category : #'Soil-Core-Visitor'
 }
+
+{ #category : #accessing }
+SoilFindRecordsVisitor >> errors [
+	^ errors
+]
 
 { #category : #api }
 SoilFindRecordsVisitor >> find: aBlock in: aSoilTransaction [ 
@@ -18,16 +24,33 @@ SoilFindRecordsVisitor >> find: aBlock in: aSoilTransaction [
 ]
 
 { #category : #initialization }
-SoilFindRecordsVisitor >> initialize [ 
+SoilFindRecordsVisitor >> initialize [
 	super initialize.
 	records := OrderedCollection new.
 	numberOfRecords := nil.
+	errors := OrderedCollection new
 ]
 
 { #category : #accessing }
 SoilFindRecordsVisitor >> numberOfRecords: anObject [
 
 	numberOfRecords := anObject
+]
+
+{ #category : #api }
+SoilFindRecordsVisitor >> processLoop [
+	"Overridden from SoilVisitor: a materialize error for one object must not
+	abort the whole scan - collect it in errors and continue with the next
+	queued object instead of letting it propagate out of find:in:."
+	| objectId record |
+	[ toBeProcessed isEmpty ] whileFalse: [ 
+		(numberOfRecords notNil and: [ records size >= numberOfRecords ]) ifTrue: [ ^ self ].
+		objectId := toBeProcessed removeFirst.
+		[ record := (soil objectRepository segmentAt: objectId segment) 
+			basicAt: objectId index version: self databaseVersion.
+		self visit: (record objectId: objectId) ]
+			on: Error
+			do: [ :e | errors add: objectId -> e messageText ] ]
 ]
 
 { #category : #accessing }
@@ -51,7 +74,8 @@ SoilFindRecordsVisitor >> visitJournalFragmentFile: aJournalFragmentFile [
 SoilFindRecordsVisitor >> visitObjectId: aSoilObjectId [ 
 	(numberOfRecords notNil and: [ records size >= numberOfRecords ]) ifTrue: [ ^ self ].
 	^ [ super visitObjectId: aSoilObjectId ]
-		on: Error do: [ :e | ] 
+		on: Error 
+		do: [ :e | errors add: aSoilObjectId -> e messageText ]
 ]
 
 { #category : #visiting }


### PR DESCRIPTION
find:in: (used by SoilTransaction>>findRecord:/findRecords:/findObject: for debugging/ad-hoc scans) had a visitObjectId: override wrapping super in on: Error do: [:e|], apparently meant to let a single unreadable object fall out of the scan instead of aborting it. Empirically this handler never fires: with the default breadth-first traversal, materialization happens inside SoilVisitor>>processLoop (resolving each queued objectId to a record before calling visit:), not through visitObjectId:. A corrupted/unreadable object therefore still crashes the entire scan today, uncaught - confirmed by temporarily reverting the fix below and reproducing the crash against a deliberately truncated object segment.

Fix: override processLoop to catch materialize errors per queued object, collect them in a new `errors` collection, and continue with the remaining queue instead of propagating out of find:in:. Also wired the (until now unreachable) visitObjectId: handler to collect into the same `errors` collection, for consistency in case future refactors route through it.

SoilFindRecordsVisitorTest>>testFindRecordsCollectsErrorInsteadOfAbortingOnCorruptedObject commits two objects, truncates the object segment on disk to corrupt one of them, and asserts the scan still returns the readable records plus a collected error, instead of raising. Verified against both the old and new processLoop (fails/crashes with MessageNotUnderstood against the old code, passes against the fix). Full Soil-Core-Tests suite: 557/557 passing.