### PR TITLE
Track A PR2a: segment-level copyVersionChain: + keptVersionsOf: (repo…

### DIFF
--- a/src/Soil-Core-Tests/SoilObjectRepositoryTest.class.st
+++ b/src/Soil-Core-Tests/SoilObjectRepositoryTest.class.st
@@ -140,6 +140,21 @@ SoilObjectRepositoryTest >> testSegmentInitializationFromDisk [
 ]
 
 { #category : #tests }
+SoilObjectRepositoryTest >> testSegmentLevelCopyVersionChainIntoClone [
+	"the segment-level copy writes a gated chain into a detached makeGCClone - what the
+	vacuum needs and what the repository-level copyVersionChain: cannot do (it routes by
+	objectId segment to the repository's own segments)."
+	| oid segment clone |
+	oid := self threeVersionNestedObjectId.
+	segment := soil objectRepository firstSegment.
+	self assert: (segment allVersionsAt: oid index) size equals: 3.
+	clone := segment makeGCClone.
+	[ clone copyVersionChain: (segment allVersionsAt: oid index) upToReadVersion: nil.
+	  self assert: (clone allVersionsAt: oid index) size equals: 1 ]
+		ensure: [ clone close. clone path ensureDeleteAll ]
+]
+
+{ #category : #tests }
 SoilObjectRepositoryTest >> testSegmentReplaceCurtailedLeavesOriginalIntact [
 	"documented caller pattern: build clone, fail before the swap, ifCurtailed deletes
 	the orphan clone and the original segment is untouched."

--- a/src/Soil-Core/SoilObjectRepository.class.st
+++ b/src/Soil-Core/SoilObjectRepository.class.st
@@ -106,35 +106,20 @@ SoilObjectRepository >> close [
 
 { #category : #copying }
 SoilObjectRepository >> copyVersionChain: aCollectionOfClusterVersions [
-	"Copy a full version chain (ordered newest->oldest, as allVersionsAt: returns)
-	into this repository, rebuilding previousVersionPosition. Returns the position
-	of the current (newest) version."
-	| position |
-	position := 0.
-	aCollectionOfClusterVersions reverseDo: [ :cluster | | copy |
-		copy := cluster copyResetPreviousVersion.
-		copy previousVersionPosition: position.
-		position := self at: cluster objectId putBytes: copy serialize ].
-	^ position
+	"Delegate to the segment that owns the chain (all versions of an object share one
+	objectId/segment). See SoilObjectSegment>>copyVersionChain:."
+	aCollectionOfClusterVersions isEmpty ifTrue: [ ^ 0 ].
+	^ (self segmentAt: aCollectionOfClusterVersions first objectId segment)
+		copyVersionChain: aCollectionOfClusterVersions
 ]
 
 { #category : #copying }
 SoilObjectRepository >> copyVersionChain: aCollectionOfClusterVersions upToReadVersion: aNumberOrNil [
-	"Like copyVersionChain: but drop versions no reader can still see: a version is
-	discardable once the smallest read version has moved to or past the version that
-	superseded it, or when there is no open transaction at all (mirrors
-	SoilIndexCleaner>>canDiscardOldState:). The current (newest) version is always
-	kept; nil (no open transactions) keeps only it. The kept suffix is copied via
-	copyVersionChain:, so I4 (previousVersionPosition rebuild, oldest kept -> 0) holds."
-	| kept newerVersion |
-	kept := OrderedCollection new.
-	newerVersion := nil.
-	aCollectionOfClusterVersions do: [ :each |
-		(newerVersion notNil and: [ aNumberOrNil isNil or: [ aNumberOrNil >= newerVersion ] ])
-			ifTrue: [ ^ self copyVersionChain: kept ].
-		kept add: each.
-		newerVersion := each version ].
-	^ self copyVersionChain: kept
+	"Delegate the retention gate + copy to the owning segment. See
+	SoilObjectSegment>>copyVersionChain:upToReadVersion: and keptVersionsOf:upToReadVersion:."
+	aCollectionOfClusterVersions isEmpty ifTrue: [ ^ 0 ].
+	^ (self segmentAt: aCollectionOfClusterVersions first objectId segment)
+		copyVersionChain: aCollectionOfClusterVersions upToReadVersion: aNumberOrNil
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilObjectSegment.class.st
+++ b/src/Soil-Core/SoilObjectSegment.class.st
@@ -117,6 +117,27 @@ SoilObjectSegment >> close [
 		indexManager close ]
 ]
 
+{ #category : #copying }
+SoilObjectSegment >> copyVersionChain: aCollectionOfClusterVersions [
+	"Copy a version chain (ordered newest->oldest, as allVersionsAt: returns) into this
+	segment, rebuilding previousVersionPosition; returns the position of the current
+	(newest) version. Unlike SoilObjectRepository>>copyVersionChain: this targets *this*
+	segment directly - e.g. a detached makeGCClone the repository cannot route to - and
+	does not fire notificationHandler recordWritten: (GC-internal copy)."
+	| position |
+	position := 0.
+	aCollectionOfClusterVersions reverseDo: [ :cluster | | copy |
+		copy := cluster copyResetPreviousVersion.
+		copy previousVersionPosition: position.
+		position := self at: cluster objectId index putBytes: copy serialize ].
+	^ position
+]
+
+{ #category : #copying }
+SoilObjectSegment >> copyVersionChain: aCollectionOfClusterVersions upToReadVersion: aNumberOrNil [
+	^ self copyVersionChain: (self keptVersionsOf: aCollectionOfClusterVersions upToReadVersion: aNumberOrNil)
+]
+
 { #category : #accessing }
 SoilObjectSegment >> flush [
 	self indexManager flush
@@ -202,6 +223,23 @@ SoilObjectSegment >> isMeta [
 { #category : #testing }
 SoilObjectSegment >> isMetaSegment [
 	^ id == 0
+]
+
+{ #category : #copying }
+SoilObjectSegment >> keptVersionsOf: aCollectionOfClusterVersions upToReadVersion: aNumberOrNil [
+	"Return the suffix (newest->oldest) of the chain still needed by a reader at
+	aNumberOrNil (nil = no open transaction): a superseded version is droppable once the
+	smallest read version has reached the version that superseded it. The current version
+	is always kept. Mirrors SoilIndexCleaner>>canDiscardOldState:."
+	| kept newerVersion |
+	kept := OrderedCollection new.
+	newerVersion := nil.
+	aCollectionOfClusterVersions do: [ :each |
+		(newerVersion notNil and: [ aNumberOrNil isNil or: [ aNumberOrNil >= newerVersion ] ])
+			ifTrue: [ ^ kept ].
+		kept add: each.
+		newerVersion := each version ].
+	^ kept
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
… delegates)

The offline vacuum writes into a detached makeGCClone segment, which SoilObjectRepository>>copyVersionChain: cannot target (it routes each cluster by objectId segment to the repository's own segments list). Add the version-chain copy where it actually belongs - on the segment, next to allVersionsAt:/at:putBytes::

- SoilObjectSegment>>copyVersionChain: - reverseDo copy into *this* segment via self at: cluster objectId index putBytes:, rebuilding previousVersionPosition.
- SoilObjectSegment>>keptVersionsOf:upToReadVersion: - the retention gate from PR 2 extracted as a filter that returns the kept suffix, so a caller can both copy the kept versions and walk their references without duplicating the predicate.
- SoilObjectSegment>>copyVersionChain:upToReadVersion: = copyVersionChain: of keptVersionsOf:.
- SoilObjectRepository>>copyVersionChain:[upToReadVersion:] now delegate to the owning segment (DRY). Behaviour-identical for backup/tests: recordWritten: is a no-op on the default SoilNotificationHandler (only SoilMetrics overrides it), so routing the write through the segment instead of repo at:putBytes: changes nothing observable; the segment copy deliberately does not fire it (GC-internal churn).

Covered by the existing repo-level gate tests (now exercising the delegation) plus a new SoilObjectRepositoryTest>>testSegmentLevelCopyVersionChainIntoClone that copies a gated chain straight into a makeGCClone - the exact move the vacuum (next PR) makes.