### PR TITLE
remove SoilObjectIdNotInitialized for now

### DIFF
--- a/src/Soil-Core/SoilObjectIdNotInitialized.class.st
+++ b/src/Soil-Core/SoilObjectIdNotInitialized.class.st
@@ -1,5 +1,0 @@
-Class {
-	#name : #SoilObjectIdNotInitialized,
-	#superclass : #SoilError,
-	#category : #'Soil-Core-Error'
-}


### PR DESCRIPTION
The exeption SoilObjectIdNotInitialized is not used. Remove it for now, we can add it back when we need it

one step for #1209