### PR TITLE
Report a stop only when there was one

### DIFF
--- a/src/Soil-Resident-Tests/SoilResidentReportingTest.class.st
+++ b/src/Soil-Resident-Tests/SoilResidentReportingTest.class.st
@@ -167,6 +167,19 @@ SoilResidentReportingTest >> testStartingAndStoppingAreReported [
 ]
 
 { #category : #tests }
+SoilResidentReportingTest >> testStoppingTwiceIsReportedOnce [
+	"an embedder that stops explicitly and then closes stops twice, and the second
+	one is not a state change - saying it again would describe a transition that
+	did not happen"
+	self residentWith: [ :d | d ].
+	self stopWithin: 2 seconds.
+	self stopWithin: 2 seconds.
+	supervisor := nil.
+	self assert: (soil reportedMatching: 'stopping') size equals: 1.
+	self assert: (soil reportedMatching: 'stopped') size equals: 1
+]
+
+{ #category : #tests }
 SoilResidentReportingTest >> testStepsAreReportedWhenAskedFor [
 	| resident |
 	resident := self residentWith: [ :d | d ].

--- a/src/Soil-Resident/SoilResident.class.st
+++ b/src/Soil-Resident/SoilResident.class.st
@@ -190,7 +190,11 @@ SoilResident >> markStarted [
 
 { #category : #accessing }
 SoilResident >> markStopped [
-	"called by my own process when it has left its loop between two work units"
+	"called by my own process when it has left its loop between two work units.
+
+	Reports only a transition that happened: #terminateProcesses marks a resident
+	stopped as well, and it may run after the loop already did"
+	state = #stopped ifTrue: [ ^ self ].
 	state := #stopped.
 	self emit: 'stopped'
 ]
@@ -233,7 +237,13 @@ SoilResident >> requestStop [
 	and held locks behind. I only set the flag -- a resident with a process checks
 	it between two work units and answers #isStopped once it has left the loop.
 	Without a process there is nobody who would notice the flag, so I am stopped
-	right away."
+	right away.
+
+	Asking a resident that has already stopped to stop does nothing at all. It used
+	to put it back into #stopping and out again, which is a state cycle that never
+	happened - and said so twice in the log. Two stops in a row is not exotic: an
+	embedder that stops explicitly and then closes does exactly that."
+	self isStopped ifTrue: [ ^ self ].
 	stopRequested := true.
 	state := #stopping.
 	self emit: 'stopping'.


### PR DESCRIPTION
requestStop put an already stopped resident back into #stopping and out again, and said both. That is a state cycle that did not happen, reported twice, and two stops in a row is not exotic - an embedder that stops explicitly and then closes does exactly that, which is how this turned up in a real log.

markStopped is guarded for the same reason: terminateProcesses marks a resident stopped as well and may run after the loop already did.