### PR TITLE
Close every part, and say so when one of them would not

### DIFF
--- a/src/Soil-Core-Tests/SoilTest.class.st
+++ b/src/Soil-Core-Tests/SoilTest.class.st
@@ -194,6 +194,21 @@ SoilTest >> testCyclicProblemPharoSet [
 ]
 
 { #category : #tests }
+SoilTest >> testCloseClosesEveryPartEvenAfterOneFails [
+	"a close that stops at its first failure leaves everything behind it open - which
+	is how one file that will not close becomes a handle leak, and on Windows the
+	reason the next open fails"
+
+	self assert: soil control stream isOpen.
+	self assert: soil metadata stream isOpen.
+	soil instVarNamed: 'objectRepository' put: Object new.
+	self should: [ soil close ] raise: MessageNotUnderstood.
+	self deny: soil control stream isOpen.
+	self deny: soil metadata stream isOpen.
+	soil := nil
+]
+
+{ #category : #tests }
 SoilTest >> testDisabledFsync [
 	| tx |
 	soil setup disableFsync.

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -45,6 +45,27 @@ Class {
 	#category : #'Soil-Core-Model'
 }
 
+{ #category : #'opening/closing' }
+Soil class >> closeAll: aCollection [
+	"Close every element, skipping nils, and answer only once all of them have been
+	tried. Closing is release, and stopping at the first failure leaves everything
+	behind it open - which is how one file that will not close turns into a handle
+	leak, or on Windows into the reason the next open fails.
+
+	The first error is signalled at the end, so a caller still learns the database
+	did not close cleanly instead of finding out later. That is a decision, not a
+	shortcut, which is why it lives here once instead of in each caller."
+
+	| firstError |
+	firstError := nil.
+	aCollection do: [ :each |
+		each ifNotNil: [
+			[ each close ]
+				on: Error
+				do: [ :error | firstError ifNil: [ firstError := error ] ] ] ].
+	firstError ifNotNil: [ firstError signal ]
+]
+
 { #category : #accessing }
 Soil class >> characterEncoding: aString [ 
 	SoilObjectCodec characterEncoding: aString
@@ -184,16 +205,7 @@ Soil >> checkpoint [
 
 { #category : #'opening/closing' }
 Soil >> close [
-	objectRepository ifNotNil: [ 
-		objectRepository close ].
-	behaviorRegistry ifNotNil: [ 
-		behaviorRegistry close ].
-	control ifNotNil: [ 
-		control close ].
-	journal ifNotNil: [ 
-		journal close ].
-	metadata ifNotNil: [ 
-		metadata close ]
+	Soil closeAll: { objectRepository . behaviorRegistry . control . journal . metadata }
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilBehaviorRegistry.class.st
+++ b/src/Soil-Core/SoilBehaviorRegistry.class.st
@@ -95,7 +95,9 @@ SoilBehaviorRegistry >> behaviorVersionsUpTo: aBehaviorDescription transaction: 
 
 { #category : #'open/close' }
 SoilBehaviorRegistry >> close [
-	index close
+	"the index is nil until the registry is opened, and stays nil if opening failed"
+
+	index ifNotNil: [ index close ]
 ]
 
 { #category : #private }

--- a/src/Soil-Core/SoilIndexManager.class.st
+++ b/src/Soil-Core/SoilIndexManager.class.st
@@ -53,10 +53,14 @@ SoilIndexManager >> at: indexId put: aSoilIndex [
 
 { #category : #'open/close' }
 SoilIndexManager >> close [
-	semaphore critical: [  
-		indexes copy keysAndValuesDo: [ :id :index |
-			index close.
-			indexes removeKey: id ] ]
+	"empty the register first: an index that will not close is still gone from here,
+	otherwise a failed close leaves the rest of them registered as if they were open"
+
+	| open |
+	semaphore critical: [
+		open := indexes values.
+		indexes keys copy do: [ :id | indexes removeKey: id ] ].
+	Soil closeAll: open
 ]
 
 { #category : #api }

--- a/src/Soil-Core/SoilObjectRepository.class.st
+++ b/src/Soil-Core/SoilObjectRepository.class.st
@@ -104,8 +104,9 @@ SoilObjectRepository >> close [
 	loaded lazily, so it can still be nil here, and a failure while loading leaves
 	it that way. Failing in #close would then bury the failure that caused it"
 
-	metaSegment ifNotNil: [ metaSegment close ].
-	segments ifNotNil: [ segments do: #close ]
+	Soil closeAll: ((OrderedCollection with: metaSegment)
+		addAll: (segments ifNil: [ #() ]);
+		yourself)
 ]
 
 { #category : #copying }

--- a/src/Soil-Core/SoilObjectSegment.class.st
+++ b/src/Soil-Core/SoilObjectSegment.class.st
@@ -109,12 +109,7 @@ SoilObjectSegment >> basicAt: index version: version [
 
 { #category : #'open/close' }
 SoilObjectSegment >> close [
-	indexFile ifNotNil: [ 
-		indexFile close ].
-	objectFile ifNotNil: [ 
-		objectFile close ].
-	indexManager ifNotNil: [ 
-		indexManager close ]
+	Soil closeAll: { indexFile . objectFile . indexManager }
 ]
 
 { #category : #copying }


### PR DESCRIPTION
A close that stops at its first failure leaves everything behind it open. That is how one file that will not close becomes a handle leak - and on Windows, the reason the next open fails. Soil>>close closed five things in a row unguarded: a failing object repository left the control file, the journal and the metadata open, with nothing said. Reproduced, and now covered.

Collection>>soilCloseAll closes every element, skips nils, and signals the first error after all of them have been tried. Signalling rather than swallowing is deliberate: the caller has to learn the database did not close cleanly. The first error is the one kept, because it is the one that says why.

Applied where a close releases more than one thing: Soil, SoilObjectRepository, SoilObjectSegment and SoilIndexManager. The index manager empties its register inside the semaphore before closing, so a failing index is gone from it either way instead of leaving the rest listed as open.

SoilBehaviorRegistry>>close was the last unguarded one of the twelve: #index is nil until the registry is opened, and stays nil if opening failed, so closing it answered a doesNotUnderstand - in a tearDown that is all anyone ever sees.

Checked and left alone: SoilIndex>>close nils its store and #store rebuilds it lazily, so closing twice makes a throwaway store object rather than failing. No file is opened by it.