### PR TITLE
Wait out the coalescing window against a deadline

### DIFF
--- a/src/Soil-Resident-Tests/SoilActiveResidentTest.class.st
+++ b/src/Soil-Resident-Tests/SoilActiveResidentTest.class.st
@@ -82,6 +82,46 @@ SoilActiveResidentTest >> testACoalescingWindowTurnsABurstIntoOneStep [
 ]
 
 { #category : #tests }
+SoilActiveResidentTest >> testACoalescingWindowIsNotCutShortByTheWorkItCollects [
+	"the window has to be waited out both when work is already pending as we enter
+	it -- the signal is then still standing -- and when a change arrives while it
+	runs. Both are the very work it collects.
+
+	Counting steps is not enough to see this, which is why the burst test above
+	stayed green while neither held: a collapsed window still produces exactly one
+	step, only far too early. So this one asserts the time."
+	| resident started |
+	resident := self residentWith: [ :d |
+		d cadence: #coalescing; window: 1 second ].
+
+	started := DateAndTime now.
+	resident noteWork.
+	200 milliSeconds asDelay wait.
+	resident noteWork.
+
+	self assert: (resident waitForStepWithin: 5 seconds).
+	self assert: DateAndTime now - started >= 1 second.
+	self assert: resident stepCount equals: 1
+]
+
+{ #category : #tests }
+SoilActiveResidentTest >> testACoalescingWindowIsCutShortByAStopRequest [
+	"the other half of the contract: a stop must not have to sit out the window,
+	or the embedder's stop timeout would have to exceed the longest window in the
+	system. An hour of window left, and the stop still comes back at once."
+	| resident started |
+	resident := self residentWith: [ :d |
+		d cadence: #coalescing; window: 1 hour ].
+
+	resident noteWork.
+	[ resident strategy isInWindow ] whileFalse: [ 10 milliSeconds asDelay wait ].
+
+	started := DateAndTime now.
+	self assert: (self stopWithin: 5 seconds) isEmpty.
+	self assert: DateAndTime now - started < 5 seconds
+]
+
+{ #category : #tests }
 SoilActiveResidentTest >> testAThrowingStepIsCountedAndTheLoopSurvivesIt [
 	"a transient failure must not take a resident down; a permanent one shows up
 	as a climbing count rather than as silence"

--- a/src/Soil-Resident/SoilCoalescingRunStrategy.class.st
+++ b/src/Soil-Resident/SoilCoalescingRunStrategy.class.st
@@ -16,20 +16,39 @@ Class {
 	#name : #SoilCoalescingRunStrategy,
 	#superclass : #SoilSignalRunStrategy,
 	#instVars : [
-		'window'
+		'window',
+		'deadline'
 	],
 	#category : #'Soil-Resident'
 }
 
 { #category : #waiting }
 SoilCoalescingRunStrategy >> awaitDue [
+	"the window is waited out against a deadline, not against a single wait on the
+	work signal. Two things would otherwise cut it short, and both are the very
+	work it exists to collect: a signal still standing when we get here -- super
+	returns at once whenever work was already pending, leaving the signal up -- and
+	a change arriving while we wait. Only a stop may end the window early, and it
+	still does: the flag is checked every turn, and #requestStop wakes us to see it."
 	super awaitDue.
-	resident shouldStop ifFalse: [ resident waitForWorkUpTo: self window ]
+	deadline := DateAndTime now + self window.
+	[ [ resident shouldStop not and: [ DateAndTime now < deadline ] ] whileTrue: [
+		resident waitForWorkUpTo: deadline - DateAndTime now ] ]
+		ensure: [ deadline := nil ]
 ]
 
 { #category : #accessing }
 SoilCoalescingRunStrategy >> defaultWindow [
 	^ 30 seconds
+]
+
+{ #category : #testing }
+SoilCoalescingRunStrategy >> isInWindow [
+	"am I inside the collecting window right now? The one state of mine worth
+	asking about from outside: a caller that needs a resident to have really
+	reached its window cannot read that off the resident, whose #isWorking covers
+	the step and deliberately not the wait before it."
+	^ deadline notNil
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
A collecting window that is waited out with a single wait on the work signal ends as soon as that signal is raised - and the signal is raised by the very work the window exists to collect. Two cases, one cause:

- a signal still standing on entry. SoilSignalRunStrategy>>awaitDue returns at once whenever work is already pending and leaves the signal up, so the following waitForWorkUpTo: returns immediately and the window is skipped entirely. Measured with a 5s window: written after 21ms.
- a change arriving while the window runs. Measured with the same window and a second change after 1000ms: written after 1031ms.

Under sustained load - the hot path the strategy exists for - both degenerate to one step per change instead of one per burst.

awaitDue now waits against a deadline, checking the stop flag every turn and waiting out the remainder otherwise. Only a stop ends the window early, which it still does: with an hour of window left the stop comes back in 57ms.

The existing burst test could not see any of this because it asserts how many steps a burst causes, not when: a collapsed window still produces exactly one step. The new test asserts the time instead, and fails without this change.

isInWindow exposes the deadline, because with the window living in the strategy "has it reached its window" can no longer be read off the resident - its isWorking covers the step and deliberately not the wait before it.