### PR TITLE
Give up on a resident whose process keeps dying

### DIFF
--- a/src/Soil-Resident-Tests/SoilResidentTest.class.st
+++ b/src/Soil-Resident-Tests/SoilResidentTest.class.st
@@ -308,6 +308,51 @@ SoilResidentTest >> testPassiveResidentStopsWithoutProcess [
 ]
 
 { #category : #tests }
+SoilResidentTest >> testProcessRestartsAreUnlimitedByDefault [
+	"nil is the default and means no bound: which number is right depends on what a
+	resident does, so the package does not invent one"
+	| supervisor resident |
+	self addResident: SoilTestActiveResidentDescription new.
+	supervisor := self startedSupervisor.
+	resident := supervisor residentNamed: #active.
+	self assert: resident maxProcessRestarts isNil.
+
+	3 timesRepeat: [
+		resident process terminate.
+		supervisor tick ].
+	self assert: resident restartCount equals: 3.
+	self deny: resident hasFailed.
+	self assert: resident hasRunningProcess.
+	self stop: supervisor within: 5 seconds
+]
+
+{ #category : #tests }
+SoilResidentTest >> testProcessRestartsStopAtTheLimit [
+	"bringing a resident back forever is a loop, not resilience. At its limit it
+	gives up visibly and stays #failed, and the error keeps the number it gave up at"
+	| supervisor resident |
+	self addResident: SoilTestActiveResidentDescription new.
+	supervisor := self startedSupervisor.
+	resident := supervisor residentNamed: #active.
+	resident maxRestarts: 1.
+
+	resident process terminate.
+	supervisor tick.
+	self assert: resident restartCount equals: 1.
+	self assert: resident hasRunningProcess.
+	self deny: resident hasFailed.
+
+	resident process terminate.
+	supervisor tick.
+	self assert: resident hasFailed.
+	self deny: resident hasRunningProcess.
+	self assert: resident restartCount equals: 1.
+	self assert: resident error class equals: SoilResidentRestartLimitReached.
+	self assert: resident error messageText equals: 'gave up restarting active after 1 restart'.
+	self stop: supervisor within: 5 seconds
+]
+
+{ #category : #tests }
 SoilResidentTest >> testRegistryIsClusterRootWithStableObjectId [
 	"deliberately a cluster root of its own from stage one, so named roots later
 	only add a name -> object id entry instead of moving data in databases in

--- a/src/Soil-Resident-Tests/SoilTestActiveResident.class.st
+++ b/src/Soil-Resident-Tests/SoilTestActiveResident.class.st
@@ -18,7 +18,8 @@ Class {
 		'prepareCount',
 		'workToLeave',
 		'throwOnStep',
-		'stepSignal'
+		'stepSignal',
+		'maxRestarts'
 	],
 	#category : #'Soil-Resident-Tests'
 }
@@ -45,6 +46,19 @@ SoilTestActiveResident >> interval [
 { #category : #accessing }
 SoilTestActiveResident >> interval: aDuration [
 	interval := aDuration
+]
+
+{ #category : #accessing }
+SoilTestActiveResident >> maxProcessRestarts [
+	"nil unless a test sets one, which is the inherited default"
+	^ maxRestarts
+]
+
+{ #category : #accessing }
+SoilTestActiveResident >> maxRestarts: anIntegerOrNil [
+	"how many revivals of my process I tolerate, so that a test can reach the limit
+	in two terminations instead of many"
+	maxRestarts := anIntegerOrNil
 ]
 
 { #category : #accessing }

--- a/src/Soil-Resident/SoilActiveResident.class.st
+++ b/src/Soil-Resident/SoilActiveResident.class.st
@@ -102,6 +102,30 @@ SoilActiveResident >> lastStepError [
 	^ lastStepError
 ]
 
+{ #category : #accessing }
+SoilActiveResident >> maxProcessRestarts [
+	"how many revivals of my process I tolerate before I give up and stay #failed.
+
+	nil means no limit, and nil is the default. Which number is right depends on what
+	a resident does -- one that talks to a foreign host on every step is a different
+	case from one that only writes back a collected window -- and that is the
+	embedder's knowledge, not this package's. A concrete resident overrides me, or
+	reads the number off its description in #prepareIn:.
+
+	The counter itself has been kept since the mechanism was built; only the bound
+	was missing, and it was left out rather than guessed."
+	^ nil
+]
+
+{ #category : #testing }
+SoilActiveResident >> mayRestartProcess [
+	"revivals are counted, not deaths: with a limit of three, three restarts happen
+	and the fourth death is the one that gives up"
+	^ self maxProcessRestarts
+		ifNil: [ true ]
+		ifNotNil: [ :limit | self restartCount < limit ]
+]
+
 { #category : #'instance creation' }
 SoilActiveResident >> newRunStrategy [
 	^ self runStrategyClass new
@@ -227,10 +251,18 @@ SoilActiveResident >> terminateProcesses [
 { #category : #running }
 SoilActiveResident >> tick [
 	"a terminated process would leave my work undone forever. Bring it back, and
-	count it, so that a crash loop is visible instead of looking like health"
+	count it, so that a crash loop is visible instead of looking like health.
+
+	Unless I have been brought back as often as I tolerate. Then bringing me back
+	again is not resilience but a loop, and the honest answer is to give up visibly
+	and let the embedder decide -- which is what #failed means everywhere else in
+	this package."
 	self hasRunningProcess ifFalse: [
-		self noteProcessRestart.
-		self startProcess ].
+		self mayRestartProcess
+			ifTrue: [
+				self noteProcessRestart.
+				self startProcess ]
+			ifFalse: [ self markFailedAfterRestartLimit ] ].
 	self reportWorkSinceLastTick
 ]
 

--- a/src/Soil-Resident/SoilResident.class.st
+++ b/src/Soil-Resident/SoilResident.class.st
@@ -208,6 +208,40 @@ SoilResident >> markFailed: anError [
 ]
 
 { #category : #accessing }
+SoilResident >> markFailedAfterRestartLimit [
+	"my process has died more often than I tolerate, so I am not brought back any
+	more. Kept as state plus error rather than signalled, exactly as #markFailed:
+	keeps a failed start.
+
+	This is where I stay: the supervisor's tick passes a failed resident by, so
+	nothing brings me back on its own. The way out is the embedder's, through
+	SoilResidentSupervisor>>restartResidentNamed:in:timeout:."
+	state := #failed.
+	error := SoilResidentRestartLimitReached new
+		         name: self name;
+		         restartCount: restartCount;
+		         yourself.
+	self emit: error messageText
+]
+
+{ #category : #accessing }
+SoilResident >> markFailedAfterRestartLimit [
+	"my process has died more often than I tolerate, so I am not brought back any
+	more. Kept as state plus error rather than signalled, exactly as #markFailed:
+	keeps a failed start.
+
+	This is where I stay: the supervisor's tick passes a failed resident by, so
+	nothing brings me back on its own. The way out is the embedder's, through
+	SoilResidentSupervisor>>restartResidentNamed:in:timeout:."
+	state := #failed.
+	error := SoilResidentRestartLimitReached new
+		         name: self name;
+		         restartCount: restartCount;
+		         yourself.
+	self emit: error messageText
+]
+
+{ #category : #accessing }
 SoilResident >> markStarted [
 	state := #started.
 	self emit: 'started'

--- a/src/Soil-Resident/SoilResidentRestartLimitReached.class.st
+++ b/src/Soil-Resident/SoilResidentRestartLimitReached.class.st
@@ -1,0 +1,34 @@
+"
+Kept as a failed resident's error after its process has been brought back as
+often as that resident tolerates. Not signalled, and that is deliberate: the
+tick that notices runs in the supervisor's own process, and there is nobody
+there to catch anything. A resident's answer to the embedder is its state plus
+its error, the same way a failed start is kept rather than raised.
+"
+Class {
+	#name : #SoilResidentRestartLimitReached,
+	#superclass : #SoilResidentError,
+	#instVars : [
+		'restartCount'
+	],
+	#category : #'Soil-Resident'
+}
+
+{ #category : #accessing }
+SoilResidentRestartLimitReached >> messageText [
+	^ 'gave up restarting ', name asString, ' after ', self restartCount printString,
+		(self restartCount = 1 ifTrue: [ ' restart' ] ifFalse: [ ' restarts' ])
+]
+
+{ #category : #accessing }
+SoilResidentRestartLimitReached >> restartCount [
+	"how many revivals had happened when I was made. The number is the diagnosis:
+	read together with the resident's name it says whether this was a slow decay or
+	a crash loop"
+	^ restartCount
+]
+
+{ #category : #accessing }
+SoilResidentRestartLimitReached >> restartCount: anInteger [
+	restartCount := anInteger
+]


### PR DESCRIPTION
The restart counter has been kept since the mechanism was built, with no bound on it, because what number should turn a resident into #failed depends on what that resident does -- one that talks to a foreign host on every step is a different case from one that only writes back a collected window. So the bound is not a number in this package: SoilActiveResident answers nil for maxProcessRestarts, meaning no limit, and a concrete resident overrides it or reads the number off its description in prepareIn:. The embedder knows, this package does not.

Where a limit is set, the tick stops reviving at it and the resident gives up visibly: state #failed, and a SoilResidentRestartLimitReached kept as its error, carrying the count it gave up at. Revivals are counted rather than deaths, so a limit of three means three restarts happen and the fourth death is the one that gives up.

Giving up is not a dead end. The supervisor's tick passes a failed resident by, so nothing brings it back on its own, and the way out is the embedder's through restartResidentNamed:in:timeout:.