### PR TITLE
Add regression test for the plain Soil newReadOnlyTransaction crash

### DIFF
--- a/src/Soil-Core-Tests/SoilTransactionTest.class.st
+++ b/src/Soil-Core-Tests/SoilTransactionTest.class.st
@@ -138,6 +138,23 @@ SoilTransactionTest >> testPrepareCommitSurvivesObjectMapGrowingDuringScan [
 ]
 
 { #category : #tests }
+SoilTransactionTest >> testNewReadOnlyTransactionDoesNotCrashOnRoot [
+	"regression test for SoilReadOnlyStrategy's missing initialize (see
+	SoilReadOnlyStrategyTest) - exercised here through the real, plain Soil>>
+	newReadOnlyTransaction path (not AGBaseDatabase's overridden one, which
+	always explicitly calls errorOnWriteAttempts/ignoreWriteAttempts right after
+	construction and so never hit the nil default in practice)."
+	| tx |
+	tx := soil newTransaction.
+	tx root: Object new.
+	tx commit.
+
+	tx := soil newReadOnlyTransaction.
+	self assert: tx root class equals: Object.
+	tx abort
+]
+
+{ #category : #tests }
 SoilTransactionTest >> testRootObject [
 	| tx obj |
 	obj := Object new.


### PR DESCRIPTION
Covers the exact scenario PR #1192 fixed but didn't test end-to-end: a plain Soil (not AGBaseDatabase, which always explicitly sets errorOnWriteAttempts/ignoreWriteAttempts right after construction and so never hit the bug in practice), newReadOnlyTransaction, then root - this used to crash with a non-boolean-receiver error since SoilReadOnlyStrategy>>ignoreWriteAttempts defaulted to nil. Verified this fails with the fix reverted and passes with it restored.