### PR TITLE
Track B PR1: extract copyClusterVersionChain: reusable chain-copy pri…

### DIFF
--- a/src/Soil-Core-Tests/SoilBackupTest.class.st
+++ b/src/Soil-Core-Tests/SoilBackupTest.class.st
@@ -304,7 +304,65 @@ SoilBackupTest >> testBackupWithIndexRemoval [
 ]
 
 { #category : #tests }
-SoilBackupTest >> testSimpleBackup [ 
+SoilBackupTest >> testCopyClusterVersionChainRebuildsPreviousVersionPosition [
+	"I4: in the target the copied chain is backward-reachable from the current
+	version and terminates at previousVersionPosition 0."
+	| tx tx2 tx3 objectId versions |
+	tx := soil newTransaction.
+	tx root: (SoilTestGraphRoot new nested: (SoilTestNestedObject new label: #versionOne)).
+	tx makeRoot: tx root nested.
+	tx commit.
+	tx2 := soil newTransaction.
+	tx2 root nested label: #versionTwo.
+	tx2 markDirty: tx2 root nested.
+	tx2 commit.
+	tx3 := soil newTransaction.
+	tx3 root nested label: #versionThree.
+	tx3 markDirty: tx3 root nested.
+	tx3 commit.
+	backupSoil := Soil createOnPath: self path, #backup.
+	SoilBackupVisitor new target: backupSoil; backup: soil.
+	backupSoil close; open.
+	tx := backupSoil newTransaction.
+	objectId := tx objectIdOf: tx root nested.
+	tx abort.
+	versions := (backupSoil objectRepository segmentAt: objectId segment)
+		allVersionsAt: objectId index.
+	self assert: versions size equals: 3.
+	self assert: versions last previousVersionPosition equals: 0.
+	self assert: (versions allButLast allSatisfy: [ :each | each previousVersionPosition > 0 ])
+]
+
+{ #category : #tests }
+SoilBackupTest >> testCopyClusterVersionChainRoundtrip [
+	"Roundtrip: a 3-version chain copied into a fresh target must answer at:version:
+	for every reader version exactly like the source database."
+	| tx tx2 tx3 |
+	tx := soil newTransaction.
+	tx root: (SoilTestGraphRoot new nested: (SoilTestNestedObject new label: #versionOne)).
+	tx makeRoot: tx root nested.
+	tx commit.
+	tx2 := soil newTransaction.
+	tx2 root nested label: #versionTwo.
+	tx2 markDirty: tx2 root nested.
+	tx2 commit.
+	tx3 := soil newTransaction.
+	tx3 root nested label: #versionThree.
+	tx3 markDirty: tx3 root nested.
+	tx3 commit.
+	self assert: soil control databaseVersion equals: 3.
+	backupSoil := Soil createOnPath: self path, #backup.
+	SoilBackupVisitor new target: backupSoil; backup: soil.
+	backupSoil close; open.
+	1 to: 3 do: [ :v | | srcTx dstTx |
+		srcTx := soil newTransactionForVersion: v.
+		dstTx := backupSoil newTransactionForVersion: v.
+		[ self assert: dstTx root nested label equals: srcTx root nested label ]
+			ensure: [ srcTx abort. dstTx abort ] ]
+]
+
+{ #category : #tests }
+SoilBackupTest >> testSimpleBackup [
 	| tx backup tx2 nested |
 	soil control
 		databaseFormatVersion: Soil databaseFormatVersion; 

--- a/src/Soil-Core/SoilBackupVisitor.class.st
+++ b/src/Soil-Core/SoilBackupVisitor.class.st
@@ -21,20 +21,15 @@ SoilBackupVisitor >> backup: aSoil [
 ]
 
 { #category : #copying }
-SoilBackupVisitor >> copyAllClusterVersions: aSoilPersistentClusterVersion [ 
-	| versions position |
-	"if there is no previous version is a single copy"
-	aSoilPersistentClusterVersion hasPreviousVersion 
-		ifFalse: [ ^ self copySourceCluster: aSoilPersistentClusterVersion  ].
-	versions := (soil objectRepository segmentAt: aSoilPersistentClusterVersion objectId segment)
-		allVersionsAt: aSoilPersistentClusterVersion objectId index.
-	position := 0.
-	"for multiple versions we need to iterate from oldest to newest to set the
-	correct previous version positions"
-	versions reverseDo: [ :cluster | | newCluster |
-		newCluster := self makeCopy: cluster.
-		newCluster previousVersionPosition: position.
-		position := self copyCluster: newCluster ]
+SoilBackupVisitor >> copyAllClusterVersions: aSoilPersistentClusterVersion [
+	"if there is no previous version this is a single copy"
+	aSoilPersistentClusterVersion hasPreviousVersion
+		ifFalse: [ ^ self copySourceCluster: aSoilPersistentClusterVersion ].
+	"for multiple versions copy the whole chain oldest-to-newest so the
+	previousVersionPosition links can be rebuilt in the target"
+	^ self copyClusterVersionChain:
+		((soil objectRepository segmentAt: aSoilPersistentClusterVersion objectId segment)
+			allVersionsAt: aSoilPersistentClusterVersion objectId index)
 ]
 
 { #category : #visiting }
@@ -47,8 +42,22 @@ SoilBackupVisitor >> copyCluster: aSoilPersistentClusterVersion [
 		self processObjectId: reference ].
 	aSoilPersistentClusterVersion indexIds do:[ :indexId |
 		self copyIndexAt: indexId segment: aSoilPersistentClusterVersion segment ].
-	^ position 
+	^ position
 
+]
+
+{ #category : #copying }
+SoilBackupVisitor >> copyClusterVersionChain: aCollectionOfClusterVersions [
+	"Copy a full version chain (ordered newest->oldest, as allVersionsAt: returns)
+	into the target, rebuilding previousVersionPosition in the target. Returns the
+	position of the current (newest) version in the target."
+	| position |
+	position := 0.
+	aCollectionOfClusterVersions reverseDo: [ :cluster | | newCluster |
+		newCluster := self makeCopy: cluster.
+		newCluster previousVersionPosition: position.
+		position := self copyCluster: newCluster ].
+	^ position
 ]
 
 { #category : #visiting }


### PR DESCRIPTION
…mitive

Extract the version-chain copy loop from SoilBackupVisitor>>copyAllClusterVersions: into a reusable, parameterizable method copyClusterVersionChain:. It copies a full version chain (ordered newest->oldest, as allVersionsAt: returns) into the target and rebuilds previousVersionPosition there, returning the position of the current (newest) version. copyAllClusterVersions: keeps the single-version fast path and now delegates the multi-version case.

Purely additive: makeCopy:/copyCluster:/copySourceCluster: unchanged, no format change, no smallestReadVersion gate, no blocks. Backup behavior is identical.

Tests (SoilBackupTest):
- testCopyClusterVersionChainRoundtrip: a 3-version chain copied into a fresh target answers newTransactionForVersion: identically to the source for every reader version.
- testCopyClusterVersionChainRebuildsPreviousVersionPosition: the copied chain in the target is backward-reachable from the current version and terminates at previousVersionPosition 0 (invariant I4).