### PR TITLE
Close the garbage collector's clones before deleting them

### DIFF
--- a/src/Soil-Core-Tests/SoilGarbageCollectorTest.class.st
+++ b/src/Soil-Core-Tests/SoilGarbageCollectorTest.class.st
@@ -23,6 +23,25 @@ SoilGarbageCollectorTest >> tearDown [
 ]
 
 { #category : #tests }
+SoilGarbageCollectorTest >> testGarbageCollectCurtailedClosesTheClones [
+	"deleting the clone directory is not enough: the files inside have to be closed
+	first. On POSIX an open file is removed anyway and only the handle leaks, so
+	the deletion alone looks like it worked"
+
+	| tx visitor |
+	tx := soil newTransaction.
+	tx root: (SoilTestGraphRoot new nested: (SoilTestNestedObject new label: #kept)).
+	tx makeRoot: tx root nested.
+	tx commit.
+	soil checkpoint.
+	visitor := SoilGarbageCollectorFailingVisitor new soil: soil; yourself.
+	[ visitor run ] on: Error do: [ :error | ].
+	(visitor instVarNamed: 'clones') valuesDo: [ :clone |
+		self deny: (clone instVarNamed: 'objectFile') isOpen.
+		self deny: (clone instVarNamed: 'indexFile') isOpen ]
+]
+
+{ #category : #tests }
 SoilGarbageCollectorTest >> testGarbageCollectCurtailedLeavesDatabaseIntact [
 	"if the collect fails mid-run (injected during the copy phase, after clones are built),
 	ifCurtailed deletes the clones and the original database is untouched."

--- a/src/Soil-Core/SoilGarbageCollectVisitor.class.st
+++ b/src/Soil-Core/SoilGarbageCollectVisitor.class.st
@@ -53,7 +53,13 @@ SoilGarbageCollectVisitor >> run [
 	  self processLoop.
 	  soil objectRepository segments do: [ :segment |
 		segment replaceWith: (clones at: segment id) ] ]
-		ifCurtailed: [ clones valuesDo: [ :clone | clone path ensureDeleteAll ] ].
+		ifCurtailed: [ clones valuesDo: [ :clone |
+			"close before deleting. An open file cannot be removed on Windows, so the
+			clone would survive the abort there; on POSIX it is removed but its handles
+			leak. A clone that failed halfway may not close cleanly - that must not stop
+			the deletion, and raising here would replace the error we are unwinding from"
+			[ clone close ] on: Error do: [ :error | ].
+			clone path ensureDeleteAll ] ].
 	soil metadata updateLastGarbageCollect
 ]
 


### PR DESCRIPTION
The collect builds a clone of every object segment and, if the run is curtailed, deletes the clones again. It deleted them without closing them first.

POSIX hides this: unlinking an open file works, the directory disappears, and only the handles leak. Windows does not - the delete fails and the clone survives the abort, which is where the CI run noticed it.

A clone that failed halfway may not close cleanly. That must not stop the deletion, and raising there would replace the error being unwound from, so the close is guarded and the delete happens either way.

The new test asserts the clones' object and index files are closed after a curtailed run - it fails without this change, which the existing testGarbageCollectCurtailedLeavesDatabaseIntact does not, because on POSIX the directory is gone whether or not anything was closed.