### PR TITLE
Call the database a signal talks about its name, not its id

### DIFF
--- a/src/Soil-Core/SoilApplicationMigration.class.st
+++ b/src/Soil-Core/SoilApplicationMigration.class.st
@@ -45,7 +45,7 @@ SoilApplicationMigration >> log: aString [
 	"where the migration reports what it is doing. Applications that collect
 	their log elsewhere override this"
 	(SoilSignal on: aString)
-		databaseId: soil name;
+		databaseName: soil name;
 		emit
 ]
 

--- a/src/Soil-Core/SoilSignal.class.st
+++ b/src/Soil-Core/SoilSignal.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'message',
 		'id',
-		'databaseId'
+		'databaseName'
 	],
 	#classVars : [
 		'IdCounter'
@@ -32,13 +32,13 @@ SoilSignal class >> startUp [
 ]
 
 { #category : #accessing }
-SoilSignal >> databaseId [
-	^ databaseId
+SoilSignal >> databaseName [
+	^ databaseName
 ]
 
 { #category : #accessing }
-SoilSignal >> databaseId: anObject [
-	databaseId := anObject
+SoilSignal >> databaseName: anObject [
+	databaseName := anObject
 ]
 
 { #category : #'instance creation' }
@@ -78,8 +78,8 @@ SoilSignal >> printOneLineOn: stream [
 	stream space.
 	self processId printOn: stream base: 10 length: 6 padded: true.
 	stream space.
-	databaseId ifNotNil: [ 
-		stream << (databaseId asString padRightTo: 24).
+	databaseName ifNotNil: [ 
+		stream << (databaseName asString padRightTo: 24).
 		stream space ].
 	message ifNotNil: [  
 		message printOn: stream.


### PR DESCRIPTION
SoilSignal carried the database as databaseId, taken from Soil>>name. Two reasons that is the wrong word here. In ApptiveGrid databaseId means the identity a database is addressed by from outside — it appears in REST paths and is compared against a user id in
AGBaseRouteMatch>>ensureBelongsToOwner: — while Soil>>name is the name of a directory, unique only below its parent. And the value in the signal is the one from Soil, so it should be called what Soil calls it.

It is databaseName rather than plain name because #name on a Beacon signal already means which kind of signal it is, is implemented by both BeaconSignal and WrapperSignal, and is read by
BeaconSignal>>printOneLineOn:.

SoilTest>>testMigrationFull and
SoilTest>>testMigrationKeepsVersionsBeforeFailingOne green, and a signal still answers its inherited #name.