### PR TITLE
Print the database path, not its inspector name

### DIFF
--- a/src/Soil-Core/Soil.class.st
+++ b/src/Soil-Core/Soil.class.st
@@ -133,7 +133,7 @@ Soil >> backupTo: aStringOrFileReference [
 { #category : #'opening/closing' }
 Soil >> basicOpen [
 	self isOpen ifTrue: [ self error: 'Database already open' ].
-	self emit: 'open database at ', path asString.
+	self emit: 'open database at ', path fullName.
 	control := SoilControlFile new
 		soil: self;
 		open.


### PR DESCRIPTION
'open database at File @ /data/apptivegrid/66/95/2e/...' - the 'File @ ' is FileReference>>printOn:, which #asString goes through. Inherited from the line this replaced, and invisible until it showed up in a production log.