### PR TITLE
Let a resident say what it is doing, not only when it fails

### DIFF
--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -131,7 +131,7 @@ Soil >> backupTo: aStringOrFileReference [
 { #category : #'opening/closing' }
 Soil >> basicOpen [
 	self isOpen ifTrue: [ self error: 'Database already open' ].
-	('open soil database at ', path asString) soilEmit.
+	self emit: 'open database at ', path asString.
 	control := SoilControlFile new
 		soil: self;
 		open.
@@ -222,6 +222,26 @@ Soil >> critical: aBlock [
 { #category : #accessing }
 Soil >> defaultFabricClass [ 
 	^ SoilFabric 
+]
+
+{ #category : #logging }
+Soil >> emit: aString [
+	"where this database says what it is doing, and the one place an embedder has
+	to fill to collect it elsewhere. Everything in Soil that reports comes through
+	here rather than emitting for itself, so overriding is a single decision per
+	database instead of one per reporter.
+
+	The default emits a SoilSignal naming the database - which reaches a logger
+	that was started for SoilSignal, and nothing else. SoilSignal is a sibling of
+	an embedder's own signal class, not an ancestor of it, so an embedder that
+	does not override me has to name SoilSignal to its logger.
+
+	Built with #on: rather than #emit:, the way SoilApplicationMigration already
+	builds its own: #emit: fills #message and leaves the wrapped object empty, and
+	the printing then puts a trailing 'nil' on every line."
+	(SoilSignal on: aString)
+		databaseName: self name;
+		emit
 ]
 
 { #category : #public }

--- a/src/Soil-Resident-Tests/SoilResidentReportingTest.class.st
+++ b/src/Soil-Resident-Tests/SoilResidentReportingTest.class.st
@@ -20,6 +20,27 @@ Class {
 }
 
 { #category : #helpers }
+SoilResidentReportingTest >> entriesOf: aMemoryLogger [
+	<ignoreNotImplementedSelectors: #( entries recordings )>
+	"The pragma is not a way around the lint rule, it is the answer to it: one of
+	the two selectors below is missing in whichever Pharo is running, and which one
+	that is, is the whole point of this method - the same shape, and for the same
+	reason, as SoilActiveResident>>wait:upTo:.
+
+	What a MemoryLogger calls its collected signals differs across the Pharo
+	versions Soil builds on: #entries does not exist before Pharo 13, and
+	#recordings is deprecated from Pharo 13 on. Asking #entries first therefore
+	never reaches the deprecated one where it is deprecated - which matters more
+	here than tidiness, because that deprecation carries a transformWith: rule and
+	rewrites the source of whichever method called it.
+
+	Fails loudly rather than answering something if neither is there."
+	(aMemoryLogger respondsTo: #entries) ifTrue: [ ^ aMemoryLogger entries ].
+	(aMemoryLogger respondsTo: #recordings) ifTrue: [ ^ aMemoryLogger recordings ].
+	self error: 'no known way to read a MemoryLogger in this Pharo'
+]
+
+{ #category : #helpers }
 SoilResidentReportingTest >> path [
 	^ 'soil-resident-reporting-tests'
 ]
@@ -164,15 +185,16 @@ SoilResidentReportingTest >> testStepsAreSilentWhenTurnedDown [
 SoilResidentReportingTest >> testTheDefaultSeamEmitsASoilSignalNamingTheDatabase [
 	"what a database that does not override Soil>>emit: does - the only test here
 	that goes through Beacon, because it is the only one about the default"
-	| logger plain |
+	| logger plain collected |
 	plain := Soil path: self path , '-default'.
 	plain destroy; initializeFilesystem.
 	logger := MemoryLogger new.
 	[ logger runFor: SoilSignal during: [ plain emit: 'something happened' ] ]
 		ensure: [ plain close. plain destroy ].
-	"#entries, not #recordings: the latter is deprecated in Pharo 13 with a
-	transformWith: rule, and running the test would rewrite this method"
-	self assert: logger entries size equals: 1.
-	self assert: logger entries first class equals: SoilSignal.
-	self assert: logger entries first databaseName equals: plain name
+	"read through #entriesOf:, because what a logger calls its collected signals
+	differs across the Pharo versions Soil builds on"
+	collected := self entriesOf: logger.
+	self assert: collected size equals: 1.
+	self assert: collected first class equals: SoilSignal.
+	self assert: collected first databaseName equals: plain name
 ]

--- a/src/Soil-Resident-Tests/SoilResidentReportingTest.class.st
+++ b/src/Soil-Resident-Tests/SoilResidentReportingTest.class.st
@@ -1,0 +1,178 @@
+"
+What a resident says while it runs, and what it stays quiet about.
+
+The subject is not that a line reaches a log - that is Soil>>emit: and is asked
+about separately here in one test. The subject is which moments produce a line
+at all, because until now only failures did, and silence therefore meant either
+'all is well' or 'nothing is running' with no way to tell the two apart.
+
+The test database collects what is reported instead of signalling it, so these
+tests read the lines directly and depend on no logger.
+"
+Class {
+	#name : #SoilResidentReportingTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'soil',
+		'supervisor'
+	],
+	#category : #'Soil-Resident-Tests'
+}
+
+{ #category : #helpers }
+SoilResidentReportingTest >> path [
+	^ 'soil-resident-reporting-tests'
+]
+
+{ #category : #helpers }
+SoilResidentReportingTest >> residentWith: aBlock [
+	| description txn |
+	description := SoilTestActiveResidentDescription new.
+	aBlock value: description.
+	soil addResidentDescription: description.
+	txn := soil newTransaction.
+	[ supervisor loadFrom: txn.
+	supervisor startAllIn: txn ]
+		ensure: [ txn abort ].
+	^ supervisor residentNamed: #active
+]
+
+{ #category : #running }
+SoilResidentReportingTest >> setUp [
+	super setUp.
+	soil := SoilTestResidentDatabase path: self path.
+	soil
+		destroy;
+		initializeFilesystem;
+		initializeRoot.
+	supervisor := soil newResidentSupervisor
+]
+
+{ #category : #helpers }
+SoilResidentReportingTest >> stopWithin: aDuration [
+	| txn |
+	txn := soil newTransaction.
+	^ [ supervisor stopAllIn: txn timeout: aDuration ]
+		ensure: [ txn isAborted ifFalse: [ txn abort ] ]
+]
+
+{ #category : #running }
+SoilResidentReportingTest >> tearDown [
+	supervisor ifNotNil: [ self stopWithin: 2 seconds ].
+	soil ifNotNil: [
+		soil close.
+		soil destroy ].
+	super tearDown
+]
+
+{ #category : #tests }
+SoilResidentReportingTest >> testAFailedStartIsReportedOnce [
+	"the supervisor used to say it as well as the state machine, which said it
+	twice in two different shapes"
+	| description txn |
+	description := SoilTestFailingResidentDescription new.
+	soil addResidentDescription: description.
+	txn := soil newTransaction.
+	[ supervisor loadFrom: txn.
+	supervisor startAllIn: txn ]
+		ensure: [ txn abort ].
+	self assert: (soil reportedMatching: 'failed to start') size equals: 1
+]
+
+{ #category : #tests }
+SoilResidentReportingTest >> testAStepFailureIsReportedEvenWhenStepsAreNot [
+	"a failure is not routine volume: turning the steps down must not turn the
+	failures off with them"
+	| resident |
+	supervisor emitsEveryStep: false.
+	resident := self residentWith: [ :d | d ].
+	resident throwOnStep: true.
+	resident noteWork.
+	self assert: (resident waitForStepWithin: 2 seconds).
+	"the routine line is gone, and the failure - which names the step it was, so
+	the number is not lost with the routine line - is not"
+	self deny: (soil reported includes: 'resident active: step 1').
+	self assert: (soil reportedMatching: 'step 1 failed: the step was told to throw') size equals: 1
+]
+
+{ #category : #tests }
+SoilResidentReportingTest >> testATickReportsWorkDoneSinceTheLastOne [
+	| resident |
+	resident := self residentWith: [ :d | d ].
+	resident noteWork.
+	self assert: (resident waitForStepWithin: 2 seconds).
+	resident tick.
+	self assert: (soil reportedMatching: '1 step since the last report') size equals: 1
+]
+
+{ #category : #tests }
+SoilResidentReportingTest >> testATickWithoutWorkSaysNothing [
+	"otherwise a quiet resident would fill the log at the tick's cadence, and the
+	lines that mean something would drown in the ones that do not"
+	| resident |
+	resident := self residentWith: [ :d | d ].
+	resident tick.
+	resident tick.
+	self assert: (soil reportedMatching: 'since the last report') isEmpty
+]
+
+{ #category : #tests }
+SoilResidentReportingTest >> testEveryLineNamesItsResident [
+	"several residents report into one database, so a line that does not say whose
+	it is cannot be read"
+	| resident |
+	resident := self residentWith: [ :d | d ].
+	resident noteWork.
+	self assert: (resident waitForStepWithin: 2 seconds).
+	self deny: soil reported isEmpty.
+	self assert: (soil reported allSatisfy: [ :each | each beginsWith: 'resident active: ' ])
+]
+
+{ #category : #tests }
+SoilResidentReportingTest >> testStartingAndStoppingAreReported [
+	"the whole point: silence now means nothing is running, because a resident that
+	is running has said so"
+	self residentWith: [ :d | d ].
+	self assert: (soil reportedMatching: 'started') size equals: 1.
+	self stopWithin: 2 seconds.
+	supervisor := nil.
+	self assert: (soil reportedMatching: 'stopping') size equals: 1.
+	self assert: (soil reportedMatching: 'stopped') size equals: 1
+]
+
+{ #category : #tests }
+SoilResidentReportingTest >> testStepsAreReportedWhenAskedFor [
+	| resident |
+	resident := self residentWith: [ :d | d ].
+	resident noteWork.
+	self assert: (resident waitForStepWithin: 2 seconds).
+	self assert: (soil reportedMatching: 'step 1') size equals: 1
+]
+
+{ #category : #tests }
+SoilResidentReportingTest >> testStepsAreSilentWhenTurnedDown [
+	"the one level whose volume scales with the work"
+	| resident |
+	supervisor emitsEveryStep: false.
+	resident := self residentWith: [ :d | d ].
+	resident noteWork.
+	self assert: (resident waitForStepWithin: 2 seconds).
+	self assert: (soil reportedMatching: 'step ') isEmpty
+]
+
+{ #category : #tests }
+SoilResidentReportingTest >> testTheDefaultSeamEmitsASoilSignalNamingTheDatabase [
+	"what a database that does not override Soil>>emit: does - the only test here
+	that goes through Beacon, because it is the only one about the default"
+	| logger plain |
+	plain := Soil path: self path , '-default'.
+	plain destroy; initializeFilesystem.
+	logger := MemoryLogger new.
+	[ logger runFor: SoilSignal during: [ plain emit: 'something happened' ] ]
+		ensure: [ plain close. plain destroy ].
+	"#entries, not #recordings: the latter is deprecated in Pharo 13 with a
+	transformWith: rule, and running the test would rewrite this method"
+	self assert: logger entries size equals: 1.
+	self assert: logger entries first class equals: SoilSignal.
+	self assert: logger entries first databaseName equals: plain name
+]

--- a/src/Soil-Resident-Tests/SoilTestActiveResident.class.st
+++ b/src/Soil-Resident-Tests/SoilTestActiveResident.class.st
@@ -1,6 +1,7 @@
 "
-The dummy active resident: it counts its steps and can be told to leave work
-behind, to throw, and which cadence to run on. Everything it does is in memory,
+The dummy active resident: it can be told to leave work behind, to throw, and
+which cadence to run on. Counting its steps is no longer its own business -
+SoilActiveResident does that, which is what this class faked before. Everything it does is in memory,
 so that a drain test is not a test of transaction speed.
 
 Which strategy it uses arrives as a Symbol rather than as a class, because the
@@ -14,7 +15,6 @@ Class {
 		'cadence',
 		'window',
 		'interval',
-		'stepCount',
 		'prepareCount',
 		'workToLeave',
 		'throwOnStep',
@@ -31,7 +31,6 @@ SoilTestActiveResident >> cadence: aSymbol [
 { #category : #initialization }
 SoilTestActiveResident >> initialize [
 	super initialize.
-	stepCount := 0.
 	prepareCount := 0.
 	workToLeave := 0.
 	throwOnStep := false.
@@ -74,9 +73,11 @@ SoilTestActiveResident >> prepareIn: aTransaction [
 
 { #category : #running }
 SoilTestActiveResident >> runStep [
-	"the signal is given in the ensure, so that a throwing step is observable too"
-	[ stepCount := stepCount + 1.
-	workToLeave > 0 ifTrue: [
+	"the signal is given in the ensure, so that a throwing step is observable too.
+	The steps are not counted here any more - SoilActiveResident counts them now,
+	and it counts them before the step rather than inside it, so one that never
+	returns is counted too"
+	[ workToLeave > 0 ifTrue: [
 		workToLeave := workToLeave - 1.
 		self noteWork ].
 	throwOnStep ifTrue: [ Error signal: 'the step was told to throw' ] ]
@@ -88,11 +89,6 @@ SoilTestActiveResident >> runStrategyClass [
 	cadence = #coalescing ifTrue: [ ^ SoilCoalescingRunStrategy ].
 	cadence = #interval ifTrue: [ ^ SoilIntervalRunStrategy ].
 	^ SoilSignalRunStrategy
-]
-
-{ #category : #accessing }
-SoilTestActiveResident >> stepCount [
-	^ stepCount
 ]
 
 { #category : #accessing }

--- a/src/Soil-Resident-Tests/SoilTestResidentDatabase.class.st
+++ b/src/Soil-Resident-Tests/SoilTestResidentDatabase.class.st
@@ -4,10 +4,19 @@ its own key in the root dictionary and thereby fills the overridable lookup
 Soil>>residentRegistryIn:. That is exactly the freedom the stage-one lookup is
 meant to leave the embedder -- Soil prescribes no structure, the way to the
 registry is overridden here.
+
+I also fill the other overridable seam, Soil>>emit:, by collecting what is
+reported instead of signalling it. A test can then read the lines straight off
+me - no logger to start, no Beacon in the way, and nothing that depends on
+another test having stopped its logger. What the default seam does is a
+question of its own and is asked in its own test.
 "
 Class {
 	#name : #SoilTestResidentDatabase,
 	#superclass : #Soil,
+	#instVars : [
+		'reported'
+	],
 	#category : #'Soil-Resident-Tests'
 }
 
@@ -41,12 +50,37 @@ SoilTestResidentDatabase >> ensureResidentRegistryIn: aTransaction [
 			registry ]
 ]
 
+{ #category : #logging }
+SoilTestResidentDatabase >> emit: aString [
+	reported add: aString
+]
+
+{ #category : #initialization }
+SoilTestResidentDatabase >> initialize [
+	super initialize.
+	reported := OrderedCollection new
+]
+
 { #category : #initialization }
 SoilTestResidentDatabase >> initializeRoot [
 	| txn |
 	txn := self newTransaction.
 	txn root: SoilPersistentDictionary new.
 	txn commit
+]
+
+{ #category : #logging }
+SoilTestResidentDatabase >> reported [
+	"the lines, in the order they were reported"
+	^ reported
+]
+
+{ #category : #logging }
+SoilTestResidentDatabase >> reportedMatching: aString [
+	"the lines containing aString. Substring rather than equality on purpose: a
+	line carries a resident's name and often a number, and a test should say which
+	part of it is the point"
+	^ reported select: [ :each | each includesSubstring: aString ]
 ]
 
 { #category : #residents }

--- a/src/Soil-Resident/SoilActiveResident.class.st
+++ b/src/Soil-Resident/SoilActiveResident.class.st
@@ -39,7 +39,9 @@ Class {
 		'pendingWork',
 		'working',
 		'lastStepError',
-		'stepErrorCount'
+		'stepErrorCount',
+		'stepCount',
+		'reportedStepCount'
 	],
 	#category : #'Soil-Resident'
 }
@@ -67,7 +69,8 @@ SoilActiveResident >> handleStepError: anError [
 	"my step threw. Keep it and count it, then let the loop go on. Subclasses that
 	can tell a transient failure from a fatal one may decide otherwise"
 	lastStepError := anError.
-	stepErrorCount := stepErrorCount + 1
+	stepErrorCount := stepErrorCount + 1.
+	self emit: 'step ', stepCount printString, ' failed: ', anError messageText
 ]
 
 { #category : #testing }
@@ -81,6 +84,8 @@ SoilActiveResident >> initialize [
 	working := false.
 	pendingWork := false.
 	stepErrorCount := 0.
+	stepCount := 0.
+	reportedStepCount := 0.
 	workSignal := Semaphore new
 ]
 
@@ -166,7 +171,9 @@ SoilActiveResident >> runStepProtected [
 	returns early on the flag would otherwise cause"
 	working := true.
 	pendingWork := false.
+	stepCount := stepCount + 1.
 	workSignal consumeAllSignals.
+	self emitsEveryStep ifTrue: [ self emit: 'step ', stepCount printString ].
 	[ [ self runStep ]
 		on: Error
 		do: [ :anError | self handleStepError: anError ] ]
@@ -223,7 +230,48 @@ SoilActiveResident >> tick [
 	count it, so that a crash loop is visible instead of looking like health"
 	self hasRunningProcess ifFalse: [
 		self noteProcessRestart.
-		self startProcess ]
+		self startProcess ].
+	self reportWorkSinceLastTick
+]
+
+{ #category : #logging }
+SoilActiveResident >> emitsEveryStep [
+	"the one reporting level whose volume scales with the work, so it is the one
+	the embedder may turn down. Without a supervisor there is nobody to report to
+	anyway"
+	^ supervisor notNil and: [ supervisor emitsEveryStep ]
+]
+
+{ #category : #logging }
+SoilActiveResident >> reportWorkSinceLastTick [
+	"a periodic line, but only when something happened: a resident that worked says
+	how much, one that sat still says nothing. Silence on a tick therefore means
+	'nothing to do', which is a different statement from the silence this whole
+	mechanism was built to end - that one meant 'no idea'.
+
+	The counters are cumulative and the line is a delta, because what one wants to
+	read off a series of these is the rate."
+	| done |
+	done := stepCount - reportedStepCount.
+	done = 0 ifTrue: [ ^ self ].
+	reportedStepCount := stepCount.
+	self emit: (self count: done of: 'step'), ' since the last report, ',
+		(self count: stepErrorCount of: 'error'), ' in all'
+]
+
+{ #category : #logging }
+SoilActiveResident >> count: anInteger of: aNoun [
+	"so that a report says '1 step' and not '1 steps'. A line written to be read by
+	somebody should read like a line"
+	^ anInteger printString, ' ', (anInteger = 1 ifTrue: [ aNoun ] ifFalse: [ aNoun, 's' ])
+]
+
+{ #category : #accessing }
+SoilActiveResident >> stepCount [
+	"how many work units I have entered. Counted before the step rather than after,
+	so a step that never returns is still counted - that is the one whose number
+	somebody will be looking for"
+	^ stepCount
 ]
 
 { #category : #waiting }

--- a/src/Soil-Resident/SoilResident.class.st
+++ b/src/Soil-Resident/SoilResident.class.st
@@ -71,6 +71,20 @@ SoilResident >> descriptionIn: aTransaction [
 	^ aTransaction objectWithId: descriptionId
 ]
 
+{ #category : #logging }
+SoilResident >> emit: aString [
+	"every line of mine names me, so that lines from several residents in one
+	database can be told apart and a stable prefix can be searched for. That the
+	prefix is decided here once, rather than written out at each of the places
+	that report, is the point of this method - it does not save typing, it keeps
+	the lines the same shape.
+
+	Reports through the supervisor, which reports through the database. A resident
+	without a supervisor is one that was never added to one, which happens in unit
+	tests, and a test has no business being stopped by a log line."
+	supervisor ifNotNil: [ :s | s emit: 'resident ', self name asString, ': ', aString ]
+]
+
 { #category : #accessing }
 SoilResident >> error [
 	"the start error, if I am #failed"
@@ -164,18 +178,21 @@ SoilResident >> markFailed: anError [
 	"my #startIn: has thrown. I am not usable; whether that keeps the database
 	from opening is the embedder's decision"
 	state := #failed.
-	error := anError
+	error := anError.
+	self emit: 'failed to start: ', anError messageText
 ]
 
 { #category : #accessing }
 SoilResident >> markStarted [
-	state := #started
+	state := #started.
+	self emit: 'started'
 ]
 
 { #category : #accessing }
 SoilResident >> markStopped [
 	"called by my own process when it has left its loop between two work units"
-	state := #stopped
+	state := #stopped.
+	self emit: 'stopped'
 ]
 
 { #category : #accessing }
@@ -204,8 +221,10 @@ SoilResident >> noteProcessRestart [
 
 	Deliberately only counted, with no upper bound: what number should turn a
 	resident into #failed is decided once a real active resident has produced
-	real numbers."
-	restartCount := restartCount + 1
+	real numbers. Counted and said: a number nobody reads is not visibility, and
+	a restart is rare enough that saying it costs nothing."
+	restartCount := restartCount + 1.
+	self emit: 'process restarted (', restartCount printString, ')'
 ]
 
 { #category : #stopping }
@@ -217,6 +236,7 @@ SoilResident >> requestStop [
 	right away."
 	stopRequested := true.
 	state := #stopping.
+	self emit: 'stopping'.
 	self wakeUp.
 	self hasRunningProcess ifFalse: [ self markStopped ]
 ]

--- a/src/Soil-Resident/SoilResidentSupervisor.class.st
+++ b/src/Soil-Resident/SoilResidentSupervisor.class.st
@@ -22,7 +22,8 @@ Class {
 		'residents',
 		'mutex',
 		'tickProcess',
-		'tickInterval'
+		'tickInterval',
+		'emitsEveryStep'
 	],
 	#category : #'Soil-Resident'
 }
@@ -75,7 +76,7 @@ SoilResidentSupervisor >> flushAll [
 	self residents do: [ :each |
 		[ each flushOnStop ]
 			on: Error
-			do: [ :err | self log: 'resident ', each name asString, ' failed to flush on stop: ', err messageText ] ]
+			do: [ :err | each emit: 'failed to flush on stop: ', err messageText ] ]
 ]
 
 { #category : #hooks }
@@ -102,7 +103,7 @@ SoilResidentSupervisor >> idleStateOf: aResident [
 	^ [ aResident isIdle ]
 		on: Error
 		do: [ :err |
-			self log: 'resident ', aResident name asString, ' failed to answer isIdle: ', err messageText.
+			aResident emit: 'failed to answer isIdle: ', err messageText.
 			false ]
 ]
 
@@ -110,7 +111,8 @@ SoilResidentSupervisor >> idleStateOf: aResident [
 SoilResidentSupervisor >> initialize [
 	super initialize.
 	residents := Dictionary new.
-	mutex := Mutex new
+	mutex := Mutex new.
+	emitsEveryStep := true
 ]
 
 { #category : #testing }
@@ -135,12 +137,28 @@ SoilResidentSupervisor >> loadFrom: aTransaction [
 ]
 
 { #category : #logging }
-SoilResidentSupervisor >> log: aString [
-	"overridable: an embedder that has its own logging fills this. Soil's default
-	emits a signal, the same way SoilApplicationMigration does"
-	SoilSignal new
-		databaseName: (soil ifNotNil: [ soil name ]);
-		emit: aString
+SoilResidentSupervisor >> emit: aString [
+	"through the database rather than emitting for myself: Soil>>emit: is the one
+	seam an embedder fills, and a resident line has no reason to need a second one.
+
+	Tolerates a missing database - a supervisor built without one is a unit test,
+	and a test has no business being stopped by a log line."
+	soil ifNotNil: [ :database | database emit: aString ]
+]
+
+{ #category : #accessing }
+SoilResidentSupervisor >> emitsEveryStep [
+	"whether the residents report every single work unit, and not only their state
+	changes and what a tick summarises. On by default because a resident that says
+	nothing between starting and stopping is exactly the silence this reporting
+	exists to end - but it is the one level whose volume scales with the work, so
+	an embedder under load can turn it down without touching code."
+	^ emitsEveryStep
+]
+
+{ #category : #accessing }
+SoilResidentSupervisor >> emitsEveryStep: aBoolean [
+	emitsEveryStep := aBoolean
 ]
 
 { #category : #transactions }
@@ -155,7 +173,7 @@ SoilResidentSupervisor >> pendingWorkOf: aResident [
 	^ [ aResident hasPendingWork ]
 		on: Error
 		do: [ :err |
-			self log: 'resident ', aResident name asString, ' failed to answer hasPendingWork: ', err messageText.
+			aResident emit: 'failed to answer hasPendingWork: ', err messageText.
 			true ]
 ]
 
@@ -195,7 +213,9 @@ SoilResidentSupervisor >> soil: aSoil [
 SoilResidentSupervisor >> startAllIn: aTransaction [
 	"phase two: now each instance gets its start, with errors isolated per
 	resident. A failure is left behind visibly as #failed plus the error, not
-	merely logged -- the embedder needs the answer to decide"
+	merely logged -- the embedder needs the answer to decide. Reporting it is
+	#markFailed:'s business, not mine: it is a state change like the others, and
+	saying it here as well would say it twice"
 	self residents do: [ :each |
 		"only what has not been started: a second start would create a second
 		process for a resident that already has one"
@@ -203,9 +223,7 @@ SoilResidentSupervisor >> startAllIn: aTransaction [
 			[ each startIn: aTransaction.
 			each markStarted ]
 				on: Error
-				do: [ :err |
-					each markFailed: err.
-					self log: 'resident ', each name asString, ' failed to start: ', err messageText ] ] ]
+				do: [ :err | each markFailed: err ] ] ]
 ]
 
 { #category : #running }
@@ -245,13 +263,13 @@ SoilResidentSupervisor >> stopAllIn: aTransaction timeout: aDuration [
 	self residents do: [ :each |
 		[ each requestStop ]
 			on: Error
-			do: [ :err | self log: 'resident ', each name asString, ' failed on requestStop: ', err messageText ] ].
+			do: [ :err | each emit: 'failed on requestStop: ', err messageText ] ].
 	pending := self waitForReceipts: aDuration.
 	pending do: [ :each |
-		self log: 'resident ', each name asString, ' did not acknowledge the stop within ', aDuration asString, ', terminating'.
+		each emit: 'did not acknowledge the stop within ', aDuration asString, ', terminating'.
 		[ each terminateProcesses ]
 			on: Error
-			do: [ :err | self log: 'resident ', each name asString, ' failed to terminate: ', err messageText ] ].
+			do: [ :err | each emit: 'failed to terminate: ', err messageText ] ].
 	self flushAll.
 	^ pending
 ]
@@ -275,7 +293,7 @@ SoilResidentSupervisor >> tick [
 		(each isStopping or: [ each isStopped ]) ifFalse: [
 			[ each tick ]
 				on: Error
-				do: [ :err | self log: 'resident ', each name asString, ' failed on tick: ', err messageText ] ] ]
+				do: [ :err | each emit: 'failed on tick: ', err messageText ] ] ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
Every self log: in the supervisor sat in an error handler, so the normal path said nothing at all. Silence therefore meant either "all is well" or "nothing is running", and the two looked exactly alike. That is the defect - not too little detail, but a purely negative signal.

Soil>>emit: is new and is the one seam per database. Soil-Core had none: the open path emitted for itself, the migration and the supervisor each had their own log:, so an embedder collecting its log elsewhere had to override three places. Now everything reports through the database, and the supervisor and the residents report through it in turn. Built with #on: rather than SoilSignal's #emit:, the way the migration already builds its own - #emit: fills #message and leaves the wrapped object empty, which puts a trailing "nil" on every line.

What is reported: a resident's state changes (started, stopping, stopped, failed to start), a revived process with its count, a failed step with the number of the step it was, a tick summary of the work since the last one, and - the only level whose volume scales with the work - every single step. That last one is on by default and the embedder can turn it down through the supervisor, because Beacon filters by signal class and these lines share one.

A tick with no work says nothing, so silence on a tick means "nothing to do", which is a statement, unlike the silence this replaces.

Every line names its resident. The supervisor's own per-resident lines now go through the resident for exactly that reason, which also removes the duplicate report of a failed start: the state machine says it, the supervisor no longer says it again in a different shape.

SoilTestActiveResident loses its own stepCount and inherits the real one - it was counting steps because the base did not.