### PR TITLE
Add missing initialize to SoilReadOnlyStrategy

### DIFF
--- a/src/Soil-Core-Tests/SoilReadOnlyStrategyTest.class.st
+++ b/src/Soil-Core-Tests/SoilReadOnlyStrategyTest.class.st
@@ -1,0 +1,36 @@
+Class {
+	#name : #SoilReadOnlyStrategyTest,
+	#superclass : #TestCase,
+	#category : #'Soil-Core-Tests-Model'
+}
+
+{ #category : #tests }
+SoilReadOnlyStrategyTest >> testDefaultsToErrorOnWriteAttempts [
+	"SoilReadOnlyStrategy had no initialize - ignoreWriteAttempts defaulted to nil,
+	which markDirty:/prepareCommit/recordMaterialized:materializer: all check via
+	`ignoreWriteAttempts ifFalse: [...]`, crashing with a non-boolean-receiver error
+	on any read-only transaction that never explicitly called errorOnWriteAttempts/
+	ignoreWriteAttempts first (e.g. the plain Soil>>newReadOnlyTransaction path,
+	as opposed to AGBaseDatabase's overridden one). Default should be the safe,
+	protective behavior: error on write attempts."
+	self should: [ SoilReadOnlyStrategy new markDirty: 42 ]
+		raise: SoilWriteOnReadOnlyTransaction
+]
+
+{ #category : #tests }
+SoilReadOnlyStrategyTest >> testIgnoreWriteAttemptsSuppressesTheError [
+	| strategy |
+	strategy := SoilReadOnlyStrategy new.
+	strategy ignoreWriteAttempts.
+	strategy markDirty: 42
+]
+
+{ #category : #tests }
+SoilReadOnlyStrategyTest >> testErrorOnWriteAttemptsAfterIgnore [
+	| strategy |
+	strategy := SoilReadOnlyStrategy new.
+	strategy ignoreWriteAttempts.
+	strategy errorOnWriteAttempts.
+	self should: [ strategy markDirty: 42 ]
+		raise: SoilWriteOnReadOnlyTransaction
+]

--- a/src/Soil-Core/SoilReadOnlyStrategy.class.st
+++ b/src/Soil-Core/SoilReadOnlyStrategy.class.st
@@ -7,8 +7,14 @@ Class {
 	#category : #'Soil-Core'
 }
 
+{ #category : #initialization }
+SoilReadOnlyStrategy >> initialize [
+	super initialize.
+	ignoreWriteAttempts := false
+]
+
 { #category : #accessing }
-SoilReadOnlyStrategy >> errorOnWriteAttempts [ 
+SoilReadOnlyStrategy >> errorOnWriteAttempts [
 	ignoreWriteAttempts := false
 ]
 


### PR DESCRIPTION
ignoreWriteAttempts had no default - it stayed nil until either errorOnWriteAttempts or ignoreWriteAttempts was called explicitly. markDirty:/prepareCommit/recordMaterialized:materializer: all guard via `ignoreWriteAttempts ifFalse: [...]`, which crashes with a non-boolean-receiver error on nil rather than erroring cleanly or silently allowing the write.

AGBaseDatabase>>newReadOnlyTransaction always sets one of the two explicitly right after construction, so this was masked there, but the plain Soil>>newReadOnlyTransaction path (used directly, without that override) hits the crash. Defaults to false - the safe, protective "error on write attempts" behavior.

ignoreWriteAttempts/errorOnWriteAttempts (no colon) are left as-is - they're paired mode-setters, not a broken getter/setter pair; nothing calls either one to just read the current value.