### PR TITLE
Let applications supply the transaction a version step runs in

### DIFF
--- a/src/Soil-Core-Tests/SoilTest.class.st
+++ b/src/Soil-Core-Tests/SoilTest.class.st
@@ -386,6 +386,21 @@ SoilTest >> testMigrationHalfForced [
 ]
 
 { #category : #tests }
+SoilTest >> testMigrationKeepsVersionsBeforeFailingOne [
+	| txn |
+	soil fabric applicationMigrationClass: SoilTestApplicationMigrationFailing.
+	self should: [ soil newApplicationMigration migrate ] raise: Error.
+	"the versions applied before the failing one keep their commit and the
+	persistent version stops right before it, so a later run resumes there"
+	self assert: soil control applicationVersion equals: 2.
+	txn := soil newTransaction.
+	self assert: (txn root at: #two) equals: 2.
+	self deny: (txn root includesKey: #three).
+	txn abort.
+	self assert: soil newApplicationMigration needsMigration
+]
+
+{ #category : #tests }
 SoilTest >> testMigrationVersionsFull [
 	soil fabric applicationMigrationClass: SoilTestApplicationMigrationFull.
 	self assertCollection: soil newApplicationMigration availableVersions hasSameElements: #( 1 2 3 4 ).

--- a/src/Soil-Core-Tests/SoilTestApplicationMigrationFailing.class.st
+++ b/src/Soil-Core-Tests/SoilTestApplicationMigrationFailing.class.st
@@ -1,0 +1,30 @@
+Class {
+	#name : #SoilTestApplicationMigrationFailing,
+	#superclass : #SoilApplicationMigration,
+	#category : #'Soil-Core-Tests-TestData'
+}
+
+{ #category : #accessing }
+SoilTestApplicationMigrationFailing >> v1: transaction [
+	<applicationVersion: 1 auto: true>
+	transaction root: SoilPersistentDictionary new
+]
+
+{ #category : #accessing }
+SoilTestApplicationMigrationFailing >> v2: transaction [
+	<applicationVersion: 2 auto: true>
+	transaction root at: #two put: 2
+]
+
+{ #category : #accessing }
+SoilTestApplicationMigrationFailing >> v3: transaction [
+	<applicationVersion: 3 auto: true>
+	transaction root at: #three put: 3.
+	Error signal: 'this version cannot be applied'
+]
+
+{ #category : #accessing }
+SoilTestApplicationMigrationFailing >> v4: transaction [
+	<applicationVersion: 4 auto: true>
+	transaction root at: #four put: 4
+]

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -345,6 +345,13 @@ Soil >> metadata [
 	^ metadata
 ]
 
+{ #category : #actions }
+Soil >> migrateApplication [
+	"run the application migration up to the version the migration considers
+	current. Answering early when there is nothing to do"
+	^ self newApplicationMigration migrate
+]
+
 { #category : #migration }
 Soil >> migrateDatabaseFormat [
 	"open for migration by just resuming the incompatible version 

--- a/src/Soil-Core/SoilApplicationMigration.class.st
+++ b/src/Soil-Core/SoilApplicationMigration.class.st
@@ -22,6 +22,12 @@ SoilApplicationMigration >> availableVersions [
 	^ versions collect: [ :pragma | pragma arguments first ]
 ]
 
+{ #category : #hooks }
+SoilApplicationMigration >> didMigrateVersion: version transaction: aSoilTransaction [
+	"a version has been applied and the persistent version has been advanced"
+	soil metadata updateLastModified
+]
+
 { #category : #accessing }
 SoilApplicationMigration >> forceMigration: anObject [
 
@@ -44,7 +50,9 @@ SoilApplicationMigration >> migrate [
 SoilApplicationMigration >> migrateUpToVersion: applicationVersion [  
 	| txn succeeded |
 	"persistentVersion is the version that has been applied already, so the
-	first step still to run is the one following it"
+	first step still to run is the one following it. Every step runs in a
+	transaction of its own and is committed on its own, so a failing step does
+	not roll back the steps that already succeeded"
 	self persistentVersion + 1 to: applicationVersion do: [ :version |
 		succeeded := false.
 		txn := soil newTransaction.
@@ -56,7 +64,8 @@ SoilApplicationMigration >> migrateUpToVersion: applicationVersion [
 					succeeded 
 						ifTrue: [ 
 							txn commit.
-							self persistentVersion: version ]
+							self persistentVersion: version.
+							self didMigrateVersion: version transaction: txn ]
 						ifFalse: [ txn abort ] ] ]
 ]
 
@@ -118,6 +127,9 @@ SoilApplicationMigration >> versionPragmaAt: anInteger [
 
 { #category : #versions }
 SoilApplicationMigration >> versionPragmas [ 
+	"only the methods of this very class are searched, inherited ones are not.
+	Version steps therefore have to live in the class that is instantiated,
+	subclassing to override a hook does not carry them along"
 	^ Pragma 
 		allNamed: #applicationVersion:auto:
 		in: self class


### PR DESCRIPTION
The migration created and committed a transaction per version step itself. An application that already holds an open transaction had no way to run its steps in that one. #newTransaction, #commitTransaction: and #abortTransaction: are now the single places where this is decided, so such an application overrides them to hand in its transaction and leave the commit to its own caller. The default is unchanged: a transaction per step, committed as soon as the step succeeded.

#didMigrateVersion:transaction: is called once a step is applied and the persistent version has been advanced, and updates the metadata's last modified timestamp, which the migration did not do before.

Soil>>migrateApplication runs the migration without the caller having to build one, next to the existing migrateDatabaseFormat.

Records on #versionPragmas that pragma lookup does not follow the superclass chain, so version steps have to live in the class that is instantiated.

SoilTest>>testMigration{Full,Half,HalfForced,VersionsFull,VersionsHalf} green. Verified that a subclass handing in one transaction for all steps persists them together once its caller commits.