### PR TITLE
Add Soil v5 changelog and announcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ Metacello new
 	baseline: 'Soil';
 	load.
 ```
-Note: For now, Windows is not supported. But v5 will most likely add support for windows
+Note: For now, Windows is not supported. Work on this is ongoing (see [PR #980](https://github.com/ApptiveGrid/Soil/pull/980)) and it is planned for an upcoming release
 
 **caution** Soil is in an early stage meaning there are might be things missing. It is battle tested as it is the driving database behind [ApptiveGrid](http://www.apptivegrid.de) but you might have different requirements. If so, tell us!
 
 ## Latest release
 
-The latest release is [v4](https://github.com/ApptiveGrid/Soil/tree/v4) which you can load via
+The latest release is [v5](https://github.com/ApptiveGrid/Soil/tree/v5) which you can load via
 
 ```smalltalk
 Metacello new 
-	repository: 'github://ApptiveGrid/Soil:v4/src';
+	repository: 'github://ApptiveGrid/Soil:v5/src';
 	baseline: 'Soil';
 	load.
 ```
@@ -60,6 +60,7 @@ If you want to see Soil in action,  [ApptiveGrid](https://www.apptivegrid.de) is
 - Demo ESUG 2022: "ApptiveGrid, a collaborative Database" [Video Youtube](https://www.youtube.com/watch?v=VVkJsIIqMKM)
 
 ### NEWS
+- [ANN] Release V5 [Announcement](https://github.com/ApptiveGrid/Soil/blob/main/docs/versions/ann-v5.md) 2026-07-28
 - A Blog Series about Soil internals [Soil Blog](https://norbert.hartl.name/blog/series/soil.html) 2026-07-24
 - ESUG 2026 Slides are online: "Soil: architectural insights" Slides [PDF](https://archive.marcusdenker.de/Soil/Videos/26-ESUG/2026-07-07-ESUG-Soil-architectural-insights.pdf) 2026-07-15
 - [ANN] Release V4 [Announcement](https://github.com/ApptiveGrid/Soil/blob/main/docs/versions/ann-v4.md) 2026-03-13

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 | date           | version | changelog                                | migration                          |
 | -------------- | ------- | ---------------------------------------- | ---------------------------------- |
+| **2026-07-28** | Soil v5 | [Changelog v5](versions/changelog-v5.md) | X                                  |
 | **2026-03-12** | Soil v4 | [Changelog v4](versions/changelog-v4.md) | [Migration to v4](migration.md) |
 | **2025-07-02** | Soil v3 | [Changelog v3](versions/changelog-v3.md) | X                                  |
 | **2024-07-19** | Soil v2 | [Changelog v2](versions/changelog-v2.md) | X                                  |

--- a/docs/versions/ann-v5.md
+++ b/docs/versions/ann-v5.md
@@ -1,0 +1,26 @@
+# [ANN] Soil v5
+
+We are happy to announce the availability of Soil version 5.
+
+## What is new?
+
+- Automatic change tracking: Soil now computes a recursive content hash for objects and uses it to detect modifications automatically. This removes the need for the explicit `markDirty:` calls that were previously required — something we called out as a goal back in the v4 announcement.
+- Read-only transactions have been hardened: we now distinguish a transaction that is *intentionally* read-only from one that just happens to end up with no changes, and read-only transactions abort automatically instead of committing a no-op.
+- Indexed collections (`SoilPersistentDictionary` and indexed dictionaries) can now be used as non-root objects, not just at the root of the database.
+- A first working garbage collector has landed: `Soil>>garbageCollect` compacts object segments offline by cloning and atomically swapping them in. There's also a new opt-in `Soil>>checkConsistency` you can run separately (e.g. after a GC, or in CI) without slowing down the GC itself. The primitives for a future online/segment-based GC are also in place, though not yet wired up.
+- A new `SoilCommitError` hierarchy lets you catch any commit-time failure with one exception class instead of several unrelated ones.
+- A good number of crash and silent-data-corruption fixes, notably around the graph exporter/importer, backup version history, and depth-first traversal.
+
+The more detailed view can be seen here: https://github.com/ApptiveGrid/Soil/blob/main/docs/versions/changelog-v5.md
+
+## What is planned next?
+
+- Multi-index collections — one list of objects, multiple indexes over it for different lookup use cases (carried over from v4's plan)
+- Partial indexes — an index restricted to a predicate, for fast filtered search and near-free size
+- Windows support — the outstanding PR (#980) needs rework since Soil's stream handling isn't currently Windows-compatible (carried over from v4's plan)
+- Finishing the online/24-7 garbage collector (Track B) on top of the offline GC primitives that landed in v5
+- The remaining offline-GC piece: trimming the meta/behavior-description tail during a GC run
+
+Hope you like it. Give it a spin and then tell us!
+
+Norbert & Marcus

--- a/docs/versions/changelog-v5.md
+++ b/docs/versions/changelog-v5.md
@@ -1,0 +1,77 @@
+# Soil v5
+
+No migration necessary from v4.
+
+---
+
+## New Features & Improvements
+
+### Automatic Change Tracking (removes the need for `markDirty:`)
+
+- Added `#soilRecursiveHash`, a recursive content hash implemented for fixed, byte and variable layouts (plus `Ephemeron`, `Behavior`, and a `WeakLayout` variant for Pharo 11 compatibility)
+- Introduced a **commit strategy** abstraction on the transaction (`readOnly`, `manual tracking`, `automatic tracking`) — automatic tracking is now the default
+- Fingerprints are generated from the recursive hash only once and cached per cluster, avoiding repeated hashing
+- This closes the item announced as planned for v5 in the [v4 announcement](ann-v4.md): removing the need for explicit `markDirty:` calls
+
+### Read-Only Transactions Hardened
+
+- Separated **intentional** read-only (`isReadOnly`) from **effective** read-only (a writable transaction that ends up with no changes / `hasChanges`) so each can be reasoned about independently
+- Read-only transactions now abort automatically instead of silently committing a no-op
+- Read-only transactions in check mode use the fingerprint to detect modification attempts
+
+### Non-Root Indexed Collections
+
+- `SoilPersistentDictionary` can now be used as a non-root object
+- Indexed dictionaries can likewise be non-root; index-creation journal entries can be added to the head or tail of the journal so ordering stays correct
+
+### Commit Error Hierarchy
+
+- Added `SoilCommitError` as a common superclass so callers can catch any commit-time failure generically
+- Concurrent-modification conflicts are now raised as a `SoilCommitError` as well
+
+### Garbage Collection Foundations
+
+- **First working offline GC:** `Soil>>garbageCollect` compacts each object segment by building a clone and atomically swapping it in (new `SoilObjectSegment>>replaceWith:`, the segment-level counterpart to `SoilIndexRewriter>>replaceIndex`)
+- Extracted `SoilCopyingVisitor` as the shared traverse-and-copy core used by both backup and the new GC vacuum
+- Added opt-in `Soil>>checkConsistency`, a separate structural/version consistency check (deliberately *not* run automatically as part of `garbageCollect`, which stays lean and fast)
+- `garbageCollect` runs now update `SoilMetadata>>lastGarbageCollect`
+- Landed the data-layer primitives for a future **online/segment-based** GC (`copyClusterVersionChain:`, `copyVersionChain:upToReadVersion:` gated by `smallestReadVersion`) — foundation only, not yet wired to a GC entry point
+
+### Misc
+
+- Added `at:ifAbsentPut:`
+- Removed the `fuel` dependency from the baseline (no longer needed)
+
+---
+
+## Bug Fixes
+
+- Fixed `SoilBehaviorRegistry>>detectIndex:` crashing on `NotFound`
+- Fixed the `SoilBehaviorRegistry` version-history cache going stale after commit — reworked to append instead of invalidate
+- Fixed `SoilBackupVisitor` not copying the full version history for all segments
+- Fixed `SoilFindRecordsVisitor` aborting the entire scan when it hit one bad object
+- Fixed `SoilVisitor` depth-first traversal crashing because its `seen` set was left `nil` (two follow-up fixes for related regressions)
+- Fixed silent data loss caused by mutating `objectMap` while iterating it during `prepareCommit`
+- Fixed `SoilTransaction>>behaviorDescriptionFor:` crashing on a cross-transaction visibility gap
+- Fixed silent data corruption in `SoilGraphExporter` / `SoilGraphImporter`
+- Fixed imported behavior not surviving a database close/reopen
+
+---
+
+## Refactoring & Internals
+
+- Removed old (pre-v4) index-format code now that the v4 migration guarantees it is unreachable
+- `SoilFreePage` no longer writes an unused `#latestVersion`
+- `uniqueKeys` is now stored as a bit (`asBit`) instead of a boolean
+- Redesigned behavior descriptions towards immutability
+- Renamed `objectAtLatestVersionWithId:` to `latestObjectWithId:`
+- Disambiguated several "shouldn't happen" exceptions that were previously indistinguishable
+- Added class comments across core classes (`SoilObjectTable`, `SoilPersistentDictionary`, serializer/materializer, ...)
+
+---
+
+## Tests & Documentation
+
+- Added tests for cyclic object structures, duplicate-key edge cases, and `at:ifAbsentPut:`
+- Added a FAQ entry on cyclic structures
+- README updates (ESUG 2026 talk, blog link, PDF links)


### PR DESCRIPTION
No migration necessary from v4.