### PR TITLE
Run the test suite on Windows too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ ubuntu-latest, windows-latest ]
         pharoversion: [ Pharo64-14, Pharo64-13, Pharo64-12, Pharo64-11 ]
         include:
           - pharoversion: Pharo64-14
             allow-failure: true
-    name: ${{ matrix.pharoversion }}
-    runs-on: ubuntu-latest
+          # Windows is not green yet - the file handling work is still in
+          # flight. Run it for the signal, do not let it fail the build.
+          # Remove this entry once Windows passes.
+          - os: windows-latest
+            allow-failure: true
+    name: ${{ matrix.pharoversion }}-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.allow-failure == true }}
     steps:
       - uses: actions/checkout@v2

--- a/src/Soil-File-Tests/SoilWindowsFileLockTest.class.st
+++ b/src/Soil-File-Tests/SoilWindowsFileLockTest.class.st
@@ -1,0 +1,210 @@
+Class {
+	#name : 'SoilWindowsFileLockTest',
+	#superclass : 'TestCase',
+	#instVars : [
+		'testFile',
+		'stream'
+	],
+	#category : 'Soil-File-Tests',
+	#package : 'Soil-File-Tests'
+}
+
+{ #category : 'running' }
+SoilWindowsFileLockTest >> setUp [
+	super setUp.
+	testFile := 'soil-winlock-test.tmp' asFileReference.
+	testFile ensureDelete
+]
+
+{ #category : 'running' }
+SoilWindowsFileLockTest >> tearDown [
+	stream ifNotNil: [
+		[ stream close ] on: Error do: [ :ex | "ignore close errors" ] ].
+	testFile ifNotNil: [
+		[ testFile ensureDelete ] on: Error do: [ :ex | "ignore delete errors" ] ].
+	super tearDown
+]
+
+{ #category : 'tests' }
+SoilWindowsFileLockTest >> testErrorDescriptions [
+	"Test error description helper method"
+
+	OSPlatform current isWindows ifFalse: [ ^ self skip ].
+
+	"Test known error codes"
+	self assert: (SoilWindowsFileLock errorDescription: 5) equals: 'Access denied'.
+	self assert: (SoilWindowsFileLock errorDescription: 6) equals: 'Invalid file handle'.
+	self assert: (SoilWindowsFileLock errorDescription: 33) equals: 'Lock violation (region already locked)'.
+	self assert: (SoilWindowsFileLock errorDescription: 158) equals: 'Region not locked'.
+
+	"Test unknown error code"
+	self assert: ((SoilWindowsFileLock errorDescription: 9999) includesSubstring: 'Unknown error')
+]
+
+{ #category : 'tests' }
+SoilWindowsFileLockTest >> testFlushFileBuffersDirect [
+	"Test FlushFileBuffers FFI call directly"
+
+	| result |
+	OSPlatform current isWindows ifFalse: [ ^ self skip ].
+
+	stream := testFile binaryWriteStream.
+	stream nextPutAll: 'Testing direct FlushFileBuffers call'.
+	stream flush.
+
+	"Call FlushFileBuffers directly"
+	result := SoilWindowsFileLock flushFileBuffers: stream fileStream fileHandle.
+
+	"Should return true (non-zero) on success"
+	self assert: result
+]
+
+{ #category : 'tests' }
+SoilWindowsFileLockTest >> testFsyncEntireFile [
+	"Test fsync on Windows using FlushFileBuffers"
+
+	OSPlatform current isWindows ifFalse: [ ^ self skip ].
+
+	stream := testFile binaryWriteStream.
+	stream nextPutAll: 'Testing fsync on Windows!'.
+	stream flush.
+
+	"Call fsync - should not raise an error"
+	self shouldnt: [ stream fileStream fsync ] raise: Error.
+
+	stream close
+]
+
+{ #category : 'tests' }
+SoilWindowsFileLockTest >> testLockAndUnlockEntireFile [
+	"Test locking and unlocking the entire file (length = 0)"
+
+	OSPlatform current isWindows ifFalse: [ ^ self skip ].
+
+	stream := testFile binaryWriteStream.
+	stream nextPutAll: 'Hello, Windows file locking!'.
+	stream flush.
+
+	"Lock entire file"
+	self assert: (SoilWindowsFileLock lock: stream fileStream fileHandle from: 0 length: 0).
+
+	"Unlock entire file"
+	self assert: (SoilWindowsFileLock unlock: stream fileStream fileHandle from: 0 length: 0)
+]
+
+{ #category : 'tests' }
+SoilWindowsFileLockTest >> testLockAndUnlockRange [
+	"Test locking and unlocking a specific byte range"
+
+	OSPlatform current isWindows ifFalse: [ ^ self skip ].
+
+	stream := testFile binaryWriteStream.
+	stream nextPutAll: 'Hello, Windows file locking!'.
+	stream flush.
+
+	"Lock bytes 7 to 14 (the word 'Windows')"
+	self assert: (SoilWindowsFileLock lock: stream fileStream fileHandle from: 7 length: 7).
+
+	"Unlock the same range"
+	self assert: (SoilWindowsFileLock unlock: stream fileStream fileHandle from: 7 length: 7)
+]
+
+{ #category : 'tests' }
+SoilWindowsFileLockTest >> testLockExclusive [
+	"Test exclusive lock"
+
+	OSPlatform current isWindows ifFalse: [ ^ self skip ].
+
+	stream := testFile binaryWriteStream.
+	stream nextPutAll: 'Test exclusive lock'.
+	stream flush.
+
+	"Lock with exclusive flag"
+	self assert: (SoilWindowsFileLock lock: stream fileStream fileHandle from: 0 length: 100 exclusive: true).
+
+	"Unlock"
+	self assert: (SoilWindowsFileLock unlock: stream fileStream fileHandle from: 0 length: 100)
+]
+
+{ #category : 'tests' }
+SoilWindowsFileLockTest >> testLockOrErrorSuccess [
+	"Test lockOrError with successful lock"
+
+	OSPlatform current isWindows ifFalse: [ ^ self skip ].
+
+	stream := testFile binaryWriteStream.
+	stream nextPutAll: 'Test lockOrError success'.
+	stream flush.
+
+	"Should not raise an error"
+	self shouldnt: [
+		SoilWindowsFileLock lockOrError: stream fileStream fileHandle from: 0 length: 100 exclusive: true ]
+		raise: Error.
+
+	"Clean up"
+	SoilWindowsFileLock unlock: stream fileStream fileHandle from: 0 length: 100
+]
+
+{ #category : 'tests' }
+SoilWindowsFileLockTest >> testLockShared [
+	"Test shared lock"
+
+	OSPlatform current isWindows ifFalse: [ ^ self skip ].
+
+	stream := testFile binaryWriteStream.
+	stream nextPutAll: 'Test shared lock'.
+	stream flush.
+
+	"Lock with shared flag"
+	self assert: (SoilWindowsFileLock lock: stream fileStream fileHandle from: 0 length: 100 exclusive: false).
+
+	"Unlock"
+	self assert: (SoilWindowsFileLock unlock: stream fileStream fileHandle from: 0 length: 100)
+]
+
+{ #category : 'tests' }
+SoilWindowsFileLockTest >> testMultipleLocks [
+	"Test locking multiple non-overlapping ranges"
+
+	OSPlatform current isWindows ifFalse: [ ^ self skip ].
+
+	stream := testFile binaryWriteStream.
+	stream nextPutAll: '0123456789ABCDEFGHIJ'.
+	stream flush.
+
+	"Lock range 0-9"
+	self assert: (SoilWindowsFileLock lock: stream fileStream fileHandle from: 0 length: 10).
+
+	"Lock range 10-19 (non-overlapping)"
+	self assert: (SoilWindowsFileLock lock: stream fileStream fileHandle from: 10 length: 10).
+
+	"Unlock both ranges"
+	self assert: (SoilWindowsFileLock unlock: stream fileStream fileHandle from: 0 length: 10).
+	self assert: (SoilWindowsFileLock unlock: stream fileStream fileHandle from: 10 length: 10)
+]
+
+{ #category : 'tests' }
+SoilWindowsFileLockTest >> testWinOverlappedStructure [
+	"Test WinOverlapped structure initialization and field access"
+
+	| overlapped |
+	OSPlatform current isWindows ifFalse: [ ^ self skip ].
+
+	overlapped := SoilWinOverlappedStruct new.
+
+	"Test field setters and getters"
+	overlapped offset: 16r12345678.
+	self assert: overlapped offset equals: 16r12345678.
+
+	overlapped offsetHigh: 16rABCDEF00.
+	self assert: overlapped offsetHigh equals: 16rABCDEF00.
+
+	overlapped internal: 0.
+	self assert: overlapped internal equals: 0.
+
+	overlapped internalHigh: 0.
+	self assert: overlapped internalHigh equals: 0.
+
+	overlapped hEvent: ExternalAddress null.
+	self assert: overlapped hEvent getHandle equals: ExternalAddress null
+]

--- a/src/Soil-File/SoilWinOverlappedStruct.class.st
+++ b/src/Soil-File/SoilWinOverlappedStruct.class.st
@@ -1,0 +1,102 @@
+Class {
+	#name : #SoilWinOverlappedStruct,
+	#superclass : #FFIStructure,
+	#classVars : [
+		'OFFSET_HEVENT',
+		'OFFSET_INTERNAL',
+		'OFFSET_INTERNALHIGH',
+		'OFFSET_OFFSET',
+		'OFFSET_OFFSETHIGH'
+	],
+	#category : #'Soil-File'
+}
+
+{ #category : #'field definition' }
+SoilWinOverlappedStruct class >> fieldsDesc [
+	"self rebuildFieldAccessors"
+
+	^ #(
+	uint64 internal;
+	uint64 internalHigh;
+	uint offset;
+	uint offsetHigh;
+	void* hEvent;
+	)
+]
+
+{ #category : #'accessing - structure variables' }
+SoilWinOverlappedStruct >> hEvent [
+	"This method was automatically generated"
+	^ExternalData fromHandle: (handle pointerAt: OFFSET_HEVENT) type: ExternalType void asPointerType
+]
+
+{ #category : #'accessing - structure variables' }
+SoilWinOverlappedStruct >> hEvent: anObject [
+	"This method was automatically generated"
+	handle pointerAt: OFFSET_HEVENT put: anObject getHandle.
+]
+
+{ #category : #initialization }
+SoilWinOverlappedStruct >> initialize [
+	super initialize
+]
+
+{ #category : #'accessing - structure variables' }
+SoilWinOverlappedStruct >> internal [
+	"This method was automatically generated"
+	^handle unsignedLongLongAt: OFFSET_INTERNAL
+]
+
+{ #category : #'accessing - structure variables' }
+SoilWinOverlappedStruct >> internal: anObject [
+	"This method was automatically generated"
+	handle unsignedLongLongAt: OFFSET_INTERNAL put: anObject
+]
+
+{ #category : #'accessing - structure variables' }
+SoilWinOverlappedStruct >> internalHigh [
+	"This method was automatically generated"
+	^handle unsignedLongLongAt: OFFSET_INTERNALHIGH
+]
+
+{ #category : #'accessing - structure variables' }
+SoilWinOverlappedStruct >> internalHigh: anObject [
+	"This method was automatically generated"
+	handle unsignedLongLongAt: OFFSET_INTERNALHIGH put: anObject
+]
+
+{ #category : #'accessing - structure variables' }
+SoilWinOverlappedStruct >> offset [
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_OFFSET
+]
+
+{ #category : #'accessing - structure variables' }
+SoilWinOverlappedStruct >> offset: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_OFFSET put: anObject
+]
+
+{ #category : #'accessing - structure variables' }
+SoilWinOverlappedStruct >> offsetHigh [
+	"This method was automatically generated"
+	^handle unsignedLongAt: OFFSET_OFFSETHIGH
+]
+
+{ #category : #'accessing - structure variables' }
+SoilWinOverlappedStruct >> offsetHigh: anObject [
+	"This method was automatically generated"
+	handle unsignedLongAt: OFFSET_OFFSETHIGH put: anObject
+]
+
+{ #category : #printing }
+SoilWinOverlappedStruct >> printOn: aStream [
+	"Append to the argument, aStream, the names and values of all the record's variables."
+
+	aStream nextPutAll: self class name; nextPutAll: ' ( '; cr.
+	self class fieldSpec fieldNames do: [ :field |
+		aStream nextPutAll: field; nextPut: $:; space; tab.
+			(self perform: field ) printOn: aStream.
+			] separatedBy: [ aStream cr ].
+	aStream cr; nextPut: $)
+]

--- a/src/Soil-File/SoilWindowsFileLock.class.st
+++ b/src/Soil-File/SoilWindowsFileLock.class.st
@@ -1,0 +1,233 @@
+Class {
+	#name : #SoilWindowsFileLock,
+	#superclass : #Object,
+	#classVars : [
+		'ERROR_ACCESS_DENIED',
+		'ERROR_INVALID_HANDLE',
+		'ERROR_IO_PENDING',
+		'ERROR_LOCK_VIOLATION',
+		'ERROR_NOT_LOCKED',
+		'LOCKFILE_EXCLUSIVE_LOCK',
+		'LOCKFILE_FAIL_IMMEDIATELY',
+		'LOCKFILE_SHARED_LOCK'
+	],
+	#category : #'Soil-File'
+}
+
+{ #category : #testing }
+SoilWindowsFileLock class >> canLock: fileHandle from: start length: length exclusive: exclusive [
+	"Windows doesn't have a direct 'test lock' API like F_GETLK.
+	We attempt to lock and immediately unlock if successful."
+
+	| success |
+	success := self lock: fileHandle from: start length: length exclusive: exclusive.
+	success ifTrue: [
+		self unlock: fileHandle from: start length: length ].
+	^ success
+]
+
+{ #category : #'private - error handling' }
+SoilWindowsFileLock class >> errorDescription: errorCode [
+	"Return a human-readable description for Windows error codes"
+
+	errorCode = ERROR_ACCESS_DENIED ifTrue: [ ^ 'Access denied' ].
+	errorCode = ERROR_INVALID_HANDLE ifTrue: [ ^ 'Invalid file handle' ].
+	errorCode = ERROR_LOCK_VIOLATION ifTrue: [ ^ 'Lock violation (region already locked)' ].
+	errorCode = ERROR_NOT_LOCKED ifTrue: [ ^ 'Region not locked' ].
+	errorCode = ERROR_IO_PENDING ifTrue: [ ^ 'I/O operation pending' ].
+
+	^ 'Unknown error (code: ', errorCode printString, ')'
+]
+
+{ #category : #'private - ffi' }
+SoilWindowsFileLock class >> flushFileBuffers: hFile [
+	"Flush all file buffers to disk using Windows API"
+
+	^ self ffiCall: #(bool FlushFileBuffers(void* hFile)) module: #kernel32
+]
+
+{ #category : #'private - ffi' }
+SoilWindowsFileLock class >> getCurrentProcessId [
+	"Get the current process ID using Windows API"
+
+	^ self ffiCall: #(uint GetCurrentProcessId()) module: #kernel32
+]
+
+{ #category : #'private - ffi' }
+SoilWindowsFileLock class >> getFileHandle: stream [
+	"Extract Windows HANDLE from a BinaryFileStream.
+	For buffered streams (ZnBufferedWriteStream), get the wrapped file stream first."
+
+	| fileStream |
+	fileStream := stream fileStream.
+	^ fileStream fileHandle
+]
+
+{ #category : #'private - ffi' }
+SoilWindowsFileLock class >> getLastError [
+	"Get Windows error code"
+
+	^ self ffiCall: #(uint GetLastError()) module: #kernel32
+]
+
+{ #category : #'class initialization' }
+SoilWindowsFileLock class >> initialize [
+	"Windows API constants"
+
+	LOCKFILE_EXCLUSIVE_LOCK := 16r00000002.
+	LOCKFILE_FAIL_IMMEDIATELY := 16r00000001.
+	LOCKFILE_SHARED_LOCK := 16r00000000.
+
+	"Error codes - from winerror.h"
+	ERROR_ACCESS_DENIED := 5.
+	ERROR_INVALID_HANDLE := 6.
+	ERROR_LOCK_VIOLATION := 33.
+	ERROR_NOT_LOCKED := 158.
+	ERROR_IO_PENDING := 997
+]
+
+{ #category : #'accessing locking' }
+SoilWindowsFileLock class >> lock: fileHandle from: start length: length [
+
+	^ self
+		lock: fileHandle
+		from: start
+		length: length
+		exclusive: true
+]
+
+{ #category : #'accessing locking' }
+SoilWindowsFileLock class >> lock: fileHandle from: start length: length exclusive: exclusive [
+	"Lock file region, returning true on success, false on failure.
+	For detailed error information, use lockOrError:from:length:exclusive:"
+
+	| overlapped flags result lockLow lockHigh |
+
+	"fileHandle is already a Windows HANDLE (ExternalAddress)"
+
+	"Create and initialize OVERLAPPED structure"
+	overlapped := SoilWinOverlappedStruct new.
+	overlapped offset: (start bitAnd: 16rFFFFFFFF).
+	overlapped offsetHigh: (start bitShift: -32).
+	overlapped hEvent: ExternalAddress null.
+
+	"Set flags for exclusive or shared lock"
+	flags := exclusive
+		ifTrue: [ LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY ]
+		ifFalse: [ LOCKFILE_SHARED_LOCK | LOCKFILE_FAIL_IMMEDIATELY ].
+
+	"Calculate lock length in low/high parts"
+	lockLow := length = 0
+		ifTrue: [ 16rFFFFFFFF ]  "0 means lock to EOF"
+		ifFalse: [ length bitAnd: 16rFFFFFFFF ].
+	lockHigh := length = 0
+		ifTrue: [ 16rFFFFFFFF ]
+		ifFalse: [ length bitShift: -32 ].
+
+	"Call LockFileEx"
+	result := self
+		lockFileEx: fileHandle
+		flags: flags
+		bytesLow: lockLow
+		bytesHigh: lockHigh
+		overlapped: overlapped.
+
+	"Return success status"
+	^ result ~= 0
+]
+
+{ #category : #'private - ffi' }
+SoilWindowsFileLock class >> lockFileEx: hFile flags: dwFlags bytesLow: nNumberOfBytesToLockLow bytesHigh: nNumberOfBytesToLockHigh overlapped: lpOverlapped [
+
+	^ self
+		ffiCall: #(bool LockFileEx(
+			void* hFile,
+			uint dwFlags,
+			uint 0,
+			uint nNumberOfBytesToLockLow,
+			uint nNumberOfBytesToLockHigh,
+			SoilWinOverlappedStruct *lpOverlapped))
+		module: #kernel32
+]
+
+{ #category : #'accessing locking' }
+SoilWindowsFileLock class >> lockOrError: fileHandle from: start length: length exclusive: exclusive [
+	"Lock file region, raising an error with detailed information on failure"
+
+	| success errorCode errorDesc lockType |
+	success := self lock: fileHandle from: start length: length exclusive: exclusive.
+
+	success ifFalse: [
+		errorCode := self getLastError.
+		errorDesc := self errorDescription: errorCode.
+		lockType := exclusive ifTrue: [ 'exclusive' ] ifFalse: [ 'shared' ].
+
+		Error signal: 'LockFileEx failed: ', lockType, ' lock at offset ', start printString,
+			' length ', length printString, ' - ', errorDesc ].
+
+	^ success
+]
+
+{ #category : #'accessing locking' }
+SoilWindowsFileLock class >> unlock: fileHandle from: start length: length [
+	"Unlock file region, returning true on success, false on failure.
+	For detailed error information, use unlockOrError:from:length:"
+
+	| overlapped result unlockLow unlockHigh |
+
+	"fileHandle is already a Windows HANDLE (ExternalAddress)"
+
+	"Create and initialize OVERLAPPED structure"
+	overlapped := SoilWinOverlappedStruct new.
+	overlapped offset: (start bitAnd: 16rFFFFFFFF).
+	overlapped offsetHigh: (start bitShift: -32).
+	overlapped hEvent: ExternalAddress null.
+
+	"Calculate unlock length in low/high parts"
+	unlockLow := length = 0
+		ifTrue: [ 16rFFFFFFFF ]
+		ifFalse: [ length bitAnd: 16rFFFFFFFF ].
+	unlockHigh := length = 0
+		ifTrue: [ 16rFFFFFFFF ]
+		ifFalse: [ length bitShift: -32 ].
+
+	"Call UnlockFileEx"
+	result := self
+		unlockFileEx: fileHandle
+		bytesLow: unlockLow
+		bytesHigh: unlockHigh
+		overlapped: overlapped.
+
+	"Return success status"
+	^ result ~= 0
+]
+
+{ #category : #'private - ffi' }
+SoilWindowsFileLock class >> unlockFileEx: hFile bytesLow: nNumberOfBytesToUnlockLow bytesHigh: nNumberOfBytesToUnlockHigh overlapped: lpOverlapped [
+
+	^ self
+		ffiCall: #(bool UnlockFileEx(
+			void* hFile,
+			uint 0,
+			uint nNumberOfBytesToUnlockLow,
+			uint nNumberOfBytesToUnlockHigh,
+			SoilWinOverlappedStruct *lpOverlapped))
+		module: #kernel32
+]
+
+{ #category : #'accessing locking' }
+SoilWindowsFileLock class >> unlockOrError: fileHandle from: start length: length [
+	"Unlock file region, raising an error with detailed information on failure"
+
+	| success errorCode errorDesc |
+	success := self unlock: fileHandle from: start length: length.
+
+	success ifFalse: [
+		errorCode := self getLastError.
+		errorDesc := self errorDescription: errorCode.
+
+		Error signal: 'UnlockFileEx failed: unlock at offset ', start printString,
+			' length ', length printString, ' - ', errorDesc ].
+
+	^ success
+]

--- a/src/Soil-File/WinPlatform.extension.st
+++ b/src/Soil-File/WinPlatform.extension.st
@@ -1,0 +1,16 @@
+Extension { #name : #WinPlatform }
+
+{ #category : #'*Soil-File' }
+WinPlatform >> flockClass [
+	^ SoilWindowsFileLock
+]
+
+{ #category : #'*Soil-File' }
+WinPlatform >> syncFile: fileHandle [
+	"Windows implementation of fsync using FlushFileBuffers API"
+
+	^ (SoilWindowsFileLock flushFileBuffers: fileHandle)
+		ifTrue: [ 0 ]
+		ifFalse: [
+			SoilWindowsFileLock getLastError ]
+]


### PR DESCRIPTION
The Windows file handling work is being split into reviewable pieces, and without a Windows job none of those pieces can be checked where they matter. Ubuntu tells us nothing about a second open of a path that is already open.

Windows is not green yet - six tests fail today - so it runs with allow-failure, the same way Pharo64-14 already does: the signal is there, the build stays honest about Linux. The include entry says to remove it once Windows passes, and that removal is what turns Windows into a supported platform.