### PR TITLE
Finish the application migration so it can be run on a real database

### DIFF
--- a/src/Soil-Core-Tests/SoilTest.class.st
+++ b/src/Soil-Core-Tests/SoilTest.class.st
@@ -388,7 +388,7 @@ SoilTest >> testMigrationHalfForced [
 { #category : #tests }
 SoilTest >> testMigrationVersionsFull [
 	soil fabric applicationMigrationClass: SoilTestApplicationMigrationFull.
-	self assertCollection: soil newApplicationMigration availableVersions hasSameElements: #( 2 3 4 ).
+	self assertCollection: soil newApplicationMigration availableVersions hasSameElements: #( 1 2 3 4 ).
 	
 	soil control applicationVersion: 2.
 	self assertCollection: soil newApplicationMigration availableVersions hasSameElements: #( 3 4 ).
@@ -399,7 +399,7 @@ SoilTest >> testMigrationVersionsFull [
 { #category : #tests }
 SoilTest >> testMigrationVersionsHalf [
 	soil fabric applicationMigrationClass: SoilTestApplicationMigrationHalf.
-	self assertCollection: soil newApplicationMigration availableVersions hasSameElements: #( 2 ).
+	self assertCollection: soil newApplicationMigration availableVersions hasSameElements: #( 1 2 ).
 	
 	soil control applicationVersion: 2.
 	self assertCollection: soil newApplicationMigration availableVersions hasSameElements: #( ).

--- a/src/Soil-Core/SoilApplicationMigration.class.st
+++ b/src/Soil-Core/SoilApplicationMigration.class.st
@@ -34,20 +34,18 @@ SoilApplicationMigration >> initialize [
 	all := false
 ]
 
-{ #category : #accessing }
-SoilApplicationMigration >> lastVersion [
-	^ self availableVersions last
-]
-
 { #category : #API }
 SoilApplicationMigration >> migrate [
-	self migrateUpToVersion: self lastVersion
+	self needsMigration ifFalse: [ ^ self ].
+	self migrateUpToVersion: self targetVersion
 ]
 
 { #category : #API }
 SoilApplicationMigration >> migrateUpToVersion: applicationVersion [  
 	| txn succeeded |
-	self persistentVersion to: applicationVersion do: [ :version |
+	"persistentVersion is the version that has been applied already, so the
+	first step still to run is the one following it"
+	self persistentVersion + 1 to: applicationVersion do: [ :version |
 		succeeded := false.
 		txn := soil newTransaction.
 		[ 
@@ -73,6 +71,11 @@ SoilApplicationMigration >> migrateVersion: version transaction: aSoilTransactio
 		ifFalse: [ false ]
 ]
 
+{ #category : #testing }
+SoilApplicationMigration >> needsMigration [
+	^ self persistentVersion < self targetVersion
+]
+
 { #category : #versions }
 SoilApplicationMigration >> persistentVersion [
 	
@@ -89,6 +92,16 @@ SoilApplicationMigration >> persistentVersion: version [
 SoilApplicationMigration >> soil: anObject [
 
 	soil := anObject
+]
+
+{ #category : #versions }
+SoilApplicationMigration >> targetVersion [
+	"the version to migrate up to. Defaults to the highest version that can be
+	reached through the pragmas. Applications keeping their target version
+	elsewhere, e.g. in the code base, override this"
+	^ self availableVersions
+		ifEmpty: [ self persistentVersion ]
+		ifNotEmpty: [ :versions | versions last ]
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilControlFile.class.st
+++ b/src/Soil-Core/SoilControlFile.class.st
@@ -133,7 +133,9 @@ SoilControlFile >> initialize [
 SoilControlFile >> initializeStart [
 	self databaseFormatVersion: Soil databaseFormatVersion.
 	self basicDatabaseVersion: 0.
-	self applicationVersion: 1
+	"no application migration has run yet. Version 1 is a step like any other
+	and has to stay available to a fresh database"
+	self applicationVersion: 0
 ]
 
 { #category : #inspector }


### PR DESCRIPTION
migrateUpToVersion: started its loop at persistentVersion, which is the version that has already been applied, so the first step was executed a second time. availableVersions meanwhile filtered on > persistentVersion, so the two disagreed with each other. Start the loop after the persisted version, and initialize a fresh control file with application version 0 so version 1 stays a step like any other.

migrate asked for lastVersion, which failed with a SubscriptOutOfBounds on an up to date database because availableVersions is empty then. lastVersion is replaced by targetVersion, which falls back to the persisted version, and migrate returns early unless needsMigration finds something to do. Both targetVersion and the existing persistentVersion are meant to be overridden by applications that determine their current or target version differently, e.g. from the code base.

testMigrationFull/Half/HalfForced are unchanged and still green. testMigrationVersionsFull/Half now expect the leading version 1, since a fresh database no longer counts it as applied. SoilBackupTest green.