### PR TITLE
Open journal fragment files read back from disk read-only

### DIFF
--- a/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
+++ b/src/Soil-Core-Tests/SoilDatabaseJournalTest.class.st
@@ -90,6 +90,46 @@ SoilDatabaseJournalTest >> tearDown [
 ]
 
 { #category : #tests }
+SoilDatabaseJournalTest >> testCurrentFragmentFileStaysWritable [
+	"read-write is reserved for the fragment file currently being written"
+	| readBack |
+	self addDictionaryRoot.
+	self assert: soil journal currentFragmentFile stream class equals: SoilLockableStream.
+	readBack := soil journal openFragmentFileNumber: 0.
+	[ self assert: readBack stream class equals: ZnBufferedReadStream ]
+		ensure: [ readBack close ]
+]
+
+{ #category : #tests }
+SoilDatabaseJournalTest >> testLazilyOpenedFragmentFileIsReadOnly [
+	"fragment files listed from disk open lazily, and that lazy open is read-only"
+	| fragmentFile |
+	self addDictionaryRoot.
+	soil checkpoint.
+	fragmentFile := soil journal fragmentFiles first.
+	self deny: fragmentFile isOpen.
+	[ self assert: fragmentFile entries isNotEmpty.
+	  self assert: fragmentFile isOpen.
+	  self should: [ fragmentFile stream nextPut: 42 ] raise: MessageNotUnderstood ]
+		ensure: [ fragmentFile close ]
+]
+
+{ #category : #tests }
+SoilDatabaseJournalTest >> testReadOnlyFragmentFileRejectsWrites [
+	"a fragment file read back from disk carries no write protocol at all"
+	| fragmentFile sizeBefore |
+	self addDictionaryRoot.
+	soil checkpoint.
+	fragmentFile := soil journal openFragmentFileNumber: 0.
+	sizeBefore := fragmentFile size.
+	[ self should: [ fragmentFile stream nextPut: 42 ] raise: MessageNotUnderstood.
+	  self should: [ fragmentFile stream nextPutAll: #( 1 2 3 4 ) ] raise: MessageNotUnderstood.
+	  self should: [ fragmentFile flush ] raise: MessageNotUnderstood.
+	  self assert: fragmentFile size equals: sizeBefore ]
+		ensure: [ fragmentFile close ]
+]
+
+{ #category : #tests }
 SoilDatabaseJournalTest >> testRecoverWithAtEnd [
 	soil close.
 	soil open.
@@ -220,6 +260,19 @@ SoilDatabaseJournalTest >> testRemoveFragmentFiles [
 	soil setup maxFragmentFiles: 5.
 	10 timesRepeat: [ soil journal cycleFragmentFile ].
 	self assert: soil journal sortedFiles size equals: 5	
+]
+
+{ #category : #tests }
+SoilDatabaseJournalTest >> testSeveralReadersOfSameFragmentFile [
+	"readers of the same fragment file do not lock each other out"
+	| first second |
+	self addDictionaryRoot.
+	soil checkpoint.
+	first := soil journal openFragmentFileNumber: 0.
+	second := soil journal openFragmentFileNumber: 0.
+	[ self assert: first entries isNotEmpty.
+	  self assert: second entries size equals: first entries size ]
+		ensure: [ first close. second close ]
 ]
 
 { #category : #tests }

--- a/src/Soil-Core/SoilBasicVisitor.class.st
+++ b/src/Soil-Core/SoilBasicVisitor.class.st
@@ -80,7 +80,7 @@ SoilBasicVisitor >> visitIndexManager: aSoilIndexManager [
 
 { #category : #visiting }
 SoilBasicVisitor >> visitJournalFragmentFile: aSoilJournalFragmentFile [ 
-	aSoilJournalFragmentFile open.
+	aSoilJournalFragmentFile openReadOnly.
 	[ self visitAll: aSoilJournalFragmentFile transactionJournals ]
 		ensure: [ aSoilJournalFragmentFile close ].
 	^ aSoilJournalFragmentFile 

--- a/src/Soil-Core/SoilDatabaseRecovery.class.st
+++ b/src/Soil-Core/SoilDatabaseRecovery.class.st
@@ -63,9 +63,7 @@ SoilDatabaseRecovery >> readFragmentFileProtected: aSoilFragmentFile [
 			"we currently have no way of reading behind a truncated piece of a fragment. We cycle
 			the fragment file in order to write new entries to a new file. Future reads can just 
 			skip a fragment file on truncated reads"
-			journal 
-				currentFragmentFile: aSoilFragmentFile;
-				cycleFragmentFile ]
+			journal cycleFragmentFileAfter: aSoilFragmentFile ]
 ]
 
 { #category : #private }
@@ -104,9 +102,7 @@ SoilDatabaseRecovery >> recover [
 		do: [ :error | 
 			"in case of a bogus checkpoint position we cannot recover the file but 
 			create a new one and continue"
-			journal 
-				currentFragmentFile: fragmentFile;
-				cycleFragmentFile.
+			journal cycleFragmentFileAfter: fragmentFile.
 			soil checkpoint.
 			^ self ].
 	"If the last checkpoint was successful we are at the end of the file and 

--- a/src/Soil-Core/SoilJournalFragmentFile.class.st
+++ b/src/Soil-Core/SoilJournalFragmentFile.class.st
@@ -242,6 +242,17 @@ SoilJournalFragmentFile >> open [
 	stream := SoilLockableStream path: path 
 ]
 
+{ #category : #'open/close' }
+SoilJournalFragmentFile >> openReadOnly [
+	"Open the fragment file for reading only. A fragment file that has been read
+	back from disk is never written to, so it does not need a lockable stream:
+	the file handle is opened non-writable and any write attempt fails at the
+	stream level. Read-write is reserved for the fragment file currently being
+	written."
+	self isOpen ifTrue: [ self error: 'File already open' ].
+	stream := path binaryReadStream
+]
+
 { #category : #accessing }
 SoilJournalFragmentFile >> path [
 	^ path
@@ -282,6 +293,16 @@ SoilJournalFragmentFile >> setToStart [
 { #category : #accessing }
 SoilJournalFragmentFile >> size [ 
 	^ stream size 
+]
+
+{ #category : #accessing }
+SoilJournalFragmentFile >> stream [
+	"A fragment file reaching this lazy open has never been opened explicitly.
+	The fragment files that are written to are opened through #openFragmentFile:
+	without exception, so whoever arrives here is a reader."
+	^ stream ifNil: [
+		self openReadOnly.
+		stream ]
 ]
 
 { #category : #journal }

--- a/src/Soil-Core/SoilPersistentDatabaseJournal.class.st
+++ b/src/Soil-Core/SoilPersistentDatabaseJournal.class.st
@@ -56,18 +56,22 @@ SoilPersistentDatabaseJournal >> currentFragmentFile [
 ]
 
 { #category : #fragmentfile }
-SoilPersistentDatabaseJournal >> currentFragmentFile: aSoilJournalFragmentFile [ 
-	currentFragmentFile := aSoilJournalFragmentFile
+SoilPersistentDatabaseJournal >> cycleFragmentFile [
+	currentFragmentFile 
+		flush;
+		writeContentsToDisk.
+	self cycleFragmentFileAfter: currentFragmentFile
 ]
 
 { #category : #fragmentfile }
-SoilPersistentDatabaseJournal >> cycleFragmentFile [
+SoilPersistentDatabaseJournal >> cycleFragmentFileAfter: aSoilJournalFragmentFile [ 
+	"Continue writing in a fresh fragment file following the given one. The file
+	passed in may have been opened for reading - recovery reads a fragment and
+	then needs a writable file to proceed - so it is only closed here, without
+	flushing or syncing."
 	| nextFileNumber |
-	nextFileNumber := (self fileNumberFrom: currentFragmentFile filename) + 1.
-	currentFragmentFile 
-		flush;
-		writeContentsToDisk;
-		close.
+	nextFileNumber := (self fileNumberFrom: aSoilJournalFragmentFile filename) + 1.
+	aSoilJournalFragmentFile close.
 	currentFragmentFile := self createFragmentFile: (self filenameFrom: nextFileNumber)
 ]
 
@@ -268,7 +272,16 @@ SoilPersistentDatabaseJournal >> openFragmentFile: filename [
 
 { #category : #'instance creation' }
 SoilPersistentDatabaseJournal >> openFragmentFileNumber: anInteger [ 
-	^ self openFragmentFile: (self filenameFrom: anInteger)
+	"only recovery reads fragment files by number, so this opens read-only"
+	^ self openFragmentFileReadOnly: (self filenameFrom: anInteger)
+]
+
+{ #category : #'instance creation' }
+SoilPersistentDatabaseJournal >> openFragmentFileReadOnly: filename [ 
+	^ (SoilJournalFragmentFile path: self path / filename )
+		databaseJournal: self;
+		openReadOnly;
+		yourself
 ]
 
 { #category : #private }
@@ -318,7 +331,7 @@ SoilPersistentDatabaseJournal >> sortedFiles [
 { #category : #accessing }
 SoilPersistentDatabaseJournal >> transactionJournalsStartingAt: index do: aBlock [ 
 	| fragmentFiles fileIndex |
-	fragmentFiles := self fragmentFiles do: #open.
+	fragmentFiles := self fragmentFiles do: #openReadOnly.
 	fileIndex := fragmentFiles 
 		detectIndex: [ :fragment | fragment firstTransactionId <= index  ]
 		ifNone: [ self error: 'fileIndex not found, should not happen' ].

--- a/src/Soil-File/ZnBufferedReadStream.extension.st
+++ b/src/Soil-File/ZnBufferedReadStream.extension.st
@@ -1,6 +1,13 @@
 Extension { #name : #ZnBufferedReadStream }
 
 { #category : #'*Soil-File' }
+ZnBufferedReadStream >> isOpen [
+	"Soil opens journal fragment files that are read back from disk through a
+	plain read stream. #isOpen completes the protocol SoilBinaryFile expects."
+	^ self closed not
+]
+
+{ #category : #'*Soil-File' }
 ZnBufferedReadStream >> nextLengthEncodedInteger [
 	| value |
 	value := self next.


### PR DESCRIPTION
A fragment file that is read back from disk is never written to, so it does not need a lockable stream: #openReadOnly opens a plain read stream, whose file handle the operating system opens non-writable. Any write attempt now fails at the stream level. Read-write is reserved for the fragment file currently being written.

The read paths follow it. Recovery reads fragments through #openFragmentFileNumber:, the visitor and #transactionJournalsStartingAt:do: open through #openReadOnly, and fragment files listed from disk open read-only through their lazy #stream - a fragment file reaching that lazy open has never been opened explicitly, and the fragment files written to are opened through #openFragmentFile: without exception.

Recovery used to declare a fragment it had only read the current fragment file, just to reach its file number when cycling to a fresh one. #cycleFragmentFileAfter: does that directly and closes the file without flushing or syncing it, which leaves #currentFragmentFile: unused.

ZnBufferedReadStream>>isOpen completes the protocol SoilBinaryFile expects of a stream.