### PR TITLE
Separate the version to migrate to from the versions that may run now

### DIFF
--- a/src/Soil-Core-Tests/SoilTest.class.st
+++ b/src/Soil-Core-Tests/SoilTest.class.st
@@ -401,6 +401,58 @@ SoilTest >> testMigrationKeepsVersionsBeforeFailingOne [
 ]
 
 { #category : #tests }
+SoilTest >> testMigrationStopsAtNonAutoVersionAndKeepsNeedingIt [
+	soil fabric applicationMigrationClass: SoilTestApplicationMigrationHalf.
+	soil newApplicationMigration migrate.
+	"the run stops before the version that is not applied automatically. The
+	database must not look fully migrated afterwards, the target is still the
+	highest version there is"
+	self assert: soil control applicationVersion equals: 2.
+	self assert: soil newApplicationMigration needsMigration.
+	self assert: soil newApplicationMigration targetVersion equals: 4
+]
+
+{ #category : #tests }
+SoilTest >> testMigrationToGivenTargetVersion [
+	| migration txn |
+	soil fabric applicationMigrationClass: SoilTestApplicationMigrationFull.
+	migration := soil newApplicationMigration 
+		targetVersion: 2; 
+		yourself.
+	self assert: migration maxVersion equals: 4.
+	migration migrate.
+	self assert: soil control applicationVersion equals: 2.
+	self deny: migration needsMigration.
+	txn := soil newTransaction.
+	self assert: (txn root at: #two) equals: 2.
+	self deny: (txn root includesKey: #three).
+	txn abort
+]
+
+{ #category : #tests }
+SoilTest >> testMigrationToVersionArmedOnTheClass [
+	[ SoilTestApplicationMigrationFull targetVersion: 2.
+	  soil fabric applicationMigrationClass: SoilTestApplicationMigrationFull.
+	  self assert: soil newApplicationMigration targetVersion equals: 2.
+	  "the armed version is held per class, arming one must not arm another"
+	  self assert: SoilTestApplicationMigrationHalf targetVersion equals: 4.
+	  soil migrateApplication.
+	  self assert: soil control applicationVersion equals: 2.
+	  self deny: soil newApplicationMigration needsMigration ]
+		ensure: [ SoilTestApplicationMigrationFull targetVersion: nil ].
+	self assert: SoilTestApplicationMigrationFull targetVersion equals: 4
+]
+
+{ #category : #tests }
+SoilTest >> testMigrationVersionsAfterAppliedNonAutoVersion [
+	soil fabric applicationMigrationClass: SoilTestApplicationMigrationHalf.
+	soil control applicationVersion: 3.
+	"version 3 is not applied automatically, but it is applied. It must not
+	block the versions behind it"
+	self assertCollection: soil newApplicationMigration availableVersions hasSameElements: #( 4 )
+]
+
+{ #category : #tests }
 SoilTest >> testMigrationVersionsFull [
 	soil fabric applicationMigrationClass: SoilTestApplicationMigrationFull.
 	self assertCollection: soil newApplicationMigration availableVersions hasSameElements: #( 1 2 3 4 ).

--- a/src/Soil-Core/SoilApplicationMigration.class.st
+++ b/src/Soil-Core/SoilApplicationMigration.class.st
@@ -3,10 +3,44 @@ Class {
 	#superclass : #Object,
 	#instVars : [
 		'soil',
-		'all'
+		'all',
+		'targetVersion'
+	],
+	#classInstVars : [
+		'targetVersion'
 	],
 	#category : #'Soil-Core-Migration'
 }
+
+{ #category : #versions }
+SoilApplicationMigration class >> defaultTargetVersion [
+	"the version that is live when none has been armed. Applications that decide
+	this elsewhere, e.g. by declaring in the code base which version goes to
+	production, override this with that number"
+	^ self maxVersion
+]
+
+{ #category : #versions }
+SoilApplicationMigration class >> maxVersion [
+	"for callers that have no migration at hand, e.g. when stamping a freshly
+	created database with the version its code is at"
+	^ self new maxVersion
+]
+
+{ #category : #versions }
+SoilApplicationMigration class >> targetVersion [
+	"the version that is meant to be live. A version method is written and
+	tested first and armed afterwards, by setting this, which makes the version a
+	deployment artefact rather than a consequence of the code being loaded"
+	^ targetVersion ifNil: [ self defaultTargetVersion ]
+]
+
+{ #category : #versions }
+SoilApplicationMigration class >> targetVersion: anIntegerOrNil [ 
+	"arm up to this version, or nil to fall back to #defaultTargetVersion. Held
+	per class, so arming one migration does not arm another"
+	targetVersion := anIntegerOrNil
+]
 
 { #category : #versions }
 SoilApplicationMigration >> availableVersions [
@@ -14,11 +48,13 @@ SoilApplicationMigration >> availableVersions [
 	stop := false.
 	versions := OrderedCollection new.
 	persistentVersion := self persistentVersion.
+	"versions that are applied already are none of our business. Checking the
+	auto flag only for the ones above the persistent version keeps an old
+	non-auto version from blocking everything behind it"
 	self versionPragmas do: [ :pragma |
-		(pragma arguments second | all) ifFalse: [ stop := true ].
-		stop ifFalse: [  
-			(pragma arguments first > persistentVersion) ifTrue: [ 
-				versions add: pragma ] ] ].
+		(pragma arguments first > persistentVersion) ifTrue: [ 
+			(pragma arguments second | all) ifFalse: [ stop := true ].
+			stop ifFalse: [ versions add: pragma ] ] ].
 	^ versions collect: [ :pragma | pragma arguments first ]
 ]
 
@@ -49,10 +85,21 @@ SoilApplicationMigration >> log: aString [
 		emit
 ]
 
+{ #category : #versions }
+SoilApplicationMigration >> maxVersion [
+	"the version the loaded code is at: the highest one its version methods
+	declare, regardless of the auto flag. Zero when it declares none, so such a
+	migration never considers a database behind. Reads no database, so it can be
+	asked before there is one"
+	^ self versionPragmas
+		ifEmpty: [ 0 ]
+		ifNotEmpty: [ :pragmas | pragmas last arguments first ]
+]
+
 { #category : #API }
 SoilApplicationMigration >> migrate [
 	self needsMigration ifFalse: [ 
-		self log: 'application version already at ', self targetVersion printString, ', nothing to migrate'.
+		self log: 'application version already at ', self persistentVersion printString, ', nothing to migrate'.
 		^ self ].
 	self log: 'application version ', self persistentVersion printString, ' needs to be migrated to ', self targetVersion printString.
 	self migrateUpToVersion: self targetVersion
@@ -128,12 +175,14 @@ SoilApplicationMigration >> soil: anObject [
 
 { #category : #versions }
 SoilApplicationMigration >> targetVersion [
-	"the version to migrate up to. Defaults to the highest version that can be
-	reached through the pragmas. Applications keeping their target version
-	elsewhere, e.g. in the code base, override this"
-	^ self availableVersions
-		ifEmpty: [ self persistentVersion ]
-		ifNotEmpty: [ :versions | versions last ]
+	"the version to migrate up to. Defaults to what the class has armed, set it
+	to stop short of that for a single run"
+	^ targetVersion ifNil: [ self class targetVersion ]
+]
+
+{ #category : #versions }
+SoilApplicationMigration >> targetVersion: anInteger [ 
+	targetVersion := anInteger
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
#targetVersion answered the highest of #availableVersions, and that collection is a list of candidates: versions above the persistent one, cut off before the first that is not applied automatically. Taking the target from it made a version that has to be applied by hand indistinguishable from being finished. Migrating the half automatic test data stopped after version 2 and then reported "application version already at 2, nothing to migrate", although versions 3 and 4 were waiting and the stop was never even logged, because the loop never reached the version it should have stopped at.

The target is now its own decision, taken on the class. A version method is written and tested first and armed afterwards, through #targetVersion:, which makes the live version a deployment artefact rather than a consequence of the code being loaded. It is held in a class instance variable, so arming one migration does not arm another.

Unarmed, #targetVersion answers #defaultTargetVersion, which defaults to #maxVersion: the highest version the version methods declare, regardless of the auto flag. An application that declares elsewhere which version goes to production overrides #defaultTargetVersion with that number and keeps #targetVersion: working, which it would not if it overrode #targetVersion itself. An instance can still be given a target of its own for a single run.

The auto flag only decides whether the target is reached, which is where it was always evaluated. The half automatic run now reports "needs to be migrated to 4", stops at 3 and says so, keeps answering #needsMigration, and reports the stop again the next time.

#maxVersion reads no database and answers zero when a class declares no version at all, so it can be asked before there is a database — class side included, for a caller that has no migration at hand and wants to stamp a freshly created database with the version its code is at.

#availableVersions tests the auto flag only for versions above the persistent one. A non-auto version that has been applied long ago used to set the stop flag and hide everything behind it; asking about versions that are applied already answers nothing about what may run now.

The "nothing to migrate" line reports the persistent version rather than the target, which is what it is talking about.

Four tests: that an applied non-auto version does not block the versions behind it, that a run stops at a non-auto version without the database looking migrated, that a target given to an instance is honoured, and that arming a class stops the run there without arming its sibling. The six existing SoilTest>>testMigration* are unchanged and green.