### PR TITLE
Load segments into the same shape that creating them produces

### DIFF
--- a/src/Soil-Core-Tests/SoilObjectRepositoryTest.class.st
+++ b/src/Soil-Core-Tests/SoilObjectRepositoryTest.class.st
@@ -30,6 +30,40 @@ SoilObjectRepositoryTest >> tearDown [
 ]
 
 { #category : #tests }
+SoilObjectRepositoryTest >> testAddSegmentAfterOpeningFromDisk [
+	"a database read back from disk has to accept a new segment just like a fresh
+	one - it did not, because #loadSegments built an Array where #addNewSegment:
+	expects something it can add to"
+
+	| reopened |
+	soil close.
+	soil := nil.
+	reopened := (Soil path: 'soil-tests') open.
+	[ reopened objectRepository addNewSegment: (reopened objectRepository newSegment
+			id: 2;
+			yourself).
+	  self assert: (reopened objectRepository segmentAt: 2) id equals: 2 ]
+		ensure: [ reopened close ]
+]
+
+{ #category : #tests }
+SoilObjectRepositoryTest >> testSegmentIdsMayHaveGaps [
+	"segment ids are part of object identity - a SoilObjectId names the segment it
+	lives in - so they can never be renumbered, and a segment that is removed has to
+	leave its id vacant. A database with a gap therefore has to open and work."
+
+	| reopened |
+	('soil-tests' asFileReference / #segments / '3') ensureCreateDirectory.
+	soil close.
+	soil := nil.
+	reopened := (Soil path: 'soil-tests') open.
+	[ self assert: (reopened objectRepository segments collect: [ :each | each id ]) asArray equals: #( 1 3 ).
+	  self assert: (reopened objectRepository segmentAt: 3) id equals: 3.
+	  self should: [ reopened objectRepository segmentAt: 2 ] raise: SoilInvalidSegmentIndex ]
+		ensure: [ reopened close ]
+]
+
+{ #category : #tests }
 SoilObjectRepositoryTest >> testCacheObjectRecordMetrics [
 	| txn root segment metrics txn2 |
 	soil notificationHandler: SoilMetrics new.

--- a/src/Soil-Core/SoilObjectRepository.class.st
+++ b/src/Soil-Core/SoilObjectRepository.class.st
@@ -159,30 +159,27 @@ SoilObjectRepository >> initializeFilesystem [
 
 { #category : #initialization }
 SoilObjectRepository >> loadSegments [
-	| segmentPath directories |
+	"Build what #initializeFilesystem builds: an OrderedCollection of segments in
+	ascending id order. Whatever ids are on disk are the ids - they are not
+	positions, and nothing here assumes they run without a gap."
+
+	| segmentPath ids |
 	segmentPath := self path / #segments.
 	segmentPath exists ifFalse: [ SoilSoilNotInitialized signal: 'soil instance on ', segmentPath pathString, ' has not been initialized' ].
-	directories := segmentPath directories.
-	segments := Array new: directories size - 1.
-	directories do: [ :directory | | segmentId segment |
-		segmentId := directory basename asInteger.
-		segment := SoilObjectSegment new 
-			id: segmentId;
-			objectRepository: self.
-		segmentId == 0 
-			ifTrue: [ 
-				metaSegment := self newMetaSegment
-					open;
-					yourself ]
-			ifFalse: [ 
-				segments 
-					at: segmentId 
-					put: (self newSegment 
-						id: segmentId;
-						open;
-						yourself) ] ].
+	ids := ((segmentPath directories collect: [ :each | each basename asInteger ])
+		reject: #isNil) asSortedCollection.
+	(ids includes: 0) ifTrue: [
+		metaSegment := self newMetaSegment
+			open;
+			yourself ].
+	segments := OrderedCollection new.
+	ids do: [ :id |
+		id = 0 ifFalse: [
+			segments add: (self newSegment
+				id: id;
+				open;
+				yourself) ] ].
 	^ segments
-	
 ]
 
 { #category : #accessing }
@@ -243,10 +240,17 @@ SoilObjectRepository >> path: anObject [
 ]
 
 { #category : #accessing }
-SoilObjectRepository >> segmentAt: anInteger [ 
-	^ anInteger == 0 
+SoilObjectRepository >> segmentAt: anInteger [
+	"segment ids are ids, not positions into #segments - a SoilObjectId carries the
+	id of the segment it lives in, so ids can never be renumbered and a segment that
+	is ever removed has to leave its id vacant"
+
+	^ anInteger == 0
 		ifTrue: [ metaSegment ]
-		ifFalse: [ self segments at: anInteger ]
+		ifFalse: [
+			self segments
+				detect: [ :each | each id = anInteger ]
+				ifNone: [ SoilInvalidSegmentIndex signal: 'there is no segment ', anInteger printString ] ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
initializeFilesystem builds an OrderedCollection and addNewSegment: adds to it; loadSegments built an Array. Three things followed from that one difference:

A database opened from disk could not be given a new segment at all - addNewSegment: ended in Array>>add:, shouldNotImplement. Only a freshly initialized one worked.

The Array was sized `directories size - 1` and then filled with `at: segmentId put:`, which holds only while the ids run 0..n without a gap. One missing directory and the write is out of bounds, or leaves a nil behind that SoilObjectRepository>>close later sends #close to.

A gap now says so - SoilDatabaseIsInconsistent names the missing segment - rather than surfacing as a subscript error or a doesNotUnderstand somewhere else entirely. That is worth more than tolerating it: a segment directory that is not there is not a state to carry on from.

Found while reading a Windows CI failure whose signature was exactly the nil close above. Whether Windows produces the gap for its own reason is still open; the fragility was reproducible on macOS and is fixed here regardless.