### PR TITLE
Allow Pharo 14 CI job to fail without failing the whole build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,12 @@ jobs:
       fail-fast: false
       matrix:
         pharoversion: [ Pharo64-14, Pharo64-13, Pharo64-12, Pharo64-11 ]
+        include:
+          - pharoversion: Pharo64-14
+            allow-failure: true
     name: ${{ matrix.pharoversion }}
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.allow-failure == true }}
     steps:
       - uses: actions/checkout@v2
       - uses: hpi-swa/setup-smalltalkCI@v1


### PR DESCRIPTION
Pharo 14 currently has an upstream bug causing CI failures unrelated to this package. Mark Pharo64-14 as an allowed-failure matrix target via continue-on-error, so the other Pharo versions still gate merges while a Pharo14 failure only shows as a warning.