### PR TITLE
Track B PR2: add smallestReadVersion gate to the version-chain copy

### DIFF
--- a/src/Soil-Core-Tests/SoilObjectRepositoryTest.class.st
+++ b/src/Soil-Core-Tests/SoilObjectRepositoryTest.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'Soil-Core-Tests-Model'
 }
 
+{ #category : #helpers }
+SoilObjectRepositoryTest >> keptVersionsIn: aSoil at: objectId [
+	^ ((aSoil objectRepository segmentAt: objectId segment) allVersionsAt: objectId index)
+		collect: [ :each | each version ]
+]
+
 { #category : #initialization }
 SoilObjectRepositoryTest >> setUp [ 
 	super setUp.
@@ -53,6 +59,49 @@ SoilObjectRepositoryTest >> testCacheObjectRecords [
 ]
 
 { #category : #tests }
+SoilObjectRepositoryTest >> testCopyVersionChainUpToReadVersionKeepsAllWhenReaderIsOld [
+	"readVersion 1: a reader at 1 still needs v1, so nothing is discardable."
+	| oid versions target |
+	oid := self threeVersionNestedObjectId.
+	versions := (soil objectRepository segmentAt: oid segment) allVersionsAt: oid index.
+	target := Soil createOnPath: 'soil-tests-target'.
+	[ target objectRepository copyVersionChain: versions upToReadVersion: 1.
+	  self assert: (self keptVersionsIn: target at: oid) asArray equals: #(3 2 1) ]
+		ensure: [ target close; destroy ]
+]
+
+{ #category : #tests }
+SoilObjectRepositoryTest >> testCopyVersionChainUpToReadVersionKeepsNeededSuffix [
+	"readVersion 2: version 1 was superseded at db version 2, so a reader at 2 no
+	longer needs it - keep {v3,v2}, drop v1, and rebuild the truncated chain (I4)."
+	| oid versions target kept |
+	oid := self threeVersionNestedObjectId.
+	versions := (soil objectRepository segmentAt: oid segment) allVersionsAt: oid index.
+	self assert: (versions collect: [ :e | e version ]) asArray equals: #(3 2 1).
+	target := Soil createOnPath: 'soil-tests-target'.
+	[ target objectRepository copyVersionChain: versions upToReadVersion: 2.
+	  kept := (target objectRepository segmentAt: oid segment) allVersionsAt: oid index.
+	  self assert: (kept collect: [ :e | e version ]) asArray equals: #(3 2).
+	  self assert: kept last previousVersionPosition equals: 0.
+	  self assert: kept first previousVersionPosition > 0 ]
+		ensure: [ target close; destroy ]
+]
+
+{ #category : #tests }
+SoilObjectRepositoryTest >> testCopyVersionChainUpToReadVersionNilKeepsOnlyCurrent [
+	"nil (no open transactions): keep only the current version."
+	| oid versions target kept |
+	oid := self threeVersionNestedObjectId.
+	versions := (soil objectRepository segmentAt: oid segment) allVersionsAt: oid index.
+	target := Soil createOnPath: 'soil-tests-target'.
+	[ target objectRepository copyVersionChain: versions upToReadVersion: nil.
+	  kept := (target objectRepository segmentAt: oid segment) allVersionsAt: oid index.
+	  self assert: (kept collect: [ :e | e version ]) asArray equals: #(3).
+	  self assert: kept last previousVersionPosition equals: 0 ]
+		ensure: [ target close; destroy ]
+]
+
+{ #category : #tests }
 SoilObjectRepositoryTest >> testFirstSegment [ 
 	self assert: soil objectRepository firstSegment id equals: 1
 ]
@@ -88,4 +137,26 @@ SoilObjectRepositoryTest >> testSegmentInitializationFromDisk [
 	('soil-tests' asFileReference / #segments / '3') ensureCreateDirectory.
 	self assert: soil objectRepository segments size equals: 3.
 
+]
+
+{ #category : #helpers }
+SoilObjectRepositoryTest >> threeVersionNestedObjectId [
+	"commit versions #v1/#v2/#v3 (db versions 1/2/3) of a nested object; answer its objectId"
+	| tx tx2 tx3 oid |
+	tx := soil newTransaction.
+	tx root: (SoilTestGraphRoot new nested: (SoilTestNestedObject new label: #v1)).
+	tx makeRoot: tx root nested.
+	tx commit.
+	tx2 := soil newTransaction.
+	tx2 root nested label: #v2.
+	tx2 markDirty: tx2 root nested.
+	tx2 commit.
+	tx3 := soil newTransaction.
+	tx3 root nested label: #v3.
+	tx3 markDirty: tx3 root nested.
+	tx3 commit.
+	tx := soil newTransaction.
+	oid := tx objectIdOf: tx root nested.
+	tx abort.
+	^ oid
 ]

--- a/src/Soil-Core/SoilObjectRepository.class.st
+++ b/src/Soil-Core/SoilObjectRepository.class.st
@@ -118,6 +118,25 @@ SoilObjectRepository >> copyVersionChain: aCollectionOfClusterVersions [
 	^ position
 ]
 
+{ #category : #copying }
+SoilObjectRepository >> copyVersionChain: aCollectionOfClusterVersions upToReadVersion: aNumberOrNil [
+	"Like copyVersionChain: but drop versions no reader can still see: a version is
+	discardable once the smallest read version has moved to or past the version that
+	superseded it, or when there is no open transaction at all (mirrors
+	SoilIndexCleaner>>canDiscardOldState:). The current (newest) version is always
+	kept; nil (no open transactions) keeps only it. The kept suffix is copied via
+	copyVersionChain:, so I4 (previousVersionPosition rebuild, oldest kept -> 0) holds."
+	| kept newerVersion |
+	kept := OrderedCollection new.
+	newerVersion := nil.
+	aCollectionOfClusterVersions do: [ :each |
+		(newerVersion notNil and: [ aNumberOrNil isNil or: [ aNumberOrNil >= newerVersion ] ])
+			ifTrue: [ ^ self copyVersionChain: kept ].
+		kept add: each.
+		newerVersion := each version ].
+	^ self copyVersionChain: kept
+]
+
 { #category : #accessing }
 SoilObjectRepository >> firstSegment [
 	^ segments first


### PR DESCRIPTION
Add SoilObjectRepository>>copyVersionChain:upToReadVersion: - a gated variant of
copyVersionChain: that drops version-chain entries no reader can still observe.

A version is discardable once the smallest read version has moved to or past the db version that superseded it, or when there is no open transaction at all. This mirrors the existing MVCC cleanup rule in SoilIndexCleaner>>canDiscardOldState: (readVersion isNil or: [readVersion >= supersededAt]). The current (newest) version is always kept; nil (no open transactions) keeps only it. The kept suffix is delegated to copyVersionChain:, so the previousVersionPosition rebuild (I4, oldest kept -> 0) is reused unchanged.

Purely additive: the ungated copyVersionChain: (used by backup for full history) is untouched. No production caller yet - the gate is consumed by tests here and will be wired to soil transactionManager smallestReadVersion in the first real Track-B GC PR.

Tests (SoilObjectRepositoryTest, on a 3-version chain at db versions 1/2/3):
- readVersion 2 keeps {v3,v2}, drops v1, oldest kept previousVersionPosition = 0.
- readVersion 1 keeps all three (a reader at 1 still needs v1).
- nil keeps only the current version.