### PR TITLE
Do not tick a resident that has failed

### DIFF
--- a/src/Soil-Resident-Tests/SoilResidentTest.class.st
+++ b/src/Soil-Resident-Tests/SoilResidentTest.class.st
@@ -244,6 +244,27 @@ SoilResidentTest >> testLoadingTwiceIsRefused [
 ]
 
 { #category : #tests }
+SoilResidentTest >> testNoTickForAFailedResident [
+	"an active resident revives its own process in its tick without asking what
+	state it is in, so a resident whose #startIn: threw used to get its run loop
+	started by the very next tick -- unprepared -- and one counted restart per tick
+	on top, which is what would have made an upper bound on restarts pointless"
+	| supervisor resident |
+	self addResident: SoilTestActiveResidentDescription new.
+	supervisor := self startedSupervisor.
+	resident := supervisor residentNamed: #active.
+	resident terminateProcesses.
+	resident markFailed: (Error new messageText: 'put here by the test').
+	self assert: resident hasFailed.
+	self deny: resident hasRunningProcess.
+
+	supervisor tick.
+	self deny: resident hasRunningProcess.
+	self assert: resident restartCount equals: 0.
+	self stop: supervisor within: 5 seconds
+]
+
+{ #category : #tests }
 SoilResidentTest >> testNoTickWhileStopped [
 	| supervisor resident before |
 	self addResident: SoilTestResidentDescription new.

--- a/src/Soil-Resident/SoilResidentSupervisor.class.st
+++ b/src/Soil-Resident/SoilResidentSupervisor.class.st
@@ -459,9 +459,22 @@ SoilResidentSupervisor >> stopTick [
 SoilResidentSupervisor >> tick [
 	"serially, one after the other, with errors isolated per resident: a throwing
 	resident must not abort the run. No tick while stopping or stopped, otherwise
-	the tick starts up again what the stop is just clearing away"
+	the tick starts up again what the stop is just clearing away.
+
+	And none for a resident that has failed, for the same kind of reason. An active
+	resident brings its own process back in its tick, and it does not ask what state
+	it is in when it does -- so a resident whose #startIn: threw got its run loop
+	started by the very next tick, with a #prepareIn: that never completed. Measured
+	before this guard: process gone to running again within one tick, #restartCount
+	climbing by one per tick while the state stayed #failed. That also made an upper
+	bound on restarts pointless, because the counter it watches was driven by the
+	tick rather than by real process deaths.
+
+	A failed resident is by definition unusable -- whether that keeps the database
+	from opening is the embedder's decision, and until it decides, doing nothing is
+	the honest answer."
 	self residents do: [ :each |
-		(each isStopping or: [ each isStopped ]) ifFalse: [
+		(each isStopping or: [ each isStopped or: [ each hasFailed ] ]) ifFalse: [
 			[ each tick ]
 				on: Error
 				do: [ :err | each emit: 'failed on tick: ', err messageText ] ] ].


### PR DESCRIPTION
An active resident brings its own process back in its tick and does not ask what state it is in while doing so. A resident whose startIn: threw therefore got its run loop started by the very next tick, with a prepareIn: that never completed -- and one counted restart per tick on top of that.

Measured before the guard: the process went from gone to running within one tick, restartCount climbed by one per tick, and the state stayed #failed throughout. That second part is what would have made an upper bound on process restarts pointless, because the counter such a bound watches was driven by the tick rather than by real process deaths.

The supervisor's tick now passes a failed resident by, for the same kind of reason it already passes a stopping or stopped one: a failed resident is unusable, whether that keeps the database from opening is the embedder's decision, and until it decides, doing nothing is the honest answer.