### PR TITLE
Track A PR3: make garbageCollect the vacuum entry + record lastGarbag…

### DIFF
--- a/src/Soil-Core-Tests/SoilGarbageCollectorTest.class.st
+++ b/src/Soil-Core-Tests/SoilGarbageCollectorTest.class.st
@@ -23,8 +23,8 @@ SoilGarbageCollectorTest >> tearDown [
 ]
 
 { #category : #tests }
-SoilGarbageCollectorTest >> testVacuumCurtailedLeavesDatabaseIntact [
-	"if the vacuum fails mid-run (injected during the copy phase, after clones are built),
+SoilGarbageCollectorTest >> testGarbageCollectCurtailedLeavesDatabaseIntact [
+	"if the collect fails mid-run (injected during the copy phase, after clones are built),
 	ifCurtailed deletes the clones and the original database is untouched."
 	| tx clonePath |
 	tx := soil newTransaction.
@@ -41,7 +41,7 @@ SoilGarbageCollectorTest >> testVacuumCurtailedLeavesDatabaseIntact [
 ]
 
 { #category : #tests }
-SoilGarbageCollectorTest >> testVacuumDropsUnreachableObject [
+SoilGarbageCollectorTest >> testGarbageCollectDropsUnreachableObject [
 	"an object no longer reachable from root is not copied into the compacted segment."
 	| tx dead deadOid tx2 |
 	tx := soil newTransaction.
@@ -58,12 +58,12 @@ SoilGarbageCollectorTest >> testVacuumDropsUnreachableObject [
 	tx2 commit.
 	soil checkpoint.
 	self assert: (soil objectRepository firstSegment basicAt: deadOid index ifAbsent: [ nil ]) notNil.
-	soil vacuum.
+	soil garbageCollect.
 	self assert: (soil objectRepository firstSegment basicAt: deadOid index ifAbsent: [ #gone ]) equals: #gone
 ]
 
 { #category : #tests }
-SoilGarbageCollectorTest >> testVacuumKeepsCurrentVersionAndReclaimsOldVersions [
+SoilGarbageCollectorTest >> testGarbageCollectKeepsCurrentVersionAndReclaimsOldVersions [
 	"no open reader: the current version stays readable, the superseded version is
 	dropped, and the objects file shrinks."
 	| tx tx2 sizeBefore oid |
@@ -81,7 +81,7 @@ SoilGarbageCollectorTest >> testVacuumKeepsCurrentVersionAndReclaimsOldVersions 
 	soil checkpoint.
 	sizeBefore := (soil objectRepository firstSegment path / #objects) size.
 	self assert: (soil objectRepository firstSegment allVersionsAt: oid index) size equals: 2.
-	soil vacuum.
+	soil garbageCollect.
 	tx := soil newTransaction.
 	[ self assert: tx root nested label equals: #v2 ] ensure: [ tx abort ].
 	self assert: (soil objectRepository firstSegment allVersionsAt: oid index) size equals: 1.
@@ -89,8 +89,8 @@ SoilGarbageCollectorTest >> testVacuumKeepsCurrentVersionAndReclaimsOldVersions 
 ]
 
 { #category : #tests }
-SoilGarbageCollectorTest >> testVacuumKeepsVersionsAnOpenReaderNeeds [
-	"a reader pinned at an old readVersion must still find its version after the vacuum."
+SoilGarbageCollectorTest >> testGarbageCollectKeepsVersionsAnOpenReaderNeeds [
+	"a reader pinned at an old readVersion must still find its version after the collect."
 	| tx tx2 oid readerTx |
 	tx := soil newTransaction.
 	tx root: (SoilTestGraphRoot new nested: (SoilTestNestedObject new label: #v1)).
@@ -104,36 +104,49 @@ SoilGarbageCollectorTest >> testVacuumKeepsVersionsAnOpenReaderNeeds [
 	oid := tx objectIdOf: tx root nested.
 	tx abort.
 	readerTx := soil newTransactionForVersion: 1.
-	[ soil vacuum.
+	[ soil garbageCollect.
 	  self assert: (soil objectRepository firstSegment allVersionsAt: oid index) size equals: 2.
 	  self assert: readerTx root nested label equals: #v1 ]
 		ensure: [ readerTx abort ]
 ]
 
 { #category : #tests }
-SoilGarbageCollectorTest >> testVacuumLeavesNoCloneDirectory [
-	"after a successful vacuum the clone directory has been renamed into place, not left behind."
+SoilGarbageCollectorTest >> testGarbageCollectLeavesNoCloneDirectory [
+	"after a successful collect the clone directory has been renamed into place, not left behind."
 	| tx |
 	tx := soil newTransaction.
 	tx root: (SoilTestGraphRoot new nested: (SoilTestNestedObject new label: #kept)).
 	tx makeRoot: tx root nested.
 	tx commit.
 	soil checkpoint.
-	soil vacuum.
+	soil garbageCollect.
 	self deny: (soil objectRepository firstSegment path, #gc) exists
 ]
 
 { #category : #tests }
-SoilGarbageCollectorTest >> testVacuumPreservesIndexedDictionary [
+SoilGarbageCollectorTest >> testGarbageCollectPreservesIndexedDictionary [
 	"indexes are carried verbatim; the indexed dictionary and its index-only-reachable
-	value must still resolve after the vacuum."
+	value must still resolve after the collect."
 	| tx |
 	tx := soil newTransaction.
 	tx root: ((SoilIndexedDictionary newWithBackend: SoilSkipList) keySize: 8; maxLevel: 16; yourself).
 	tx root at: #foo put: (SoilTestNestedObject new label: #indexed).
 	tx commit.
 	soil checkpoint.
-	soil vacuum.
+	soil garbageCollect.
 	tx := soil newTransaction.
 	[ self assert: (tx root at: #foo) label equals: #indexed ] ensure: [ tx abort ]
+]
+
+{ #category : #tests }
+SoilGarbageCollectorTest >> testGarbageCollectSetsLastGarbageCollect [
+	"a successful collect records a fresh timestamp in the metadata (advances past the default)."
+	| tx before |
+	tx := soil newTransaction.
+	tx root: (SoilTestGraphRoot new nested: (SoilTestNestedObject new label: #kept)).
+	tx makeRoot: tx root nested.
+	tx commit.
+	before := soil metadata lastGarbageCollect.
+	soil garbageCollect.
+	self assert: soil metadata lastGarbageCollect > before
 ]

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -229,8 +229,10 @@ Soil >> fuelAccept: aGeneralMapper [
 
 { #category : #'memory space' }
 Soil >> garbageCollect [
-	Error signal: 'garbage collect is not ready to be used, yet'.
-	SoilGarbageCollectVisitor new 
+	"Offline object-heap garbage collection (Track A): compact each object segment,
+	dropping unreachable objects and version-chain entries no open reader still needs.
+	Quiescent - no concurrent writers during the run. Meta segment untouched."
+	SoilGarbageCollectVisitor new
 		soil: self;
 		run
 ]
@@ -520,16 +522,6 @@ Soil >> transactionClass [
 Soil >> transactionManager [
 
 	^ transactionManager
-]
-
-{ #category : #'memory space' }
-Soil >> vacuum [
-	"Offline object-heap garbage collection (Track A): compact each object segment,
-	dropping unreachable objects and version-chain entries no open reader still needs.
-	Quiescent - no concurrent writers during the run. Meta segment untouched."
-	SoilGarbageCollectVisitor new
-		soil: self;
-		run
 ]
 
 { #category : #writing }

--- a/src/Soil-Core/SoilGarbageCollectVisitor.class.st
+++ b/src/Soil-Core/SoilGarbageCollectVisitor.class.st
@@ -39,8 +39,8 @@ SoilGarbageCollectVisitor >> processBehaviorDescription: aSoilObjectId [
 
 { #category : #running }
 SoilGarbageCollectVisitor >> run [
-	"quiescent object-heap vacuum: compact each object segment into a clone (reachable,
-	gated version chains + verbatim indexes) and atomically swap it in"
+	"quiescent object-heap garbage collect: compact each object segment into a clone
+	(reachable, gated version chains + verbatim indexes) and atomically swap it in"
 	readVersion := soil transactionManager smallestReadVersion.
 	clones := Dictionary new.
 	soil objectRepository flush.
@@ -53,7 +53,8 @@ SoilGarbageCollectVisitor >> run [
 	  self processLoop.
 	  soil objectRepository segments do: [ :segment |
 		segment replaceWith: (clones at: segment id) ] ]
-		ifCurtailed: [ clones valuesDo: [ :clone | clone path ensureDeleteAll ] ]
+		ifCurtailed: [ clones valuesDo: [ :clone | clone path ensureDeleteAll ] ].
+	soil metadata updateLastGarbageCollect
 ]
 
 { #category : #copying }


### PR DESCRIPTION
…eCollect

Finalise the offline object-heap GC entry now that the vacuum works:

- Soil>>garbageCollect drops its "not ready" Error guard and simply runs the SoilGarbageCollectVisitor - it is now the real, working entry point.
- Soil>>vacuum removed; garbageCollect is the single entry (chosen over vacuum).
- SoilGarbageCollectVisitor>>run records the run by calling soil metadata updateLastGarbageCollect after a successful compaction+replace (skipped on ifCurtailed unwind).

Tests renamed SoilGarbageCollectorTest>>testVacuum* -> testGarbageCollect* and call soil garbageCollect; added testGarbageCollectSetsLastGarbageCollect (the metadata timestamp advances past its default). SoilBackupTest stays 12/12.

Still deferred (later Track-A PRs): consistency/compare gates (I3/I6), meta/behavior- description tail-trim (I2).