### PR TITLE
Give a resident a process and a cadence instead of hand-building both

### DIFF
--- a/src/Soil-Resident-Tests/SoilActiveResidentTest.class.st
+++ b/src/Soil-Resident-Tests/SoilActiveResidentTest.class.st
@@ -1,0 +1,219 @@
+"
+What the active half of a resident has to be provable against: it starts a
+process, works when there is work, drains while there is more, survives a
+throwing step, is revived by the tick, and acknowledges a cooperative stop
+without sitting out its own cadence first.
+
+The tests synchronise on the work itself -- the dummy signals a semaphore at the
+end of every step -- rather than on a sleep chosen long enough to be safe. The
+durations that do appear are upper bounds for waiting, not pauses.
+"
+Class {
+	#name : #SoilActiveResidentTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'soil',
+		'supervisor'
+	],
+	#category : #'Soil-Resident-Tests'
+}
+
+{ #category : #helpers }
+SoilActiveResidentTest >> path [
+	^ 'soil-active-resident-tests'
+]
+
+{ #category : #helpers }
+SoilActiveResidentTest >> residentWith: aBlock [
+	"add a dummy active resident configured by the block, start everything the way
+	an embedder does, and answer the running instance"
+	| description txn |
+	description := SoilTestActiveResidentDescription new.
+	aBlock value: description.
+	soil addResidentDescription: description.
+	supervisor := soil newResidentSupervisor.
+	txn := soil newTransaction.
+	[ supervisor loadFrom: txn.
+	supervisor startAllIn: txn ]
+		ensure: [ txn abort ].
+	^ supervisor residentNamed: #active
+]
+
+{ #category : #running }
+SoilActiveResidentTest >> setUp [
+	super setUp.
+	soil := SoilTestResidentDatabase path: self path.
+	soil
+		destroy;
+		initializeFilesystem;
+		initializeRoot
+]
+
+{ #category : #helpers }
+SoilActiveResidentTest >> stopWithin: aDuration [
+	| txn |
+	txn := soil newTransaction.
+	^ [ supervisor stopAllIn: txn timeout: aDuration ]
+		ensure: [ txn isAborted ifFalse: [ txn abort ] ]
+]
+
+{ #category : #running }
+SoilActiveResidentTest >> tearDown [
+	supervisor ifNotNil: [ self stopWithin: 2 seconds ].
+	soil ifNotNil: [
+		soil close.
+		soil destroy ].
+	super tearDown
+]
+
+{ #category : #tests }
+SoilActiveResidentTest >> testACoalescingWindowTurnsABurstIntoOneStep [
+	"the reason the strategy exists: work that is triggered far more often than it
+	needs to be done must not cost one step per trigger"
+	| resident |
+	resident := self residentWith: [ :d |
+		d cadence: #coalescing; window: 200 milliSeconds ].
+
+	5 timesRepeat: [ resident noteWork ].
+
+	self assert: (resident waitForStepWithin: 3 seconds).
+	self assert: resident stepCount equals: 1.
+	self deny: (resident waitForStepWithin: 300 milliSeconds)
+]
+
+{ #category : #tests }
+SoilActiveResidentTest >> testAThrowingStepIsCountedAndTheLoopSurvivesIt [
+	"a transient failure must not take a resident down; a permanent one shows up
+	as a climbing count rather than as silence"
+	| resident |
+	resident := self residentWith: [ :d | d cadence: #signal ].
+	resident throwOnStep: true.
+
+	resident noteWork.
+	self assert: (resident waitForStepWithin: 3 seconds).
+
+	self assert: resident stepErrorCount equals: 1.
+	self assert: resident lastStepError notNil.
+	self assert: resident hasRunningProcess.
+
+	resident throwOnStep: false.
+	resident noteWork.
+	self assert: (resident waitForStepWithin: 3 seconds).
+	self assert: resident stepCount equals: 2.
+	self assert: resident stepErrorCount equals: 1
+]
+
+{ #category : #tests }
+SoilActiveResidentTest >> testAnIntervalIsDueAtOnceAndNotAgainBeforeItElapsed [
+	"unit test on the strategy, without a process: a freshly opened database
+	should not stay stale for a first interval, and afterwards the clock decides"
+	| strategy |
+	strategy := SoilIntervalRunStrategy new
+		resident: SoilTestActiveResident new;
+		interval: 10 minutes;
+		yourself.
+
+	self assert: strategy isDue.
+
+	strategy lastRun: DateAndTime now.
+	self deny: strategy isDue.
+
+	strategy lastRun: DateAndTime now - 11 minutes.
+	self assert: strategy isDue
+]
+
+{ #category : #tests }
+SoilActiveResidentTest >> testAnIntervalWaitIsCutShortByAStopRequest [
+	"the failure the old AGIntervalRunStrategy has: waited out on the clock, a
+	stop would have to sit through the whole interval, and the embedder's timeout
+	would have to exceed the longest interval in the system"
+	| resident pending |
+	resident := self residentWith: [ :d |
+		d cadence: #interval; interval: 10 minutes ].
+	self assert: (resident waitForStepWithin: 3 seconds).
+
+	pending := self stopWithin: 2 seconds.
+	supervisor := nil.
+
+	self assert: pending isEmpty.
+	self assert: resident isStopped
+]
+
+{ #category : #tests }
+SoilActiveResidentTest >> testDrainsWhileWorkRemainsWithoutFurtherSignals [
+	"one wake-up, four steps: a tracker woken once works through what is there
+	instead of needing a signal per item"
+	| resident |
+	resident := self residentWith: [ :d | d cadence: #signal ].
+	resident workToLeave: 3.
+
+	resident noteWork.
+
+	1 to: 4 do: [ :each |
+		self
+			assert: (resident waitForStepWithin: 3 seconds)
+			description: 'step ' , each printString , ' did not arrive' ].
+	self assert: resident stepCount equals: 4.
+	self deny: (resident waitForStepWithin: 300 milliSeconds)
+]
+
+{ #category : #tests }
+SoilActiveResidentTest >> testStartsAProcessAndAcknowledgesACooperativeStop [
+	| resident pending |
+	resident := self residentWith: [ :d | d cadence: #signal ].
+
+	self assert: resident hasRunningProcess.
+	self assert: resident isStarted.
+	self assert: resident prepareCount equals: 1.
+
+	pending := self stopWithin: 2 seconds.
+	supervisor := nil.
+
+	self assert: pending isEmpty.
+	self assert: resident isStopped
+]
+
+{ #category : #tests }
+SoilActiveResidentTest >> testThePendingFlagIsClearedBeforeTheStepNotAfter [
+	"so that a change arriving while a step runs survives it. Cleared afterwards,
+	it would be swallowed; cleared before, the worst case is one redundant step,
+	and that beats a lost one"
+	| resident |
+	resident := SoilTestActiveResident new.
+
+	resident noteWork.
+	resident workToLeave: 0.
+	resident runStepProtected.
+	self deny: resident hasPendingWork.
+
+	resident workToLeave: 1.
+	resident runStepProtected.
+	self assert: resident hasPendingWork
+]
+
+{ #category : #tests }
+SoilActiveResidentTest >> testTickRevivesATerminatedProcessAndCountsTheRestart [
+	"a dead process would leave the work undone forever, and restarting silently
+	looks exactly like health from the outside"
+	| resident |
+	resident := self residentWith: [ :d | d cadence: #signal ].
+	resident process terminate.
+	self deny: resident hasRunningProcess.
+
+	supervisor tick.
+
+	self assert: resident hasRunningProcess.
+	self assert: resident restartCount equals: 1
+]
+
+{ #category : #tests }
+SoilActiveResidentTest >> testWorkFromOutsideRunsAStep [
+	| resident |
+	resident := self residentWith: [ :d | d cadence: #signal ].
+	self assert: resident stepCount equals: 0.
+
+	resident noteWork.
+
+	self assert: (resident waitForStepWithin: 3 seconds).
+	self assert: resident stepCount equals: 1
+]

--- a/src/Soil-Resident-Tests/SoilActiveResidentTest.class.st
+++ b/src/Soil-Resident-Tests/SoilActiveResidentTest.class.st
@@ -192,6 +192,21 @@ SoilActiveResidentTest >> testThePendingFlagIsClearedBeforeTheStepNotAfter [
 ]
 
 { #category : #tests }
+SoilActiveResidentTest >> testTheTimedWaitAnswersWhetherSomethingHappened [
+	"the two spellings that #wait:upTo: bridges both answer 'the deadline
+	expired', and it answers the opposite. Getting that polarity backwards would
+	leave every waiting test passing for the wrong reason"
+	| resident semaphore |
+	resident := SoilTestActiveResident new.
+	semaphore := Semaphore new.
+
+	self deny: (resident wait: semaphore upTo: 20 milliSeconds).
+
+	semaphore signal.
+	self assert: (resident wait: semaphore upTo: 20 milliSeconds)
+]
+
+{ #category : #tests }
 SoilActiveResidentTest >> testTickRevivesATerminatedProcessAndCountsTheRestart [
 	"a dead process would leave the work undone forever, and restarting silently
 	looks exactly like health from the outside"

--- a/src/Soil-Resident-Tests/SoilTestActiveResident.class.st
+++ b/src/Soil-Resident-Tests/SoilTestActiveResident.class.st
@@ -1,0 +1,124 @@
+"
+The dummy active resident: it counts its steps and can be told to leave work
+behind, to throw, and which cadence to run on. Everything it does is in memory,
+so that a drain test is not a test of transaction speed.
+
+Which strategy it uses arrives as a Symbol rather than as a class, because the
+description that carries the setting is a persisted cluster root -- a class or a
+block in there would have to be serialized.
+"
+Class {
+	#name : #SoilTestActiveResident,
+	#superclass : #SoilActiveResident,
+	#instVars : [
+		'cadence',
+		'window',
+		'interval',
+		'stepCount',
+		'prepareCount',
+		'workToLeave',
+		'throwOnStep',
+		'stepSignal'
+	],
+	#category : #'Soil-Resident-Tests'
+}
+
+{ #category : #accessing }
+SoilTestActiveResident >> cadence: aSymbol [
+	cadence := aSymbol
+]
+
+{ #category : #initialization }
+SoilTestActiveResident >> initialize [
+	super initialize.
+	stepCount := 0.
+	prepareCount := 0.
+	workToLeave := 0.
+	throwOnStep := false.
+	stepSignal := Semaphore new
+]
+
+{ #category : #accessing }
+SoilTestActiveResident >> interval [
+	^ interval ifNil: [ 50 milliSeconds ]
+]
+
+{ #category : #accessing }
+SoilTestActiveResident >> interval: aDuration [
+	interval := aDuration
+]
+
+{ #category : #accessing }
+SoilTestActiveResident >> name [
+	^ #active
+]
+
+{ #category : #'instance creation' }
+SoilTestActiveResident >> newRunStrategy [
+	| strat |
+	strat := super newRunStrategy.
+	cadence = #coalescing ifTrue: [ strat window: self window ].
+	cadence = #interval ifTrue: [ strat interval: self interval ].
+	^ strat
+]
+
+{ #category : #accessing }
+SoilTestActiveResident >> prepareCount [
+	^ prepareCount
+]
+
+{ #category : #running }
+SoilTestActiveResident >> prepareIn: aTransaction [
+	prepareCount := prepareCount + 1
+]
+
+{ #category : #running }
+SoilTestActiveResident >> runStep [
+	"the signal is given in the ensure, so that a throwing step is observable too"
+	[ stepCount := stepCount + 1.
+	workToLeave > 0 ifTrue: [
+		workToLeave := workToLeave - 1.
+		self noteWork ].
+	throwOnStep ifTrue: [ Error signal: 'the step was told to throw' ] ]
+		ensure: [ stepSignal signal ]
+]
+
+{ #category : #accessing }
+SoilTestActiveResident >> runStrategyClass [
+	cadence = #coalescing ifTrue: [ ^ SoilCoalescingRunStrategy ].
+	cadence = #interval ifTrue: [ ^ SoilIntervalRunStrategy ].
+	^ SoilSignalRunStrategy
+]
+
+{ #category : #accessing }
+SoilTestActiveResident >> stepCount [
+	^ stepCount
+]
+
+{ #category : #accessing }
+SoilTestActiveResident >> throwOnStep: aBoolean [
+	throwOnStep := aBoolean
+]
+
+{ #category : #waiting }
+SoilTestActiveResident >> waitForStepWithin: aDuration [
+	"answers whether a step finished in time, so that tests synchronise on the
+	work rather than on a sleep long enough to be safe"
+	^ (stepSignal waitTimeoutMilliseconds: aDuration asMilliSeconds) not
+]
+
+{ #category : #accessing }
+SoilTestActiveResident >> window [
+	^ window ifNil: [ 50 milliSeconds ]
+]
+
+{ #category : #accessing }
+SoilTestActiveResident >> window: aDuration [
+	window := aDuration
+]
+
+{ #category : #accessing }
+SoilTestActiveResident >> workToLeave: anInteger [
+	"how many of the coming steps say afterwards that there is still work"
+	workToLeave := anInteger
+]

--- a/src/Soil-Resident-Tests/SoilTestActiveResident.class.st
+++ b/src/Soil-Resident-Tests/SoilTestActiveResident.class.st
@@ -104,7 +104,7 @@ SoilTestActiveResident >> throwOnStep: aBoolean [
 SoilTestActiveResident >> waitForStepWithin: aDuration [
 	"answers whether a step finished in time, so that tests synchronise on the
 	work rather than on a sleep long enough to be safe"
-	^ (stepSignal waitTimeoutMilliseconds: aDuration asMilliSeconds) not
+	^ self wait: stepSignal upTo: aDuration
 ]
 
 { #category : #accessing }

--- a/src/Soil-Resident-Tests/SoilTestActiveResidentDescription.class.st
+++ b/src/Soil-Resident-Tests/SoilTestActiveResidentDescription.class.st
@@ -1,0 +1,71 @@
+"
+Description of the dummy active resident. It carries the cadence as a Symbol and
+its two durations, because those are what a test varies -- and all three survive
+being written, which a class or a block would not.
+"
+Class {
+	#name : #SoilTestActiveResidentDescription,
+	#superclass : #SoilResidentDescription,
+	#instVars : [
+		'cadence',
+		'window',
+		'interval'
+	],
+	#category : #'Soil-Resident-Tests'
+}
+
+{ #category : #accessing }
+SoilTestActiveResidentDescription >> cadence [
+	^ cadence ifNil: [ #signal ]
+]
+
+{ #category : #accessing }
+SoilTestActiveResidentDescription >> cadence: aSymbol [
+	cadence := aSymbol
+]
+
+{ #category : #initialization }
+SoilTestActiveResidentDescription >> initializeFrom: aTransaction [
+	workspace := SoilPersistentDictionary new.
+	aTransaction makeRoot: workspace.
+	workspace at: #steps put: 0
+]
+
+{ #category : #'instance creation' }
+SoilTestActiveResidentDescription >> instanceClass [
+	^ SoilTestActiveResident
+]
+
+{ #category : #accessing }
+SoilTestActiveResidentDescription >> interval [
+	^ interval
+]
+
+{ #category : #accessing }
+SoilTestActiveResidentDescription >> interval: aDuration [
+	interval := aDuration
+]
+
+{ #category : #accessing }
+SoilTestActiveResidentDescription >> name [
+	^ #active
+]
+
+{ #category : #'instance creation' }
+SoilTestActiveResidentDescription >> newInstanceIn: aTransaction [
+	^ (super newInstanceIn: aTransaction)
+		cadence: self cadence;
+		window: self window;
+		interval: self interval;
+		yourself
+]
+
+{ #category : #accessing }
+SoilTestActiveResidentDescription >> window [
+	^ window
+]
+
+{ #category : #accessing }
+SoilTestActiveResidentDescription >> window: aDuration [
+	window := aDuration
+]

--- a/src/Soil-Resident/SoilActiveResident.class.st
+++ b/src/Soil-Resident/SoilActiveResident.class.st
@@ -1,0 +1,249 @@
+"
+A resident that drives its own work: I own a process, a work signal, and the loop
+between them. The base runs only in other people's transactions and in the
+supervisor's tick; I am the other half of the pair its #hasRunningProcess comment
+names -- ""answered by the process-carrying residents; a passive one stays with
+false"".
+
+What is mine and what is not. Mine is everything the cooperative stop touches:
+the process, the loop that checks the stop flag between two work units, the
+receipt through #markStopped, the revival in #tick. *When* the next step is due
+is not mine -- that is a run strategy, and it is a separate object because the
+two vary independently. A resident's purpose says nothing about whether it runs
+on a clock, on a signal, or on a signal followed by a collecting window; and the
+same cadence serves residents that have nothing else in common.
+
+The only thing a strategy may ask me is #hasPendingWork, and that is a flag,
+never a question put to the database. Measured on the existing AGQueueTracker:
+""is there more data"" is answered there as a side effect of doing the work,
+inside the transaction that does it. Asking separately would cost a second
+transaction per step and would be racy on top -- the answer can change between
+the question and the step.
+
+Hence the flag is cleared *before* a step, not after. Whoever signals a change
+while I am in a step sets it again and is not lost; the worst case is one
+redundant step, and that beats a lost one. A step that knowingly leaves work
+behind says so by calling #noteWork.
+
+A throwing step does not kill me. It is counted, the last one is kept, and the
+loop goes on -- a transient failure must not take a resident down, and a
+permanent one shows up as a climbing #stepErrorCount rather than as silence.
+"
+Class {
+	#name : #SoilActiveResident,
+	#superclass : #SoilResident,
+	#instVars : [
+		'process',
+		'workSignal',
+		'strategy',
+		'pendingWork',
+		'working',
+		'lastStepError',
+		'stepErrorCount'
+	],
+	#category : #'Soil-Resident'
+}
+
+{ #category : #accessing }
+SoilActiveResident class >> soilTransientInstVars [
+	"nothing about me is persisted either; the list has to repeat the inherited
+	entry, because a subclass declaration replaces its superclass's rather than
+	adding to it"
+	^ #( supervisor process workSignal strategy )
+]
+
+{ #category : #testing }
+SoilActiveResident >> basicHasPendingWork [
+	^ pendingWork
+]
+
+{ #category : #testing }
+SoilActiveResident >> basicIsIdle [
+	^ working not and: [ pendingWork not ]
+]
+
+{ #category : #running }
+SoilActiveResident >> handleStepError: anError [
+	"my step threw. Keep it and count it, then let the loop go on. Subclasses that
+	can tell a transient failure from a fatal one may decide otherwise"
+	lastStepError := anError.
+	stepErrorCount := stepErrorCount + 1
+]
+
+{ #category : #testing }
+SoilActiveResident >> hasRunningProcess [
+	^ process notNil and: [ process isTerminated not ]
+]
+
+{ #category : #initialization }
+SoilActiveResident >> initialize [
+	super initialize.
+	working := false.
+	pendingWork := false.
+	stepErrorCount := 0.
+	workSignal := Semaphore new
+]
+
+{ #category : #testing }
+SoilActiveResident >> isWorking [
+	"inside a work unit. Distinguishes 'not idle because something is pending'
+	from 'not idle because I am in it'"
+	^ working
+]
+
+{ #category : #accessing }
+SoilActiveResident >> lastStepError [
+	"the last error a step threw, for diagnosis"
+	^ lastStepError
+]
+
+{ #category : #'instance creation' }
+SoilActiveResident >> newRunStrategy [
+	^ self runStrategyClass new
+		resident: self;
+		yourself
+]
+
+{ #category : #notifying }
+SoilActiveResident >> noteChanged [
+	"a detached object of mine changed. For me that is work, not just a reason to
+	wake: the flag has to be set as well, or the embedder's sweep could find me
+	idle between the signal and my process being scheduled"
+	self noteWork
+]
+
+{ #category : #notifying }
+SoilActiveResident >> noteWork [
+	"there is something to do. Set the flag first and signal second, both in the
+	calling process -- the window between them is exactly what the sweep uses"
+	pendingWork := true.
+	workSignal signal
+]
+
+{ #category : #running }
+SoilActiveResident >> prepareIn: aTransaction [
+	"what a subclass does before its process exists, with the transaction the
+	supervisor hands to all residents. Keep it small: anything that can fail on
+	the environment belongs into the first work unit, because a throwing start
+	keeps the whole database from opening.
+
+	Default: nothing to prepare"
+]
+
+{ #category : #accessing }
+SoilActiveResident >> process [
+	^ process
+]
+
+{ #category : #accessing }
+SoilActiveResident >> processName [
+	^ 'soil resident ' , self name
+]
+
+{ #category : #running }
+SoilActiveResident >> runLoop [
+	"the stop flag is checked twice per turn on purpose: once before waiting, and
+	once after, because #requestStop wakes me precisely while I wait"
+	[ self shouldStop ] whileFalse: [
+		self strategy awaitDue.
+		self shouldStop ifFalse: [ self runStepProtected ] ].
+	self markStopped
+]
+
+{ #category : #running }
+SoilActiveResident >> runStep [
+	"one work unit. One transaction at most, and none held across two units"
+	self subclassResponsibility
+]
+
+{ #category : #running }
+SoilActiveResident >> runStepProtected [
+	"the flag is cleared before the step, so a change arriving during it survives.
+	The signals that led here are spent in the same breath: a signal says that
+	something happened, and what happened is about to be handled. Left standing,
+	the next turn would find the flag down, wait on a signal that is already
+	answered, and run an empty step -- which is exactly what a strategy that
+	returns early on the flag would otherwise cause"
+	working := true.
+	pendingWork := false.
+	workSignal consumeAllSignals.
+	[ [ self runStep ]
+		on: Error
+		do: [ :anError | self handleStepError: anError ] ]
+			ensure: [ working := false ]
+]
+
+{ #category : #accessing }
+SoilActiveResident >> runStrategyClass [
+	"which cadence drives me. Answered by every concrete active resident"
+	^ self subclassResponsibility
+]
+
+{ #category : #running }
+SoilActiveResident >> startIn: aTransaction [
+	"phase two, once every resident exists. Subclasses hook into #prepareIn:
+	rather than overriding me, so that preparing before forking is not a matter
+	of remembering where the super send goes"
+	self prepareIn: aTransaction.
+	self startProcess
+]
+
+{ #category : #running }
+SoilActiveResident >> startProcess [
+	process := [ self runLoop ] forkNamed: self processName
+]
+
+{ #category : #accessing }
+SoilActiveResident >> stepErrorCount [
+	"how many steps of mine threw. A crash loop is a climbing number here"
+	^ stepErrorCount
+]
+
+{ #category : #accessing }
+SoilActiveResident >> strategy [
+	^ strategy ifNil: [ strategy := self newRunStrategy ]
+]
+
+{ #category : #accessing }
+SoilActiveResident >> strategy: aRunStrategy [
+	strategy := aRunStrategy.
+	aRunStrategy resident: self
+]
+
+{ #category : #stopping }
+SoilActiveResident >> terminateProcesses [
+	"the hard way out, after my receipt failed to arrive within the timeout"
+	process ifNotNil: [ :p | p terminate ].
+	self markStopped
+]
+
+{ #category : #running }
+SoilActiveResident >> tick [
+	"a terminated process would leave my work undone forever. Bring it back, and
+	count it, so that a crash loop is visible instead of looking like health"
+	self hasRunningProcess ifFalse: [
+		self noteProcessRestart.
+		self startProcess ]
+]
+
+{ #category : #waiting }
+SoilActiveResident >> waitForWork [
+	"what a strategy uses to block until something happens. All signals are
+	consumed, so n signals do not become n runs -- the flag says whether there is
+	work, the signal only says that something happened"
+	workSignal wait.
+	workSignal consumeAllSignals
+]
+
+{ #category : #waiting }
+SoilActiveResident >> waitForWorkUpTo: aDuration [
+	"the same, bounded. Returns early when woken -- by new work or by a stop"
+	workSignal waitTimeoutMilliseconds: aDuration asMilliSeconds.
+	workSignal consumeAllSignals
+]
+
+{ #category : #stopping }
+SoilActiveResident >> wakeUp [
+	"my loop blocks in the strategy and would never get to see the stop flag"
+	workSignal signal
+]

--- a/src/Soil-Resident/SoilActiveResident.class.st
+++ b/src/Soil-Resident/SoilActiveResident.class.st
@@ -227,6 +227,28 @@ SoilActiveResident >> tick [
 ]
 
 { #category : #waiting }
+SoilActiveResident >> wait: aSemaphore upTo: aDuration [
+	"How a Semaphore is asked to wait with a timeout differs across the Pharo
+	versions Soil builds on: #waitTimeoutMilliseconds: does not exist in Pharo 11,
+	and #waitTimeoutMSecs: is deprecated from Pharo 12 on. A development image can
+	show neither -- it is one version, and there whichever selector it has simply
+	works.
+
+	Fails loudly rather than answering something if neither is there, the way
+	SoilResidentCleanCodeTest>>protocolNameOf: does for the same kind of drift.
+
+	Both spellings answer whether the deadline expired. I answer the opposite,
+	because what a caller wants to know is whether something happened."
+	| milliseconds |
+	milliseconds := aDuration asMilliSeconds.
+	(aSemaphore respondsTo: #waitTimeoutMilliseconds:) ifTrue: [
+		^ (aSemaphore waitTimeoutMilliseconds: milliseconds) not ].
+	(aSemaphore respondsTo: #waitTimeoutMSecs:) ifTrue: [
+		^ (aSemaphore waitTimeoutMSecs: milliseconds) not ].
+	self error: 'no known way to wait on a Semaphore with a timeout in this Pharo'
+]
+
+{ #category : #waiting }
 SoilActiveResident >> waitForWork [
 	"what a strategy uses to block until something happens. All signals are
 	consumed, so n signals do not become n runs -- the flag says whether there is
@@ -238,7 +260,7 @@ SoilActiveResident >> waitForWork [
 { #category : #waiting }
 SoilActiveResident >> waitForWorkUpTo: aDuration [
 	"the same, bounded. Returns early when woken -- by new work or by a stop"
-	workSignal waitTimeoutMilliseconds: aDuration asMilliSeconds.
+	self wait: workSignal upTo: aDuration.
 	workSignal consumeAllSignals
 ]
 

--- a/src/Soil-Resident/SoilActiveResident.class.st
+++ b/src/Soil-Resident/SoilActiveResident.class.st
@@ -228,7 +228,12 @@ SoilActiveResident >> tick [
 
 { #category : #waiting }
 SoilActiveResident >> wait: aSemaphore upTo: aDuration [
-	"How a Semaphore is asked to wait with a timeout differs across the Pharo
+	<ignoreNotImplementedSelectors: #( waitTimeoutMilliseconds: waitTimeoutMSecs: )>
+	"The pragma is not a way around the lint rule, it is the answer to it: one of
+	the two selectors below is missing in whichever Pharo is running, and which
+	one that is, is the whole point of this method.
+
+	How a Semaphore is asked to wait with a timeout differs across the Pharo
 	versions Soil builds on: #waitTimeoutMilliseconds: does not exist in Pharo 11,
 	and #waitTimeoutMSecs: is deprecated from Pharo 12 on. A development image can
 	show neither -- it is one version, and there whichever selector it has simply

--- a/src/Soil-Resident/SoilCoalescingRunStrategy.class.st
+++ b/src/Soil-Resident/SoilCoalescingRunStrategy.class.st
@@ -1,0 +1,43 @@
+"
+Wait for a signal, and then wait a little longer on purpose: everything arriving
+during that window is absorbed into the same step instead of causing one of its
+own.
+
+For work that is triggered far more often than it needs to be done. A limit that
+is asked about and used once per flow node would otherwise be one commit per
+node; with a window it is one commit per burst.
+
+The window is waited out on the resident's work signal rather than on the clock,
+so that a stop cuts it short. Nothing is lost by cutting it: the resident's
+pending flag is still up -- it is cleared only when a step begins -- and his
+#flushOnStop writes what the window was still holding.
+"
+Class {
+	#name : #SoilCoalescingRunStrategy,
+	#superclass : #SoilSignalRunStrategy,
+	#instVars : [
+		'window'
+	],
+	#category : #'Soil-Resident'
+}
+
+{ #category : #waiting }
+SoilCoalescingRunStrategy >> awaitDue [
+	super awaitDue.
+	resident shouldStop ifFalse: [ resident waitForWorkUpTo: self window ]
+]
+
+{ #category : #accessing }
+SoilCoalescingRunStrategy >> defaultWindow [
+	^ 30 seconds
+]
+
+{ #category : #accessing }
+SoilCoalescingRunStrategy >> window [
+	^ window ifNil: [ window := self defaultWindow ]
+]
+
+{ #category : #accessing }
+SoilCoalescingRunStrategy >> window: aDuration [
+	window := aDuration
+]

--- a/src/Soil-Resident/SoilIntervalRunStrategy.class.st
+++ b/src/Soil-Resident/SoilIntervalRunStrategy.class.st
@@ -1,0 +1,78 @@
+"
+Run once per interval, by the clock. For work whose moment nobody announces --
+fetching from a foreign service, for instance.
+
+The waiting happens on the resident's work signal with a timeout, not on the
+clock alone, and that is the point rather than a detail. Waited out on the clock,
+a stop request would have to sit through the whole interval before the loop even
+looks at the flag, and the embedder's stop timeout would then have to exceed the
+longest interval in the system. The old AGIntervalRunStrategy waits with
+(nextRun - now) wait and has exactly that problem; it was never noticed because
+that world stopped its residents by terminating the process.
+
+The interval counts from the start of a step, not from its end: a step that
+takes longer than the interval is then due again immediately rather than pushing
+the schedule ahead of itself.
+"
+Class {
+	#name : #SoilIntervalRunStrategy,
+	#superclass : #SoilResidentRunStrategy,
+	#instVars : [
+		'interval',
+		'lastRun'
+	],
+	#category : #'Soil-Resident'
+}
+
+{ #category : #waiting }
+SoilIntervalRunStrategy >> awaitDue [
+	[ self isDue ] whileFalse: [
+		resident waitForWorkUpTo: self remaining.
+		resident shouldStop ifTrue: [ ^ self ] ].
+	lastRun := DateAndTime now
+]
+
+{ #category : #accessing }
+SoilIntervalRunStrategy >> defaultInterval [
+	^ 1 minute
+]
+
+{ #category : #accessing }
+SoilIntervalRunStrategy >> interval [
+	^ interval ifNil: [ interval := self defaultInterval ]
+]
+
+{ #category : #accessing }
+SoilIntervalRunStrategy >> interval: aDuration [
+	interval := aDuration
+]
+
+{ #category : #testing }
+SoilIntervalRunStrategy >> isDue [
+	"never run yet counts as due: a resident starts by doing its work once, and
+	waiting out a first interval would leave a freshly opened database stale for
+	no reason"
+	^ lastRun isNil or: [ DateAndTime now >= self nextRun ]
+]
+
+{ #category : #accessing }
+SoilIntervalRunStrategy >> lastRun [
+	^ lastRun
+]
+
+{ #category : #accessing }
+SoilIntervalRunStrategy >> lastRun: aDateAndTime [
+	"so that a resident whose description remembers when it last ran does not
+	repeat the work after every restart"
+	lastRun := aDateAndTime
+]
+
+{ #category : #accessing }
+SoilIntervalRunStrategy >> nextRun [
+	^ lastRun + self interval
+]
+
+{ #category : #accessing }
+SoilIntervalRunStrategy >> remaining [
+	^ self nextRun - DateAndTime now
+]

--- a/src/Soil-Resident/SoilResidentRunStrategy.class.st
+++ b/src/Soil-Resident/SoilResidentRunStrategy.class.st
@@ -1,0 +1,41 @@
+"
+When a resident's next work unit is due -- and nothing else.
+
+I am a separate object from the resident because cadence and purpose vary
+independently. What a resident is for says nothing about whether it runs on a
+clock, on a signal, or on a signal followed by a collecting window; and one
+cadence serves residents that have nothing else in common. Kept apart, that is
+two small hierarchies instead of their cross product.
+
+What I must not do is decide anything about his life. The process, the loop, the
+cooperative stop and its receipt are his. I only block until it is time.
+
+And I never read the database. The one thing I may ask him is #hasPendingWork,
+and that is a flag he maintains, not a question put to storage -- see
+SoilActiveResident on why that distinction is not a detail.
+"
+Class {
+	#name : #SoilResidentRunStrategy,
+	#superclass : #Object,
+	#instVars : [
+		'resident'
+	],
+	#category : #'Soil-Resident'
+}
+
+{ #category : #waiting }
+SoilResidentRunStrategy >> awaitDue [
+	"block until the next step is due. I may also return because the resident was
+	asked to stop -- his loop checks that itself, right after I return"
+	self subclassResponsibility
+]
+
+{ #category : #accessing }
+SoilResidentRunStrategy >> resident [
+	^ resident
+]
+
+{ #category : #accessing }
+SoilResidentRunStrategy >> resident: aResident [
+	resident := aResident
+]

--- a/src/Soil-Resident/SoilSignalRunStrategy.class.st
+++ b/src/Soil-Resident/SoilSignalRunStrategy.class.st
@@ -1,0 +1,21 @@
+"
+Wait for a signal -- and do not wait at all while the resident still has work.
+
+The second half is what turns a signal into a drain. A tracker that is woken
+once works through what is there without needing a signal per item, and blocks
+again only when the flag has gone down. That is why the question is put to the
+resident's flag and not to the semaphore: signals count up, so n signals would
+otherwise become n runs, and a queue that filled up while a step ran would need
+exactly as many wake-ups as it has items.
+"
+Class {
+	#name : #SoilSignalRunStrategy,
+	#superclass : #SoilResidentRunStrategy,
+	#category : #'Soil-Resident'
+}
+
+{ #category : #waiting }
+SoilSignalRunStrategy >> awaitDue [
+	resident hasPendingWork ifTrue: [ ^ self ].
+	resident waitForWork
+]


### PR DESCRIPTION
Every active resident so far builds the same machinery by hand: a process, a work semaphore, a loop that checks the stop flag between two units, a revival in the tick, a pending flag. AGLimitsResident does it, AGQueueTracker does it, the old AGDatabaseModuleInstance did it through a run strategy whose signal variant had no user at all -- and was then rebuilt by hand anyway, because the extraction to Soil-Resident took the lifecycle half and left the process half behind.

SoilActiveResident is that half. The base stays exactly as it is: passive, its four hooks answering "nothing to do", so a resident without a process needs no nil check anywhere. What the subclass owns is everything the cooperative stop touches -- process, loop, receipt, revival.

When the next step is due is a separate object, because cadence and purpose vary independently. A resident's purpose says nothing about whether it runs on a clock, on a signal, or on a signal followed by a collecting window, and one cadence serves residents with nothing else in common. Two small hierarchies instead of their cross product. Three concrete ones, each with a user waiting: signal for the trackers, an interval for the accounts module, a collecting window for the limits.

Two decisions in there are measured rather than assumed.

A strategy may ask the resident #hasPendingWork, and that is a flag, never a question put to storage. On AGQueueTracker "is there more data" is answered as a side effect of doing the work, inside the transaction that does it; asking separately would mean a second context, a second cursor lookup and an index find: per step, and would be racy on top. So the flag is cleared when a step begins, not when it ends -- a change arriving during a step then survives it, and the worst case is one redundant step rather than a lost one. The signals that led to a step are spent at the same moment, or a strategy returning early on the flag leaves one standing and the next turn runs empty.

The interval waits on the work semaphore with a timeout, not on the clock. The old AGIntervalRunStrategy waits with (nextRun - now) wait, so a stop request has to sit through the whole interval; nobody noticed because that world stopped its residents by terminating the process. Under a cooperative stop it would force the embedder's timeout to exceed the longest interval in the system.

SoilTestResident keeps building its machinery by hand on purpose. It is what proves the base, and a base proved against an implementation derived from itself proves nothing.