### PR TITLE
Track A PR2b-2: offline object-heap vacuum (Soil>>vacuum)

### DIFF
--- a/src/Soil-Core-Tests/SoilGarbageCollectorFailingVisitor.class.st
+++ b/src/Soil-Core-Tests/SoilGarbageCollectorFailingVisitor.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #SoilGarbageCollectorFailingVisitor,
+	#superclass : #SoilGarbageCollectVisitor,
+	#category : #'Soil-Core-Tests'
+}
+
+{ #category : #testing }
+SoilGarbageCollectorFailingVisitor >> keptVersionsOf: aCollectionOfClusterVersions [
+	"test support: fail during the copy phase, after clones are built, before replace"
+	Error signal: 'injected vacuum failure'
+]

--- a/src/Soil-Core-Tests/SoilGarbageCollectorTest.class.st
+++ b/src/Soil-Core-Tests/SoilGarbageCollectorTest.class.st
@@ -1,0 +1,139 @@
+Class {
+	#name : #SoilGarbageCollectorTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'soil'
+	],
+	#category : #'Soil-Core-Tests'
+}
+
+{ #category : #running }
+SoilGarbageCollectorTest >> setUp [
+	super setUp.
+	soil := (Soil new path: 'soil-gc-tests')
+		destroy;
+		initializeFilesystem;
+		yourself
+]
+
+{ #category : #running }
+SoilGarbageCollectorTest >> tearDown [
+	super tearDown.
+	soil ifNotNil: [ soil close ]
+]
+
+{ #category : #tests }
+SoilGarbageCollectorTest >> testVacuumCurtailedLeavesDatabaseIntact [
+	"if the vacuum fails mid-run (injected during the copy phase, after clones are built),
+	ifCurtailed deletes the clones and the original database is untouched."
+	| tx clonePath |
+	tx := soil newTransaction.
+	tx root: (SoilTestGraphRoot new nested: (SoilTestNestedObject new label: #kept)).
+	tx makeRoot: tx root nested.
+	tx commit.
+	soil checkpoint.
+	clonePath := soil objectRepository firstSegment path, #gc.
+	[ SoilGarbageCollectorFailingVisitor new soil: soil; run ]
+		on: Error do: [ :e | ].
+	self deny: clonePath exists.
+	tx := soil newTransaction.
+	[ self assert: tx root nested label equals: #kept ] ensure: [ tx abort ]
+]
+
+{ #category : #tests }
+SoilGarbageCollectorTest >> testVacuumDropsUnreachableObject [
+	"an object no longer reachable from root is not copied into the compacted segment."
+	| tx dead deadOid tx2 |
+	tx := soil newTransaction.
+	dead := SoilTestNestedObject new label: #dead.
+	tx makeRoot: dead.
+	tx root: (Dictionary new at: #dead put: dead; yourself).
+	tx commit.
+	tx := soil newTransaction.
+	deadOid := tx objectIdOf: (tx root at: #dead).
+	tx abort.
+	tx2 := soil newTransaction.
+	tx2 root removeKey: #dead.
+	tx2 markDirty: tx2 root.
+	tx2 commit.
+	soil checkpoint.
+	self assert: (soil objectRepository firstSegment basicAt: deadOid index ifAbsent: [ nil ]) notNil.
+	soil vacuum.
+	self assert: (soil objectRepository firstSegment basicAt: deadOid index ifAbsent: [ #gone ]) equals: #gone
+]
+
+{ #category : #tests }
+SoilGarbageCollectorTest >> testVacuumKeepsCurrentVersionAndReclaimsOldVersions [
+	"no open reader: the current version stays readable, the superseded version is
+	dropped, and the objects file shrinks."
+	| tx tx2 sizeBefore oid |
+	tx := soil newTransaction.
+	tx root: (SoilTestGraphRoot new nested: (SoilTestNestedObject new label: #v1)).
+	tx makeRoot: tx root nested.
+	tx commit.
+	tx2 := soil newTransaction.
+	tx2 root nested label: #v2.
+	tx2 markDirty: tx2 root nested.
+	tx2 commit.
+	tx := soil newTransaction.
+	oid := tx objectIdOf: tx root nested.
+	tx abort.
+	soil checkpoint.
+	sizeBefore := (soil objectRepository firstSegment path / #objects) size.
+	self assert: (soil objectRepository firstSegment allVersionsAt: oid index) size equals: 2.
+	soil vacuum.
+	tx := soil newTransaction.
+	[ self assert: tx root nested label equals: #v2 ] ensure: [ tx abort ].
+	self assert: (soil objectRepository firstSegment allVersionsAt: oid index) size equals: 1.
+	self assert: (soil objectRepository firstSegment path / #objects) size < sizeBefore
+]
+
+{ #category : #tests }
+SoilGarbageCollectorTest >> testVacuumKeepsVersionsAnOpenReaderNeeds [
+	"a reader pinned at an old readVersion must still find its version after the vacuum."
+	| tx tx2 oid readerTx |
+	tx := soil newTransaction.
+	tx root: (SoilTestGraphRoot new nested: (SoilTestNestedObject new label: #v1)).
+	tx makeRoot: tx root nested.
+	tx commit.
+	tx2 := soil newTransaction.
+	tx2 root nested label: #v2.
+	tx2 markDirty: tx2 root nested.
+	tx2 commit.
+	tx := soil newTransaction.
+	oid := tx objectIdOf: tx root nested.
+	tx abort.
+	readerTx := soil newTransactionForVersion: 1.
+	[ soil vacuum.
+	  self assert: (soil objectRepository firstSegment allVersionsAt: oid index) size equals: 2.
+	  self assert: readerTx root nested label equals: #v1 ]
+		ensure: [ readerTx abort ]
+]
+
+{ #category : #tests }
+SoilGarbageCollectorTest >> testVacuumLeavesNoCloneDirectory [
+	"after a successful vacuum the clone directory has been renamed into place, not left behind."
+	| tx |
+	tx := soil newTransaction.
+	tx root: (SoilTestGraphRoot new nested: (SoilTestNestedObject new label: #kept)).
+	tx makeRoot: tx root nested.
+	tx commit.
+	soil checkpoint.
+	soil vacuum.
+	self deny: (soil objectRepository firstSegment path, #gc) exists
+]
+
+{ #category : #tests }
+SoilGarbageCollectorTest >> testVacuumPreservesIndexedDictionary [
+	"indexes are carried verbatim; the indexed dictionary and its index-only-reachable
+	value must still resolve after the vacuum."
+	| tx |
+	tx := soil newTransaction.
+	tx root: ((SoilIndexedDictionary newWithBackend: SoilSkipList) keySize: 8; maxLevel: 16; yourself).
+	tx root at: #foo put: (SoilTestNestedObject new label: #indexed).
+	tx commit.
+	soil checkpoint.
+	soil vacuum.
+	tx := soil newTransaction.
+	[ self assert: (tx root at: #foo) label equals: #indexed ] ensure: [ tx abort ]
+]

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -522,8 +522,18 @@ Soil >> transactionManager [
 	^ transactionManager
 ]
 
+{ #category : #'memory space' }
+Soil >> vacuum [
+	"Offline object-heap garbage collection (Track A): compact each object segment,
+	dropping unreachable objects and version-chain entries no open reader still needs.
+	Quiescent - no concurrent writers during the run. Meta segment untouched."
+	SoilGarbageCollectVisitor new
+		soil: self;
+		run
+]
+
 { #category : #writing }
-Soil >> writeEverythingToDisk [ 
+Soil >> writeEverythingToDisk [
 	self behaviorRegistry 
 		flush;
 		writeContentsToDisk.

--- a/src/Soil-Core/SoilGarbageCollectVisitor.class.st
+++ b/src/Soil-Core/SoilGarbageCollectVisitor.class.st
@@ -1,93 +1,62 @@
 Class {
 	#name : #SoilGarbageCollectVisitor,
-	#superclass : #SoilVisitor,
+	#superclass : #SoilCopyingVisitor,
 	#instVars : [
-		'newSegment',
-		'indexIds',
-		'behaviorDescriptions',
-		'currentSegment'
+		'readVersion',
+		'clones'
 	],
 	#category : #'Soil-Core-Visitor'
 }
 
-{ #category : #api }
-SoilGarbageCollectVisitor >> cleanIndexes [
-	self halt.
+{ #category : #running }
+SoilGarbageCollectVisitor >> carryIndexesInto: cloneSegment from: sourceSegment [
+	"indexes map key->objectId (position-independent); heap compaction keeps objectIds
+	stable, so copy the index files verbatim into the clone"
+	(cloneSegment path / #indexes) ensureDeleteAll.
+	(sourceSegment path / #indexes) copyAllTo: (cloneSegment path / #indexes)
 ]
 
-{ #category : #api }
-SoilGarbageCollectVisitor >> compactIndexes [
-
+{ #category : #copying }
+SoilGarbageCollectVisitor >> copyIndexAt: indexId segment: segmentId [
+	"indexes are carried verbatim per segment (see run); nothing to do per index, and
+	the reachability of index values comes from the inherited traversal"
+	^ self
 ]
 
-{ #category : #api }
-SoilGarbageCollectVisitor >> garbageCollectHeap [
-	currentSegment := soil objectRepository firstSegment.
-	newSegment := currentSegment makeGCClone.
-	indexIds := Set new.
-	behaviorDescriptions := Set new.
-	self processObjectId: SoilObjectId root.
-	self processLoop.
-	newSegment := nil 
+{ #category : #copying }
+SoilGarbageCollectVisitor >> keptVersionsOf: aCollectionOfClusterVersions [
+	"the vacuum prunes: keep only versions still needed by the smallest open reader"
+	^ (soil objectRepository segmentAt: aCollectionOfClusterVersions first objectId segment)
+		keptVersionsOf: aCollectionOfClusterVersions upToReadVersion: readVersion
 ]
 
-{ #category : #api }
-SoilGarbageCollectVisitor >> garbageCollectMeta [
-self halt.
-	newSegment := soil objectRepository metaSegment makeGCClone.
-	toBeProcessed := behaviorDescriptions asOrderedCollection.
-	self processLoop.
-	newSegment := nil 
+{ #category : #processing }
+SoilGarbageCollectVisitor >> processBehaviorDescription: aSoilObjectId [
+	"meta segment (behavior descriptions) is left untouched by this vacuum, so do not
+	traverse into it (I2 deferred)"
+	^ aSoilObjectId
 ]
 
 { #category : #running }
 SoilGarbageCollectVisitor >> run [
-	self 
-		garbageCollectHeap;
-		garbageCollectMeta;
-		cleanIndexes;
-		compactIndexes
-	
+	"quiescent object-heap vacuum: compact each object segment into a clone (reachable,
+	gated version chains + verbatim indexes) and atomically swap it in"
+	readVersion := soil transactionManager smallestReadVersion.
+	clones := Dictionary new.
+	soil objectRepository flush.
+	[ soil objectRepository segments do: [ :segment | | clone |
+		clone := segment makeGCClone.
+		clone lastObjectIndex: segment lastObjectIndex.
+		self carryIndexesInto: clone from: segment.
+		clones at: segment id put: clone ].
+	  self processObjectId: SoilObjectId root.
+	  self processLoop.
+	  soil objectRepository segments do: [ :segment |
+		segment replaceWith: (clones at: segment id) ] ]
+		ifCurtailed: [ clones valuesDo: [ :clone | clone path ensureDeleteAll ] ]
 ]
 
-{ #category : #visiting }
-SoilGarbageCollectVisitor >> visitDatabaseJournal: aSoilJournal [ 
-	"we ignore the journal for now"
-]
-
-{ #category : #visiting }
-SoilGarbageCollectVisitor >> visitObjectSegment: aSoilObjectSegment [ 
-	self halt.
-	self processObjectId: SoilObjectId root.
-]
-
-{ #category : #visiting }
-SoilGarbageCollectVisitor >> visitPersistentClusterVersion: aSoilPersistentClusterVersion [ 
-	newSegment  
-		at: aSoilPersistentClusterVersion objectId index
-		putBytes: aSoilPersistentClusterVersion serialize.
-	aSoilPersistentClusterVersion references do: [ :reference |
-		self processObjectId: reference ].
-	behaviorDescriptions addAll: aSoilPersistentClusterVersion behaviorDescriptions.
-	[aSoilPersistentClusterVersion indexIds do: [ :indexId |
-		 self visit: (currentSegment indexManager at: indexId ifAbsent: [ Error signal ]) ] ]
-	on: Error do: [:x | ].
-
-	^ aSoilPersistentClusterVersion 
-]
-
-{ #category : #visiting }
-SoilGarbageCollectVisitor >> visitSkipList: aSoilSkipList [ 
-	| newSkipList |
-	indexIds add: aSoilSkipList indexId.
-	newSkipList := newSegment indexManager  
-		createIndexWithId: aSoilSkipList indexId 
-		class: aSoilSkipList class. 
-	newSkipList initializeParametersFrom: aSoilSkipList. 
-	
-	aSoilSkipList newIterator associationsDo: [ :item |
-		item value isRemoved ifFalse: [ 
-			newSkipList at: item key put: item value.
-			self processObjectId: item value asSoilObjectId  ]  ].
-	newSkipList close.
+{ #category : #copying }
+SoilGarbageCollectVisitor >> targetSegmentFor: aSegmentId [
+	^ clones at: aSegmentId
 ]


### PR DESCRIPTION
The first working GC: rebuild SoilGarbageCollectVisitor as a second SoilCopyingVisitor subclass (sibling of SoilBackupVisitor - backup is untouched) that compacts the object heap in place.

Soil>>vacuum runs it quiescently: capture smallestReadVersion once; for each object segment make a makeGCClone and carry its indexes/ directory over verbatim (indexes map key->objectId, position-independent, so they stay valid after heap compaction); traverse from root copying each reachable object's gated version chain into the clone; then replaceWith: each segment. The whole run is wrapped in ifCurtailed: that deletes the clones, so a failure before the swap leaves the database untouched.

The SoilCopyingVisitor seams do the steering: keptVersionsOf: prunes via segment keptVersionsOf:upToReadVersion: (drop versions no open reader still needs; nil = keep only current), targetSegmentFor: returns the clone, copyIndexAt: is a no-op (indexes carried verbatim; index-value reachability comes from the inherited traversal), and processBehaviorDescription: is a no-op (meta segment left untouched - I2 deferred).

Scope: object heap only. Deferred (unchanged): meta/behavior-description tail-trim (I2), SoilConsistencyVisitor/SoilCompareVersionsVisitor gating (I3/I6), updateLastGarbageCollect, removing the Soil>>garbageCollect prototype guard, multi-segment crash markers.

Tests (SoilGarbageCollectorTest): current version kept + old versions reclaimed (file shrinks); a version an open reader needs survives; an unreachable object is dropped; an indexed SoilIndexedDictionary and its index-only-reachable value still resolve; no clone directory left behind; and an injected mid-run failure (SoilGarbageCollectorFailingVisitor) leaves the database intact. SoilBackupTest stays 12/12.