### PR TITLE
Fix Soil>>printOn: always printing empty brackets

### DIFF
--- a/src/Soil-Core-Tests/SoilTest.class.st
+++ b/src/Soil-Core-Tests/SoilTest.class.st
@@ -411,6 +411,36 @@ SoilTest >> testMigrationVersionsHalf [
 ]
 
 { #category : #tests }
+SoilTest >> testPrintString [
+
+	self
+		assert: soil printString
+		equals: 'Soil [0] ' , soil path pathString
+]
+
+{ #category : #tests }
+SoilTest >> testPrintStringAfterCommit [
+
+	soil newTransaction
+		root: Object new;
+		commit.
+
+	self
+		assert: soil printString
+		equals: 'Soil [1] ' , soil path pathString
+]
+
+{ #category : #tests }
+SoilTest >> testPrintStringWhenClosed [
+
+	soil close.
+
+	self
+		assert: soil printString
+		equals: 'Soil [closed] ' , soil path pathString
+]
+
+{ #category : #tests }
 SoilTest >> testRootSendingClass [
 	"We have a root in a Dictionary and that object overrides #= that checks using #class.
 	This tests that the proxy forwards #class correctly"

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -450,8 +450,8 @@ Soil >> path: aString [
 Soil >> printOn: aStream [ 
 	aStream << 'Soil ['.
 	self isOpen 
-		ifTrue: [ self control databaseVersion printString ]
-		ifFalse: [ #closed ].
+		ifTrue: [ aStream print: self control databaseVersion ]
+		ifFalse: [ aStream << #closed ].
 	aStream 
 		<< '] '
 		<< self path pathString

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -450,7 +450,7 @@ Soil >> path: aString [
 Soil >> printOn: aStream [ 
 	aStream << 'Soil ['.
 	self isOpen 
-		ifTrue: [ aStream print: self control databaseVersion ]
+		ifTrue: [ self control databaseVersion printOn: aStream ]
 		ifFalse: [ aStream << #closed ].
 	aStream 
 		<< '] '

--- a/src/Soil-Core/SoilReadOnlyStrategy.class.st
+++ b/src/Soil-Core/SoilReadOnlyStrategy.class.st
@@ -7,12 +7,6 @@ Class {
 	#category : #'Soil-Core'
 }
 
-{ #category : #initialization }
-SoilReadOnlyStrategy >> initialize [
-	super initialize.
-	ignoreWriteAttempts := false
-]
-
 { #category : #accessing }
 SoilReadOnlyStrategy >> errorOnWriteAttempts [
 	ignoreWriteAttempts := false
@@ -26,6 +20,12 @@ SoilReadOnlyStrategy >> hasChanges [
 { #category : #accessing }
 SoilReadOnlyStrategy >> ignoreWriteAttempts [ 
 	ignoreWriteAttempts := true
+]
+
+{ #category : #initialization }
+SoilReadOnlyStrategy >> initialize [
+	super initialize.
+	ignoreWriteAttempts := false
 ]
 
 { #category : #testing }


### PR DESCRIPTION
The ifTrue:ifFalse: computed the database version, or #closed, and then discarded the result rather than writing it to the stream. 

Result:
* An open database printed as 'Soil [] /path/to/db' with the version never shown, 
* A closed database printed as 'Soil [] /path/to/db' with the word "closed" never shown

Fix:
Write to aStream in both branches.