### PR TITLE
Say which way recovery went, and what the database did around it

### DIFF
--- a/src/Soil-Core-Tests/SoilRecoveryReportingTest.class.st
+++ b/src/Soil-Core-Tests/SoilRecoveryReportingTest.class.st
@@ -1,0 +1,116 @@
+"
+What recovery says about the way it went.
+
+#recover has six ways out and used to take all of them in silence, which is how a
+day of hunting a Windows problem could go by without the log ever naming which
+one had happened. These tests stage the three that can be staged and hold each to
+its own line.
+
+Staging them means putting a database into the state a crash would leave. Every
+commit that changed something checkpoints - SoilTransactionManager does it - so
+after a clean close there is never anything past the last checkpoint. Winding the
+control file's checkpoint back is what makes the difference, and it is the same
+handle SoilJournalConverter reaches for.
+
+The three not staged here: a database on read-only media, a fragment file missing
+for the last checkpoint (unreachable through #open, which recreates one and
+checkpoints before recovery looks), and a checkpoint that ends the journal
+(#isNeeded appears to rule it out before #recover is entered).
+"
+Class {
+	#name : #SoilRecoveryReportingTest,
+	#superclass : #TestCase,
+	#instVars : [
+		'soil'
+	],
+	#category : #'Soil-Core-Tests'
+}
+
+{ #category : #helpers }
+SoilRecoveryReportingTest >> commit: anInteger [
+	"a committing transaction, so that the journal gets an entry to replay"
+	| txn |
+	txn := soil newTransaction.
+	txn root: (SoilPersistentDictionary new
+		at: #n put: anInteger;
+		yourself).
+	txn commit
+]
+
+{ #category : #helpers }
+SoilRecoveryReportingTest >> path [
+	^ 'soil-recovery-reporting-tests'
+]
+
+{ #category : #helpers }
+SoilRecoveryReportingTest >> reopen [
+	"close and open again, which is where recovery runs"
+	soil close.
+	soil := SoilReportingTestDatabase path: self path.
+	soil open
+]
+
+{ #category : #running }
+SoilRecoveryReportingTest >> setUp [
+	super setUp.
+	soil := SoilReportingTestDatabase path: self path.
+	soil
+		destroy;
+		initializeFilesystem
+]
+
+{ #category : #running }
+SoilRecoveryReportingTest >> tearDown [
+	soil ifNotNil: [
+		soil isOpen ifTrue: [ soil close ].
+		soil destroy ].
+	super tearDown
+]
+
+{ #category : #tests }
+SoilRecoveryReportingTest >> testABogusCheckpointPositionIsNamedWithItsError [
+	"the position does not read back as an entry, so recovery quietly starts a fresh
+	fragment file. Quietly was the problem: the line carries the read error, which
+	is the only thing that says what was wrong with the file"
+	self commit: 1.
+	soil control checkpoint: (SoilLogSequenceNumber fileNumber: 0 offset: 0).
+	self reopen.
+	self assert: (soil reportedMatching: 'does not read back') size equals: 1
+]
+
+{ #category : #tests }
+SoilRecoveryReportingTest >> testACleanDatabaseSaysThereIsNothingToDo [
+	"the common case, and it has to say something - otherwise silence still means
+	either 'clean' or 'recovery never ran'"
+	self commit: 1.
+	self reopen.
+	self assert: (soil reportedMatching: 'nothing past the last checkpoint') size equals: 1
+]
+
+{ #category : #tests }
+SoilRecoveryReportingTest >> testAReplayCountsWhatItReplayed [
+	"the count is the point: a line saying only that recovery ran leaves open
+	whether it found one transaction or a thousand"
+	| checkpoint |
+	self commit: 1.
+	checkpoint := soil control lastCheckpoint.
+	self commit: 2.
+	self commit: 3.
+	"back to a checkpoint that is real but no longer the last - what a crash after
+	those two commits would have left"
+	soil control checkpoint: checkpoint.
+	self reopen.
+	self assert: (soil reportedMatching: 'replaying the journal from the last checkpoint') size equals: 1.
+	self assert: (soil reportedMatching: 'replayed 2 transactions from 1 fragment file') size equals: 1
+]
+
+{ #category : #tests }
+SoilRecoveryReportingTest >> testCommittingStaysSilent [
+	"the hot path is out of scope, and it is easy to slip into: every commit that
+	changed something checkpoints, so a line in Soil>>checkpoint would be one per
+	commit"
+	self commit: 1.
+	self commit: 2.
+	self commit: 3.
+	self assert: (soil reportedMatching: 'checkpoint') isEmpty
+]

--- a/src/Soil-Core-Tests/SoilReportingTestDatabase.class.st
+++ b/src/Soil-Core-Tests/SoilReportingTestDatabase.class.st
@@ -1,0 +1,38 @@
+"
+A database that collects what it reports instead of signalling it, by filling the
+overridable seam Soil>>emit:.
+
+A test can then read the lines straight off it - no logger to start, nothing that
+depends on another test having stopped its own, and no dependency on what a
+MemoryLogger happens to call its collected signals in this Pharo.
+"
+Class {
+	#name : #SoilReportingTestDatabase,
+	#superclass : #Soil,
+	#instVars : [
+		'reported'
+	],
+	#category : #'Soil-Core-Tests'
+}
+
+{ #category : #logging }
+SoilReportingTestDatabase >> emit: aString [
+	reported add: aString
+]
+
+{ #category : #initialization }
+SoilReportingTestDatabase >> initialize [
+	super initialize.
+	reported := OrderedCollection new
+]
+
+{ #category : #logging }
+SoilReportingTestDatabase >> reported [
+	"the lines, in the order they were reported"
+	^ reported
+]
+
+{ #category : #logging }
+SoilReportingTestDatabase >> reportedMatching: aString [
+	^ reported select: [ :each | each includesSubstring: aString ]
+]

--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -121,10 +121,12 @@ Soil >> backupTo: aStringOrFileReference [
 		path: aStringOrFileReference asFileReference;
 		destroy;
 		initializeFilesystem.
+	self emit: 'backing up to ', aStringOrFileReference asString.
 	SoilBackupVisitor new 
 		target: backupSoil;
 		backup: self.
-	backupSoil close
+	backupSoil close.
+	self emit: 'backup to ', aStringOrFileReference asString, ' finished'
 		
 ]
 
@@ -200,11 +202,17 @@ Soil >> checkpoint [
 		creates a real checkpoint"
 		entry commitIn: self.
  ].
+	"deliberately silent: SoilTransactionManager>>commitTransaction: checkpoints on
+	every commit that changed something, so this is the hot path and not the rare
+	lifecycle step it looks like from its callers in recovery and on a first open"
 	^ entry
 ]
 
 { #category : #'opening/closing' }
 Soil >> close [
+	"said before rather than after, because the interesting case is the one where
+	closing does not return"
+	self emit: 'closing database'.
 	Soil closeAll: { objectRepository . behaviorRegistry . control . journal . metadata }
 ]
 

--- a/src/Soil-Core/SoilDatabaseRecovery.class.st
+++ b/src/Soil-Core/SoilDatabaseRecovery.class.st
@@ -4,7 +4,8 @@ Class {
 	#instVars : [
 		'soil',
 		'journal',
-		'lsn'
+		'lsn',
+		'replayedTransactions'
 	],
 	#category : #'Soil-Core-Journal'
 }
@@ -53,7 +54,8 @@ SoilDatabaseRecovery >> readFragmentFile: aSoilJournalFragmentFile [
 			"transaction journals are written always completely so we can read until we 
 			discover a commit entry. "
 			self readTransactionJournal: transactionJournal from: aSoilJournalFragmentFile stream.
-			transactionJournal commitIn: soil recovery: true ].
+			transactionJournal commitIn: soil recovery: true.
+			replayedTransactions ifNotNil: [ replayedTransactions := replayedTransactions + 1 ] ].
 		"reading a checkpoint entry is unlikely. It should be possible only if there was an 
 		error after writing the checkpoint entry and before marking that position in the control
 		file. But it is possible it happens so we just need to complete it by updating the 
@@ -95,16 +97,25 @@ SoilDatabaseRecovery >> readTransactionJournal: transactionJournal from: stream 
 	SoilTruncatedRead signal: 'reading of transaction journal is incomplete'
 ]
 
+{ #category : #private }
+SoilDatabaseRecovery >> count: anInteger of: aNoun [
+	"so that a report says '1 transaction' and not '1 transactions'"
+	^ anInteger printString, ' ', (anInteger = 1 ifTrue: [ aNoun ] ifFalse: [ aNoun, 's' ])
+]
+
 { #category : #api }
 SoilDatabaseRecovery >> recover [
 	| lastCheckpoint checkpointEntry fragmentFile |
 	"nothing past the last checkpoint means nothing to do, and nothing to write"
-	self isNeeded ifFalse: [ ^ self ].
+	self isNeeded ifFalse: [
+		soil emit: 'recovery: nothing past the last checkpoint'.
+		^ self ].
 	"from here on recovery writes - the heap, the control file, sometimes a fresh
 	fragment file. Refusing here rather than failing inside one of those writes is
 	what lets a database on read-only media be opened at all: the reader learns that
 	the state is not readable as it stands, and can repair a copy it may write to."
 	soil canRecover ifFalse: [
+		soil emit: 'recovery: needed, but this image may not write to the database'.
 		SoilDatabaseNeedsRecovery new
 			soil: soil;
 			signal ].
@@ -118,6 +129,8 @@ SoilDatabaseRecovery >> recover [
 	filesystem inconsistency we can continue to use the database with the last checkpointed
 	state. This may become a configuration option later"
 	(journal existsFragmentFileForLSN: lastCheckpoint) ifFalse: [ 
+		soil emit: 'recovery: the fragment file for the last checkpoint ',
+			lastCheckpoint printString, ' is missing - starting a new one and checkpointing'.
 		journal cycleFragmentFile.
 		soil checkpoint.
 		^ self ].
@@ -129,6 +142,9 @@ SoilDatabaseRecovery >> recover [
 		do: [ :error | 
 			"in case of a bogus checkpoint position we cannot recover the file but 
 			create a new one and continue"
+			soil emit: 'recovery: the last checkpoint position ', lastCheckpoint printString,
+				' does not read back (', error messageText,
+				') - starting a new fragment file and checkpointing'.
 			journal cycleFragmentFileAfter: fragmentFile.
 			soil checkpoint.
 			^ self ].
@@ -137,11 +153,16 @@ SoilDatabaseRecovery >> recover [
 	recovery handle so the journal can later open the file for writing (a second
 	open in write mode while this one is still open fails on Windows)"
 	fragmentFile atEnd ifTrue: [
+		soil emit: 'recovery: nothing to replay, the last checkpoint ',
+			lastCheckpoint printString, ' ends the journal'.
 		fragmentFile close.
 		^ self ].
 	
 	"the fragment file contains more entries after the last checkpoint. Read the
 	current fragment file to its end and apply all transaction logs/checkpoints found"
+	soil emit: 'recovery: replaying the journal from the last checkpoint ',
+		lastCheckpoint printString.
+	replayedTransactions := 0.
 	self readFragmentFileProtected: fragmentFile.
 	fragmentFile close.
 	
@@ -159,6 +180,10 @@ SoilDatabaseRecovery >> recover [
 	to mark that we covered about the extra entries or bogus data so future reads can
 	proceed from here"
 	soil checkpoint.
+	soil emit: 'recovery: replayed ',
+		(self count: replayedTransactions of: 'transaction'), ' from ',
+		(self count: journal lastFileNumber - lastCheckpoint fileNumber + 1 of: 'fragment file'),
+		', checkpointed'
 ]
 
 { #category : #accessing }

--- a/src/Soil-Core/SoilObjectRepository.class.st
+++ b/src/Soil-Core/SoilObjectRepository.class.st
@@ -29,6 +29,9 @@ SoilObjectRepository >> addNewSegment: aSegment [
 		objectRepository: self;
 		initializeFilesystem.
 	segments add: aSegment.
+	"once per segment in a database's life - today only the first one, from
+	#initializeFilesystem. Cheap to say, and the kind of thing one wants dated"
+	soil emit: 'segment ', aSegment id printString, ' created'.
 	^ aSegment 
 ]
 

--- a/src/Soil-Resident-Tests/SoilResidentReportingTest.class.st
+++ b/src/Soil-Resident-Tests/SoilResidentReportingTest.class.st
@@ -140,9 +140,14 @@ SoilResidentReportingTest >> testATickWithoutWorkSaysNothing [
 { #category : #tests }
 SoilResidentReportingTest >> testEveryLineNamesItsResident [
 	"several residents report into one database, so a line that does not say whose
-	it is cannot be read"
+	it is cannot be read.
+
+	The database reports about itself as well - a segment created, an open, a close -
+	so what is asked here is that a resident's lines name it, not that every line the
+	database collected does. Hence the clearing: from there on only the resident acts."
 	| resident |
 	resident := self residentWith: [ :d | d ].
+	soil reported removeAll.
 	resident noteWork.
 	self assert: (resident waitForStepWithin: 2 seconds).
 	self deny: soil reported isEmpty.


### PR DESCRIPTION
#recover has six ways out and took all of them in silence. A database that had quietly started a fresh fragment file, one that had replayed a hundred transactions, and one that had nothing to do all looked the same from outside - which is how a day of hunting a Windows problem could pass without the log ever naming which had happened. Three of the six can be staged, and each now says what it did, the bogus-checkpoint one carrying the read error that is the only thing describing what was wrong with the file. A replay counts what it replayed: a line saying only that recovery ran leaves open whether it found one transaction or a thousand.

Around it: #close says so before it starts, because the interesting case is the one where closing does not return; #backupTo: brackets itself; and a new segment says so, which happens once in a database's life.

Checkpoint is deliberately silent, and that is a correction to what the plan assumed. It looks like a rare lifecycle step from its callers in recovery and on a first open, but SoilTransactionManager>>commitTransaction: checkpoints on every commit that changed something. Measured, not read: three commits produced three lines before it was taken out again. A test holds it there.

SoilRecoveryReportingTest is the first test to exercise recovery at all. Staging a crash means winding the control file's checkpoint back, the same handle SoilJournalConverter reaches for, because a clean close never leaves anything past the last checkpoint.

The one resident test that assumed every collected line came from a resident is narrowed: the database reports about itself now too.