### PR TITLE
Report what the application migration is doing

### DIFF
--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -369,6 +369,13 @@ Soil >> migrateDatabaseFormat [
 		migrate
 ]
 
+{ #category : #accessing }
+Soil >> name [
+	"how this database is addressed: the name of its directory. Not an identity,
+	two databases below different roots can carry the same one"
+	^ self path basename
+]
+
 { #category : #actions }
 Soil >> newApplicationMigration [  
 	^ self applicationMigrationClass new 

--- a/src/Soil-Core/SoilApplicationMigration.class.st
+++ b/src/Soil-Core/SoilApplicationMigration.class.st
@@ -40,9 +40,21 @@ SoilApplicationMigration >> initialize [
 	all := false
 ]
 
+{ #category : #logging }
+SoilApplicationMigration >> log: aString [
+	"where the migration reports what it is doing. Applications that collect
+	their log elsewhere override this"
+	(SoilSignal on: aString)
+		databaseId: soil name;
+		emit
+]
+
 { #category : #API }
 SoilApplicationMigration >> migrate [
-	self needsMigration ifFalse: [ ^ self ].
+	self needsMigration ifFalse: [ 
+		self log: 'application version already at ', self targetVersion printString, ', nothing to migrate'.
+		^ self ].
+	self log: 'application version ', self persistentVersion printString, ' needs to be migrated to ', self targetVersion printString.
 	self migrateUpToVersion: self targetVersion
 ]
 
@@ -75,9 +87,12 @@ SoilApplicationMigration >> migrateVersion: version transaction: aSoilTransactio
 	pragma := self versionPragmaAt: version.
 	^ (pragma arguments second | all) 
 		ifTrue: [  
+			self log: 'migrating to application version ', version printString.
 			self perform: pragma method selector with: aSoilTransaction.
 			true ]
-		ifFalse: [ false ]
+		ifFalse: [ 
+			self log: 'stopping before application version ', version printString, ', it is not applied automatically'.
+			false ]
 ]
 
 { #category : #testing }

--- a/src/Soil-Core/SoilSignal.class.st
+++ b/src/Soil-Core/SoilSignal.class.st
@@ -3,7 +3,8 @@ Class {
 	#superclass : #WrapperSignal,
 	#instVars : [
 		'message',
-		'id'
+		'id',
+		'databaseId'
 	],
 	#classVars : [
 		'IdCounter'
@@ -28,6 +29,16 @@ SoilSignal class >> nextId [
 { #category : #'system startup' }
 SoilSignal class >> startUp [
 	IdCounter := 0
+]
+
+{ #category : #accessing }
+SoilSignal >> databaseId [
+	^ databaseId
+]
+
+{ #category : #accessing }
+SoilSignal >> databaseId: anObject [
+	databaseId := anObject
 ]
 
 { #category : #'instance creation' }
@@ -67,6 +78,9 @@ SoilSignal >> printOneLineOn: stream [
 	stream space.
 	self processId printOn: stream base: 10 length: 6 padded: true.
 	stream space.
+	databaseId ifNotNil: [ 
+		stream << (databaseId asString padRightTo: 24).
+		stream space ].
 	message ifNotNil: [  
 		message printOn: stream.
 		stream space ].


### PR DESCRIPTION
The migration ran silently, so an application that wanted to see the progress of a database upgrade had to build its own reporting around it. It now reports through #log:, which emits a SoilSignal, and applications that collect their log elsewhere override that single method.

The signal carries the database it is talking about, so the lines of several databases upgraded in one run stay distinguishable. It is taken from Soil>>id and named databaseId after it.

Reported are: that a migration is needed and up to which version, or that there is nothing to do; every version that is about to be applied; and that migrateUpToVersion: stops before a version which is not applied automatically.

#log: wraps the string with SoilSignal>>on: rather than passing it to #emit:, which leaves the signal without a target and prints a trailing nil after every line.