### PR TITLE
Fix and unskip SoilIndexedDictionaryTest>>#testAddRandom

### DIFF
--- a/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
+++ b/src/Soil-Core-Tests/SoilIndexedDictionaryTest.class.st
@@ -78,7 +78,7 @@ SoilIndexedDictionaryTest >> testAddAndRemoveExistingList [
 { #category : #tests }
 SoilIndexedDictionaryTest >> testAddRandom [
 	| tx numEntries entries result |
-	self skip.
+	
 	tx := soil newTransaction.
 	tx root: dict.
 	"just some random adding and checking that we can find it, configured to create lots of pages"
@@ -89,22 +89,22 @@ SoilIndexedDictionaryTest >> testAddRandom [
 	numEntries timesRepeat: [ | toAdd |
 		toAdd := (numEntries*20) atRandom.
 		entries add: toAdd.
-		dict at: toAdd  put: toAdd asDummySoilObjectId].
+		dict at: toAdd put: toAdd asString].
 	
 	"check size"
 	self assert: dict size equals: entries size.
 	
 	"can we find all the keys we added?"
-	entries do: [:each | self assert: (dict at: each ) equals: each asDummySoilObjectId].
+	entries do: [:each | self assert: (dict at: each) equals: each asString].
 	
 	"iterate index, all should be in entries"
-	
+
 	result := OrderedCollection new.
 	"we use do: to iterate over the index"
 	dict do: [ :each |
 		result add: each].
 	
-	entries := (entries collect: #asDummySoilObjectId).
+	entries := (entries collect: #asString).
 	result do: [ :each | self assert: (entries includes: each) ].
 	
 	dict reverseDo: [ :each |


### PR DESCRIPTION
The test was using #asDummySoilObjectId (as it started as a copy of the low level tests).

Rewrite the test to use a nornal object, as we should not care about ObjectIDs at the level of the IndexDictionary. 

fixes #1206