### PR TITLE
Let one resident be stopped and restarted on its own

### DIFF
--- a/src/Soil-Resident-Tests/SoilResidentTest.class.st
+++ b/src/Soil-Resident-Tests/SoilResidentTest.class.st
@@ -30,6 +30,16 @@ SoilResidentTest >> residentRegistryObjectId [
 		ensure: [ txn abort ]
 ]
 
+{ #category : #helpers }
+SoilResidentTest >> restart: aSupervisor resident: aSymbol within: aDuration [
+	"like #stop:within:, the embedder's transaction stays reading and is discarded:
+	a resident reads its configuration in it and opens its own to write"
+	| txn |
+	txn := soil newTransaction.
+	^ [ aSupervisor restartResidentNamed: aSymbol in: txn timeout: aDuration ]
+		ensure: [ txn isAborted ifFalse: [ txn abort ] ]
+]
+
 { #category : #running }
 SoilResidentTest >> setUp [
 	super setUp.
@@ -317,6 +327,107 @@ SoilResidentTest >> testResidentNamedSignalsWhenAbsent [
 	self
 		should: [ supervisor residentNamed: #nothingHere ]
 		raise: SoilResidentNotFound
+]
+
+{ #category : #tests }
+SoilResidentTest >> testRestartingAnUnknownNameSignals [
+	"an embedder asking to restart something that is not here has the wrong name,
+	and a silent no is how that stays unnoticed"
+	| supervisor |
+	self addResident: SoilTestResidentDescription new.
+	supervisor := self startedSupervisor.
+
+	self
+		should: [ self restart: supervisor resident: #nosuchresident within: 5 seconds ]
+		raise: SoilResidentNotFound.
+	self stop: supervisor within: 5 seconds
+]
+
+{ #category : #tests }
+SoilResidentTest >> testRestartingBringsAFailedResidentBack [
+	"the way back: a resident that #failed -- at its first start or through a later
+	guard -- is startable again, and its start really runs"
+	| supervisor resident |
+	self addResident: SoilTestResidentDescription new.
+	supervisor := self startedSupervisor.
+	resident := supervisor residentNamed: #dummy.
+	resident markFailed: (Error new messageText: 'put here by the test').
+	self assert: resident hasFailed.
+
+	self restart: supervisor resident: #dummy within: 5 seconds.
+	self assert: resident isStarted.
+	self deny: resident hasFailed.
+	self assert: resident startCount equals: 2.
+	self stop: supervisor within: 5 seconds
+]
+
+{ #category : #tests }
+SoilResidentTest >> testRestartingClearsTheStopFlagSoWorkGoesOn [
+	"the trap this exists to avoid: the stop flag survives a stop, and a loop
+	started with it still up leaves at its first check and marks itself stopped
+	again -- a restart that reports success and started nothing"
+	| supervisor resident |
+	self addResident: SoilTestActiveResidentDescription new.
+	supervisor := self startedSupervisor.
+	resident := supervisor residentNamed: #active.
+
+	self restart: supervisor resident: #active within: 5 seconds.
+	self assert: resident isStarted.
+	self deny: resident shouldStop.
+	resident noteWork.
+	self assert: (resident waitForStepWithin: 5 seconds).
+	self stop: supervisor within: 5 seconds
+]
+
+{ #category : #tests }
+SoilResidentTest >> testRestartingReadsTheConfigurationAgain [
+	"what the whole call is for: #prepareIn: is where a resident reads its
+	description, so a second run of it is the observable that the new configuration
+	arrived"
+	| supervisor resident |
+	self addResident: SoilTestActiveResidentDescription new.
+	supervisor := self startedSupervisor.
+	resident := supervisor residentNamed: #active.
+	self assert: resident prepareCount equals: 1.
+
+	self
+		assert: (self restart: supervisor resident: #active within: 5 seconds)
+		identicalTo: resident.
+	self assert: resident prepareCount equals: 2.
+	self assert: resident isStarted.
+	self assert: resident hasRunningProcess.
+	self stop: supervisor within: 5 seconds
+]
+
+{ #category : #tests }
+SoilResidentTest >> testStoppingAHangingResidentReportsTheHardWayOut [
+	"false means the receipt did not arrive and the process was terminated after
+	all -- the same deliberate exit the group stop takes"
+	| supervisor hanging |
+	self addResident: SoilTestHangingResidentDescription new.
+	supervisor := self startedSupervisor.
+	hanging := supervisor residentNamed: #hanging.
+
+	self deny: (supervisor stopResidentNamed: #hanging timeout: 200 milliSeconds).
+	self assert: hanging isStopped.
+	self deny: hanging hasRunningProcess
+]
+
+{ #category : #tests }
+SoilResidentTest >> testStoppingOneResidentLeavesTheOthersRunning [
+	"putting one resident aside must not close the database down around the others"
+	| supervisor dummy active |
+	self addResident: SoilTestResidentDescription new.
+	self addResident: SoilTestActiveResidentDescription new.
+	supervisor := self startedSupervisor.
+	dummy := supervisor residentNamed: #dummy.
+	active := supervisor residentNamed: #active.
+
+	self assert: (supervisor stopResidentNamed: #dummy timeout: 5 seconds).
+	self assert: dummy isStopped.
+	self assert: active isStarted.
+	self assert: active hasRunningProcess.
+	self stop: supervisor within: 5 seconds
 ]
 
 { #category : #tests }

--- a/src/Soil-Resident/SoilResident.class.st
+++ b/src/Soil-Resident/SoilResident.class.st
@@ -256,6 +256,32 @@ SoilResident >> noteProcessRestart [
 	self emit: 'process restarted (', restartCount printString, ')'
 ]
 
+{ #category : #running }
+SoilResident >> restartIn: aTransaction [
+	"start again, reading my configuration off my description the way a first start
+	does -- #startIn: is 'read the config, then run', and there is no second place
+	that pair lives.
+
+	Whoever changed my description calls this. The base deliberately does not watch
+	for such a change: what follows from one differs per field -- an interval is a
+	setter, a changed host invalidates the progress kept in my workspace -- so the
+	decision belongs to the embedder that made the change, not to a version marker
+	here (Norbert, 2026-09-10).
+
+	Clears the stop flag first. It survives a stop, and a loop started with it still
+	up leaves at its very first check and marks itself stopped again: a restart that
+	reports success and started nothing.
+
+	Also the way back for a resident that is #failed, whether its first start threw
+	or a later guard put it there. A #startIn: that throws again lands in
+	#markFailed: exactly as it does in phase two."
+	stopRequested := false.
+	[ self startIn: aTransaction.
+	self markStarted ]
+		on: Error
+		do: [ :err | self markFailed: err ]
+]
+
 { #category : #stopping }
 SoilResident >> requestStop [
 	"cooperative, never Process>>suspend: that mid-transaction leaves half writes

--- a/src/Soil-Resident/SoilResidentSupervisor.class.st
+++ b/src/Soil-Resident/SoilResidentSupervisor.class.st
@@ -360,6 +360,63 @@ SoilResidentSupervisor >> startTickProcess [
 		forkNamed: 'soil resident tick'
 ]
 
+{ #category : #running }
+SoilResidentSupervisor >> restartResidentNamed: aSymbol in: aTransaction timeout: aDuration [
+	"stop one resident and start it again, so that it reads its configuration off
+	its description anew. This is the one path from a running resident back to a
+	started one: #startAllIn: starts only what is #created and walks past a stopped
+	one.
+
+	Cooperative like every stop here -- the receipt arrives between two work units,
+	and only the timeout terminates after all. A restart therefore waits out at most
+	one work unit; it does not cut into one.
+
+	Also the way back for a resident that is #failed.
+
+	Answers the resident, so that the caller can see what it became: a restart whose
+	#startIn: threw is #failed, not started.
+
+	Unknown name signals SoilResidentNotFound rather than doing nothing: an embedder
+	asking to restart something that is not here has the wrong name, and a silent no
+	is how that stays unnoticed."
+	| resident |
+	resident := self residentNamed: aSymbol.
+	self stopResident: resident timeout: aDuration.
+	resident restartIn: aTransaction.
+	^ resident
+]
+
+{ #category : #stopping }
+SoilResidentSupervisor >> stopResidentNamed: aSymbol timeout: aDuration [
+	"stop a single resident and leave it stopped -- what an embedder needs to put one
+	resident aside without closing the database, and the counterpart to
+	#restartResidentNamed:in:timeout:.
+
+	Answers whether the receipt arrived in time; false means the process was
+	terminated the hard way."
+	^ self stopResident: (self residentNamed: aSymbol) timeout: aDuration
+]
+
+{ #category : #private }
+SoilResidentSupervisor >> stopResident: aResident timeout: aDuration [
+	"ask, wait for the receipt, terminate if it did not come. The single-resident
+	shape of #stopAllIn:timeout:, and deliberately not reused by it: the group asks
+	everybody before it waits for anybody, because a resident still running could
+	talk to one already stopped. With one resident there is nobody to be out of step
+	with.
+
+	Answers whether the receipt arrived in time."
+	[ aResident requestStop ]
+		on: Error
+		do: [ :err | aResident emit: 'failed on requestStop: ', err messageText ].
+	(self waitFor: { aResident } upTo: aDuration) ifEmpty: [ ^ true ].
+	aResident emit: 'did not acknowledge the stop within ', aDuration asString, ', terminating'.
+	[ aResident terminateProcesses ]
+		on: Error
+		do: [ :err | aResident emit: 'failed to terminate: ', err messageText ].
+	^ false
+]
+
 { #category : #stopping }
 SoilResidentSupervisor >> stopAllIn: aTransaction timeout: aDuration [
 	"symmetric stop. Stopped in one phase, a resident still running could talk to
@@ -422,13 +479,24 @@ SoilResidentSupervisor >> tickProcessIsRunning [
 ]
 
 { #category : #stopping }
-SoilResidentSupervisor >> waitForReceipts: aDuration [
+SoilResidentSupervisor >> waitFor: aCollectionOfResidents upTo: aDuration [
 	"poll rather than wait out the whole timeout, so a quick stop returns
-	quickly. Answers whoever is still missing"
+	quickly. Answers whoever is still missing.
+
+	The collection is taken as given rather than re-read every turn: the group stop
+	hands in the residents it asked, and waiting for one that was added while the
+	stop was already running would wait for a receipt nobody was asked for."
 	| deadline pending |
 	deadline := DateAndTime now + aDuration.
-	[ pending := self residents reject: [ :each | each isStopped ].
+	[ pending := aCollectionOfResidents reject: [ :each | each isStopped ].
 	pending isEmpty or: [ DateAndTime now > deadline ] ]
 		whileFalse: [ 50 milliSeconds wait ].
 	^ pending
+]
+
+{ #category : #stopping }
+SoilResidentSupervisor >> waitForReceipts: aDuration [
+	"the group's receipts. One resident's are awaited by #stopResident:timeout:,
+	through the same poll"
+	^ self waitFor: self residents upTo: aDuration
 ]


### PR DESCRIPTION
A resident reads its configuration off its description exactly once, at start, so a change made while it runs takes effect only when the database is opened again. Instead of watching the description for changes, the supervisor now offers the operation and leaves the decision to whoever made the change: what follows from a change differs per field anyway -- an interval is a setter, a changed host invalidates the progress kept in the workspace.

restartResidentNamed:in:timeout: stops one resident, waits for its receipt and starts it again, which re-reads the description through startIn:. stopResidentNamed:timeout: is the counterpart that leaves it stopped, so one resident can be put aside without closing the database.

Three things this has to get right. The stop flag survives a stop, so it is cleared before the restart -- a loop started with it still up leaves at its very first check and marks itself stopped again, a restart that reports success and started nothing. The restart does not go through startAllIn:, which starts only what is #created and walks past a stopped resident. And the receipt is awaited the way the group stop awaits it; waitForReceipts: now shares that poll through waitFor:upTo:.

The same call is the way back for a resident that is #failed, whether its first start threw or a later guard put it there.