### PR TITLE
Track A PR4: opt-in Soil>>checkConsistency (I3/I6), separate from gar…

### DIFF
--- a/src/Soil-Core-Tests/SoilConsistencyFailingVisitor.class.st
+++ b/src/Soil-Core-Tests/SoilConsistencyFailingVisitor.class.st
@@ -1,0 +1,11 @@
+Class {
+	#name : #SoilConsistencyFailingVisitor,
+	#superclass : #SoilConsistencyVisitor,
+	#category : #'Soil-Core-Tests'
+}
+
+{ #category : #testing }
+SoilConsistencyFailingVisitor >> checkCluster: cluster [
+	"test support: inject an inconsistency, captured through the normal check:using: path"
+	self check: cluster using: [ Error signal: 'injected inconsistency' ]
+]

--- a/src/Soil-Core-Tests/SoilConsistencyTest.class.st
+++ b/src/Soil-Core-Tests/SoilConsistencyTest.class.st
@@ -1,0 +1,65 @@
+Class {
+	#name : #SoilConsistencyTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'soil'
+	],
+	#category : #'Soil-Core-Tests'
+}
+
+{ #category : #helpers }
+SoilConsistencyTest >> commitSampleGraph [
+	| tx |
+	tx := soil newTransaction.
+	tx root: (SoilTestGraphRoot new nested: (SoilTestNestedObject new label: #v1)).
+	tx makeRoot: tx root nested.
+	tx commit.
+	tx := soil newTransaction.
+	tx root nested label: #v2.
+	tx markDirty: tx root nested.
+	tx commit
+]
+
+{ #category : #running }
+SoilConsistencyTest >> setUp [
+	super setUp.
+	soil := (Soil new path: 'soil-consistency-tests')
+		destroy;
+		initializeFilesystem;
+		yourself
+]
+
+{ #category : #running }
+SoilConsistencyTest >> tearDown [
+	super tearDown.
+	soil ifNotNil: [ soil close ]
+]
+
+{ #category : #tests }
+SoilConsistencyTest >> testCheckConsistencyPassesAfterGarbageCollect [
+	"the GC must leave the database I3/I6-consistent."
+	self commitSampleGraph.
+	soil garbageCollect.
+	self shouldnt: [ soil checkConsistency ] raise: Error
+]
+
+{ #category : #tests }
+SoilConsistencyTest >> testCheckConsistencyPassesOnHealthyDatabase [
+	self commitSampleGraph.
+	self shouldnt: [ soil checkConsistency ] raise: Error
+]
+
+{ #category : #tests }
+SoilConsistencyTest >> testCheckConsistencyRaisesOnVersionMismatch [
+	"I6: a divergence between scanned max version and control databaseVersion is caught."
+	self commitSampleGraph.
+	soil control databaseVersion: 999.
+	self should: [ soil checkConsistency ] raise: Error
+]
+
+{ #category : #tests }
+SoilConsistencyTest >> testConsistencyVisitorValidateRaisesOnInconsistency [
+	"I3: validate: raises when the check finds any error."
+	self commitSampleGraph.
+	self should: [ SoilConsistencyFailingVisitor new validate: soil ] raise: Error
+]

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -144,8 +144,17 @@ Soil >> behaviorRegistry [
 	^ behaviorRegistry
 ]
 
+{ #category : #checking }
+Soil >> checkConsistency [
+	"Opt-in structural check of this database: index<->heap consistency (I3) and version
+	consistency (I6). Raises on the first violation, otherwise returns self. Not part of
+	garbageCollect - call it explicitly (e.g. after a GC or in CI)."
+	SoilConsistencyVisitor new validate: self.
+	SoilCompareVersionsVisitor new validate: self
+]
+
 { #category : #accessing }
-Soil >> checkpoint [ 
+Soil >> checkpoint [
 	| entry checkpointLSN |
 	semaphore critical: [  
 		"prepare a consistent setting first "

--- a/src/Soil-Core/SoilConsistencyVisitor.class.st
+++ b/src/Soil-Core/SoilConsistencyVisitor.class.st
@@ -102,8 +102,17 @@ SoilConsistencyVisitor >> processObjectId: aSoilObjectId [
 	super processObjectId: aSoilObjectId 
 ]
 
+{ #category : #checking }
+SoilConsistencyVisitor >> validate: aSoil [
+	"run the index<->heap consistency check over aSoil; raise if any inconsistency was found"
+	soil := aSoil.
+	self check.
+	errors ifNotEmpty: [
+		Error signal: 'consistency check found ', errors size printString, ' error(s): ', errors printString ]
+]
+
 { #category : #visiting }
-SoilConsistencyVisitor >> visitDatabaseJournal: aJournal [ 
+SoilConsistencyVisitor >> visitDatabaseJournal: aJournal [
 
 ]
 


### PR DESCRIPTION
…bageCollect

Make the two orphan check visitors usable as an explicit, opt-in structural check - deliberately NOT wired into garbageCollect, which stays lean/fast (a GC run should just GC). Consistency checking is a separate operation you call when you want it (after a GC, in CI, manually).

- SoilConsistencyVisitor>>validate: aSoil - run check over aSoil, raise if errors were found (symmetric with the existing SoilCompareVersionsVisitor>>validate:).
- Soil>>checkConsistency - runs both: index<->heap consistency (I3) + version consistency (I6); raises on the first violation.

A truly preventive gate (check the clone *before* the replace, so a bad clone is never swapped in) is deferred: the check visitors run over a whole Soil, not a bare makeGCClone segment, so that needs a separate clone-level check - checkConsistency will be its building block.

Tests (SoilConsistencyTest): checkConsistency passes on a healthy DB and after a garbageCollect (so the GC provably preserves I3/I6, without slowing the GC itself); raises on an injected version mismatch (I6); and validate: raises on an injected inconsistency via a SoilConsistencyFailingVisitor stub (I3). SoilBackupTest stays 12/12.

Depends on PR3 (garbageCollect entry).