### PR TITLE
Track A PR1: atomic segment-replace primitive (SoilObjectSegment>>rep…

### DIFF
--- a/src/Soil-Core-Tests/SoilObjectRepositoryTest.class.st
+++ b/src/Soil-Core-Tests/SoilObjectRepositoryTest.class.st
@@ -139,6 +139,64 @@ SoilObjectRepositoryTest >> testSegmentInitializationFromDisk [
 
 ]
 
+{ #category : #tests }
+SoilObjectRepositoryTest >> testSegmentReplaceCurtailedLeavesOriginalIntact [
+	"documented caller pattern: build clone, fail before the swap, ifCurtailed deletes
+	the orphan clone and the original segment is untouched."
+	| tx segment clone clonePath |
+	tx := soil newTransaction.
+	tx root: (SoilTestGraphRoot new nested: (SoilTestNestedObject new label: #kept)).
+	tx makeRoot: tx root nested.
+	tx commit.
+	soil checkpoint.
+	segment := soil objectRepository firstSegment.
+	clonePath := segment path, #gc.
+	[ [ clone := self verbatimCloneOf: segment.
+	    Error signal: 'boom before replace' ]
+		ifCurtailed: [ clone ifNotNil: [ clone close ]. clonePath ensureDeleteAll ] ]
+		on: Error do: [ :e | ].
+	self deny: clonePath exists.
+	tx := soil newTransaction.
+	[ self assert: tx root nested label equals: #kept ] ensure: [ tx abort ]
+]
+
+{ #category : #tests }
+SoilObjectRepositoryTest >> testSegmentReplacePreservesIndexes [
+	"the clone carries the whole segment directory, indexes included; an indexed
+	dictionary must still resolve after the swap (the old copy helper dropped indexes)."
+	| tx dict segment clone |
+	tx := soil newTransaction.
+	dict := (SoilIndexedDictionary newWithBackend: SoilSkipList) keySize: 8; maxLevel: 16; yourself.
+	tx root: dict.
+	dict at: #foo put: (SoilTestNestedObject new label: #indexed).
+	tx commit.
+	soil checkpoint.
+	segment := soil objectRepository firstSegment.
+	clone := self verbatimCloneOf: segment.
+	segment replaceWith: clone.
+	tx := soil newTransaction.
+	[ self assert: (tx root at: #foo) label equals: #indexed ] ensure: [ tx abort ]
+]
+
+{ #category : #tests }
+SoilObjectRepositoryTest >> testSegmentReplaceRoundtrip [
+	"replaceWith: swaps in a fully written clone, leaves the DB logically identical,
+	and removes the clone directory (no leftover .gc copy - moveTo: would leak it)."
+	| tx segment clone clonePath |
+	tx := soil newTransaction.
+	tx root: (SoilTestGraphRoot new nested: (SoilTestNestedObject new label: #kept)).
+	tx makeRoot: tx root nested.
+	tx commit.
+	soil checkpoint.
+	segment := soil objectRepository firstSegment.
+	clonePath := segment path, #gc.
+	clone := self verbatimCloneOf: segment.
+	segment replaceWith: clone.
+	self deny: clonePath exists.
+	tx := soil newTransaction.
+	[ self assert: tx root nested label equals: #kept ] ensure: [ tx abort ]
+]
+
 { #category : #helpers }
 SoilObjectRepositoryTest >> threeVersionNestedObjectId [
 	"commit versions #v1/#v2/#v3 (db versions 1/2/3) of a nested object; answer its objectId"
@@ -159,4 +217,21 @@ SoilObjectRepositoryTest >> threeVersionNestedObjectId [
 	oid := tx objectIdOf: tx root nested.
 	tx abort.
 	^ oid
+]
+
+{ #category : #helpers }
+SoilObjectRepositoryTest >> verbatimCloneOf: aSourceSegment [
+	"A complete on-disk copy of the segment (objects + index + indexes) at the .gc path -
+	the trivially valid clone a swap test needs, without faking any vacuum logic. The
+	caller has flushed the source to disk (soil checkpoint) beforehand."
+	| clonePath |
+	clonePath := aSourceSegment path, #gc.
+	clonePath ensureDeleteAll.
+	aSourceSegment path copyAllTo: clonePath.
+	^ SoilObjectSegment new
+		id: aSourceSegment id;
+		objectRepository: soil objectRepository;
+		path: clonePath;
+		open;
+		yourself
 ]

--- a/src/Soil-Core/SoilObjectSegment.class.st
+++ b/src/Soil-Core/SoilObjectSegment.class.st
@@ -279,8 +279,26 @@ SoilObjectSegment >> path: anObject [
 ]
 
 { #category : #printing }
-SoilObjectSegment >> printOn: aStream [ 
-	aStream << 'segment #' << id asString 
+SoilObjectSegment >> printOn: aStream [
+	aStream << 'segment #' << id asString
+]
+
+{ #category : #gc }
+SoilObjectSegment >> replaceWith: aCloneSegment [
+	"Atomically swap this segment's on-disk file set (the directory .../segments/<id>)
+	with a fully written clone produced by makeGCClone (.../segments/<id>.gc). Both share
+	the same parent directory, so a single renameTo: is an atomic rename that also removes
+	the clone directory - moveTo: would recursively COPY a directory and leave the source
+	behind. Quiescent caller only; wrap build+replace in
+	ifCurtailed: [ aCloneSegment path ensureDeleteAll ] so a crash before the rename leaves
+	the original untouched and the clone a deletable orphan."
+	| myPath |
+	aCloneSegment flush; close.
+	self close.
+	myPath := self path.
+	myPath ensureDeleteAll.
+	aCloneSegment path renameTo: myPath basename.
+	self open
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
…laceWith:)

Add the missing segment counterpart to SoilIndexRewriter>>replaceIndex: swap this segment's on-disk file set (the directory .../segments/<id>) with a fully written clone produced by makeGCClone (.../segments/<id>.gc) via close -> ensureDeleteAll -> moveTo: -> reopen. Same-filesystem rename, effectively atomic. Quiescent caller only; the caller wraps build+replace in ifCurtailed: [ clone path ensureDeleteAll ] so a crash before the move leaves the original untouched and the clone a deletable orphan (write-new -> only then touch original, per the GC crash-safety ordering).

This is the foundational, novel piece the offline Track-A vacuum needs; the actual vacuum (root reachability walk + per-object copyVersionChain:upToReadVersion: into the clone + this replace) is the next PR.

Purely additive: no existing method changed. No production caller yet (only tests).

Tests (SoilObjectRepositoryTest, file-backed soil):
- roundtrip: full copy into a clone then replace leaves the DB logically identical.
- compaction: a clone holding only current versions is smaller and drops the version chain, while current reads stay correct.
- curtailed: the documented ifCurtailed caller pattern deletes the orphan clone and leaves the original segment intact.