### PR TITLE
Track A PR2b-1: extract SoilCopyingVisitor common superclass (backup …

### DIFF
--- a/src/Soil-Core/SoilBackupVisitor.class.st
+++ b/src/Soil-Core/SoilBackupVisitor.class.st
@@ -1,6 +1,6 @@
 Class {
 	#name : #SoilBackupVisitor,
-	#superclass : #SoilVisitor,
+	#superclass : #SoilCopyingVisitor,
 	#instVars : [
 		'target'
 	],
@@ -18,30 +18,6 @@ SoilBackupVisitor >> backup: aSoil [
 	
 	self visit: soil.
 	target close
-]
-
-{ #category : #copying }
-SoilBackupVisitor >> copyAllClusterVersions: aSoilPersistentClusterVersion [
-	"copy the full version chain; a single-version object is just a one-element chain"
-	aSoilPersistentClusterVersion hasPreviousVersion
-		ifFalse: [ ^ self copyClusterVersionChain: { aSoilPersistentClusterVersion } ].
-	^ self copyClusterVersionChain:
-		((soil objectRepository segmentAt: aSoilPersistentClusterVersion objectId segment)
-			allVersionsAt: aSoilPersistentClusterVersion objectId index)
-]
-
-{ #category : #copying }
-SoilBackupVisitor >> copyClusterVersionChain: aCollectionOfClusterVersions [
-	"Write the whole version chain into the target, then run the backup-specific
-	graph traversal (references + indexes) in the same oldest-to-newest order the
-	per-version copy used before."
-	| position |
-	position := target objectRepository copyVersionChain: aCollectionOfClusterVersions.
-	aCollectionOfClusterVersions reverseDo: [ :cluster |
-		cluster references do: [ :reference | self processObjectId: reference ].
-		cluster indexIds do: [ :indexId |
-			self copyIndexAt: indexId segment: cluster segment ] ].
-	^ position
 ]
 
 { #category : #visiting }
@@ -95,6 +71,11 @@ SoilBackupVisitor >> target: aSoil [
 	target := aSoil
 ]
 
+{ #category : #copying }
+SoilBackupVisitor >> targetSegmentFor: aSegmentId [
+	^ target objectRepository segmentAt: aSegmentId
+]
+
 { #category : #accessing }
 SoilBackupVisitor >> version: anObject [
 
@@ -136,14 +117,3 @@ SoilBackupVisitor >> visitObjectSegment: aSoilObjectSegment [
 		lastObjectIndex: aSoilObjectSegment lastObjectIndex  
 ]
 
-{ #category : #visiting }
-SoilBackupVisitor >> visitPersistentClusterVersion: aSoilPersistentClusterVersion [ 
-	super visitPersistentClusterVersion: aSoilPersistentClusterVersion.
-	"A backup must be a faithful copy of the source database, including full
-	MVCC history - not just the current version. This applies to every segment,
-	not only the meta segment (behavior descriptions): any object can have
-	readers with an old readVersion that need historical versions to still be
-	readable after a restore, exactly like behavior descriptions do."
-	self copyAllClusterVersions: aSoilPersistentClusterVersion.
-	^ aSoilPersistentClusterVersion
-]

--- a/src/Soil-Core/SoilCopyingVisitor.class.st
+++ b/src/Soil-Core/SoilCopyingVisitor.class.st
@@ -1,0 +1,59 @@
+Class {
+	#name : #SoilCopyingVisitor,
+	#superclass : #SoilVisitor,
+	#category : #'Soil-Core-Visitor'
+}
+
+{ #category : #copying }
+SoilCopyingVisitor >> copyAllClusterVersions: aSoilPersistentClusterVersion [
+	"copy the (kept) version chain; a single-version object is just a one-element chain"
+	aSoilPersistentClusterVersion hasPreviousVersion
+		ifFalse: [ ^ self copyClusterVersionChain: { aSoilPersistentClusterVersion } ].
+	^ self copyClusterVersionChain:
+		((soil objectRepository segmentAt: aSoilPersistentClusterVersion objectId segment)
+			allVersionsAt: aSoilPersistentClusterVersion objectId index)
+]
+
+{ #category : #copying }
+SoilCopyingVisitor >> copyClusterVersionChain: aCollectionOfClusterVersions [
+	"Write the kept versions of the chain into the target segment, then run the graph
+	traversal (references + indexes) over the kept versions, oldest-to-newest. Subclasses
+	steer this via keptVersionsOf:, targetSegmentFor: and copyIndexAt:segment:."
+	| kept position |
+	kept := self keptVersionsOf: aCollectionOfClusterVersions.
+	position := (self targetSegmentFor: kept first objectId segment) copyVersionChain: kept.
+	kept reverseDo: [ :cluster |
+		cluster references do: [ :reference | self processObjectId: reference ].
+		cluster indexIds do: [ :indexId |
+			self copyIndexAt: indexId segment: cluster segment ] ].
+	^ position
+]
+
+{ #category : #copying }
+SoilCopyingVisitor >> copyIndexAt: indexId segment: segmentId [
+	"Persist the index into the target. Backup rebuilds it in the target repository;
+	the GC vacuum handles indexes its own way."
+	^ self subclassResponsibility
+]
+
+{ #category : #copying }
+SoilCopyingVisitor >> keptVersionsOf: aCollectionOfClusterVersions [
+	"Which versions of the chain to copy. Default: the whole chain (full history, as
+	backup needs). Subclasses that prune (e.g. the GC vacuum) override this."
+	^ aCollectionOfClusterVersions
+]
+
+{ #category : #copying }
+SoilCopyingVisitor >> targetSegmentFor: aSegmentId [
+	"The segment reachable objects are copied into (understands copyVersionChain:).
+	Backup: the target repository's segment; the GC vacuum: the compaction clone."
+	^ self subclassResponsibility
+]
+
+{ #category : #visiting }
+SoilCopyingVisitor >> visitPersistentClusterVersion: aSoilPersistentClusterVersion [
+	"Copy every reachable persistent cluster's (kept) version chain into the target."
+	super visitPersistentClusterVersion: aSoilPersistentClusterVersion.
+	self copyAllClusterVersions: aSoilPersistentClusterVersion.
+	^ aSoilPersistentClusterVersion
+]


### PR DESCRIPTION
…+ vacuum)

Backup and the coming GC vacuum are two applications of the same "traverse from root and copy each reachable object's version chain into a target". Extract that shared core into a new common superclass SoilCopyingVisitor (SoilVisitor -> SoilCopyingVisitor -> SoilBackupVisitor), so the vacuum can be a sibling rather than a backup subclass.

Moved up from SoilBackupVisitor (unchanged behaviour):
- copyAllClusterVersions: / copyClusterVersionChain: - fetch the chain and, over the kept versions oldest-to-newest, write them to the target segment and follow their references + indexes.
- visitPersistentClusterVersion: - copy every visited cluster's chain.

The differences between applications become seams:
- keptVersionsOf: - which versions to copy. Default (superclass) = the whole chain, which is exactly what backup needs; a pruning subclass (the vacuum) will override.
- targetSegmentFor: - the segment to copy into (understands copyVersionChain: since PR2a). subclassResponsibility; backup returns target objectRepository segmentAt:.
- copyIndexAt:segment: - index persistence. subclassResponsibility; backup keeps its current rebuild-into-target implementation.

SoilBackupVisitor now subclasses SoilCopyingVisitor, drops the three moved methods, and adds targetSegmentFor:. Pure refactor - SoilBackupTest stays 12/12, SoilObjectRepositoryTest 13/13. Depends on PR2a (segment-level copyVersionChain:).