### PR TITLE
Say when a resident is stuck inside a work unit

### DIFF
--- a/src/Soil-Resident-Tests/SoilResidentReportingTest.class.st
+++ b/src/Soil-Resident-Tests/SoilResidentReportingTest.class.st
@@ -232,6 +232,54 @@ SoilResidentReportingTest >> testATickReportsWorkDoneSinceTheLastOne [
 ]
 
 { #category : #tests }
+SoilResidentReportingTest >> testAResidentHangingInAStepSaysSoOnTheTick [
+	"the silence that was left: a step that never returns leaves the delta at zero,
+	exactly like an idle resident - and the restart counter does not see it either,
+	because the process is alive and simply not coming back"
+	| resident |
+	resident := self residentWith: [ :d | d ].
+	resident hangOnStep: true.
+	resident noteWork.
+	self assert: (resident waitForHangingStepWithin: 2 seconds).
+	"the first tick still has a delta - the step is counted on the way in - so it
+	is the second one that has nothing to report and speaks up anyway"
+	resident tick.
+	resident tick.
+
+	self assert: (soil reportedMatching: 'still in step 1, started') size equals: 1.
+	resident releaseHangingStep
+]
+
+{ #category : #tests }
+SoilResidentReportingTest >> testATickAfterAFinishedStepSaysNothingAboutHanging [
+	"the line belongs to a step that did not come back, not to every quiet tick -
+	otherwise it would be the noise that testATickWithoutWorkSaysNothing rules out"
+	| resident |
+	resident := self residentWith: [ :d | d ].
+	resident noteWork.
+	self assert: (resident waitForStepWithin: 2 seconds).
+	resident tick.
+	resident tick.
+
+	self assert: (soil reportedMatching: 'still in step') isEmpty
+]
+
+{ #category : #tests }
+SoilResidentReportingTest >> testTheStatusLineSaysThatAStepIsStillRunning [
+	"'what has happened at all' has to include 'and one of it has not finished' -
+	the half-hourly report is where somebody looks first, and a resident stuck in
+	a work unit stands there with the same line as a healthy idle one"
+	| resident |
+	resident := self residentWith: [ :d | d ].
+	resident hangOnStep: true.
+	resident noteWork.
+	self assert: (resident waitForHangingStepWithin: 2 seconds).
+
+	self assert: (resident statusLine beginsWith: 'active started, 1 step, 0 errors, in step 1 for ').
+	resident releaseHangingStep
+]
+
+{ #category : #tests }
 SoilResidentReportingTest >> testATickWithoutWorkSaysNothing [
 	"otherwise a quiet resident would fill the log at the tick's cadence, and the
 	lines that mean something would drown in the ones that do not"

--- a/src/Soil-Resident-Tests/SoilTestActiveResident.class.st
+++ b/src/Soil-Resident-Tests/SoilTestActiveResident.class.st
@@ -1,6 +1,6 @@
 "
-The dummy active resident: it can be told to leave work behind, to throw, and
-which cadence to run on. Counting its steps is no longer its own business -
+The dummy active resident: it can be told to leave work behind, to throw, to
+hang inside a step until the test lets it out, and which cadence to run on. Counting its steps is no longer its own business -
 SoilActiveResident does that, which is what this class faked before. Everything it does is in memory,
 so that a drain test is not a test of transaction speed.
 
@@ -19,7 +19,10 @@ Class {
 		'workToLeave',
 		'throwOnStep',
 		'stepSignal',
-		'maxRestarts'
+		'maxRestarts',
+		'hangOnStep',
+		'inHangingStep',
+		'leaveHangingStep'
 	],
 	#category : #'Soil-Resident-Tests'
 }
@@ -35,7 +38,10 @@ SoilTestActiveResident >> initialize [
 	prepareCount := 0.
 	workToLeave := 0.
 	throwOnStep := false.
-	stepSignal := Semaphore new
+	stepSignal := Semaphore new.
+	hangOnStep := false.
+	inHangingStep := Semaphore new.
+	leaveHangingStep := Semaphore new
 ]
 
 { #category : #accessing }
@@ -94,8 +100,37 @@ SoilTestActiveResident >> runStep [
 	[ workToLeave > 0 ifTrue: [
 		workToLeave := workToLeave - 1.
 		self noteWork ].
+	hangOnStep ifTrue: [
+		inHangingStep signal.
+		leaveHangingStep wait ].
 	throwOnStep ifTrue: [ Error signal: 'the step was told to throw' ] ]
 		ensure: [ stepSignal signal ]
+]
+
+{ #category : #accessing }
+SoilTestActiveResident >> hangOnStep: aBoolean [
+	"the coming steps block inside the work unit until #releaseHangingStep. What
+	the existing SoilTestHangingResident does not give: that one is passive and
+	ignores the stop flag, which is the stop-timeout path. This is a live process
+	sitting in a step, which is the case a restart counter cannot see"
+	hangOnStep := aBoolean
+]
+
+{ #category : #accessing }
+SoilTestActiveResident >> releaseHangingStep [
+	"lets the waiting step finish and takes the switch back out, so the next step
+	does not hang again. A test that made a step hang has to call me, or its
+	process is still in there when the test is over"
+	hangOnStep := false.
+	leaveHangingStep signal
+]
+
+{ #category : #waiting }
+SoilTestActiveResident >> waitForHangingStepWithin: aDuration [
+	"answers whether the step got as far as hanging, so a test synchronises on
+	being inside a work unit the way #waitForStepWithin: synchronises on one
+	being over"
+	^ self wait: inHangingStep upTo: aDuration
 ]
 
 { #category : #accessing }

--- a/src/Soil-Resident/SoilActiveResident.class.st
+++ b/src/Soil-Resident/SoilActiveResident.class.st
@@ -41,7 +41,8 @@ Class {
 		'lastStepError',
 		'stepErrorCount',
 		'stepCount',
-		'reportedStepCount'
+		'reportedStepCount',
+		'stepStartedAt'
 	],
 	#category : #'Soil-Resident'
 }
@@ -50,7 +51,11 @@ Class {
 SoilActiveResident class >> soilTransientInstVars [
 	"nothing about me is persisted either; the list has to repeat the inherited
 	entry, because a subclass declaration replaces its superclass's rather than
-	adding to it"
+	adding to it.
+
+	What is listed here is what must not be dragged into a written graph, not
+	everything that is transient in spirit: the counters and #stepStartedAt are
+	plain values and stand outside for the same reason #stepCount does."
 	^ #( supervisor process workSignal strategy )
 ]
 
@@ -192,10 +197,16 @@ SoilActiveResident >> runStepProtected [
 	something happened, and what happened is about to be handled. Left standing,
 	the next turn would find the flag down, wait on a signal that is already
 	answered, and run an empty step -- which is exactly what a strategy that
-	returns early on the flag would otherwise cause"
+	returns early on the flag would otherwise cause.
+
+	The count and the start time are set before #working, not after, so that
+	whoever finds me working reads a number and a timestamp that already belong to
+	the step I am in. The other order leaves a window in which a report says
+	'in step 3' about step 4, or reads no start time at all"
+	stepCount := stepCount + 1.
+	stepStartedAt := DateAndTime now.
 	working := true.
 	pendingWork := false.
-	stepCount := stepCount + 1.
 	workSignal consumeAllSignals.
 	self emitsEveryStep ifTrue: [ self emit: 'step ', stepCount printString ].
 	[ [ self runStep ]
@@ -275,13 +286,44 @@ SoilActiveResident >> emitsEveryStep [
 ]
 
 { #category : #logging }
+SoilActiveResident >> durationString: aDuration [
+	"'14 minutes' rather than '0:00:14:00'. A line whose whole worth is that
+	somebody reads it should carry an interval that reads like one.
+
+	Which selector does that differs across the Pharo versions Soil builds on, and
+	that question is answered once, in SoilResidentSupervisor>>durationString: --
+	repeating the version check here would mean two places to get it wrong. The
+	nil guard has the same shape and the same reason as #emitsEveryStep: a
+	resident without a supervisor is one that was never added to one, which
+	happens in unit tests, and Duration's own printString is what the lines here
+	have always fallen back to anyway."
+	^ supervisor
+		ifNil: [ aDuration asString ]
+		ifNotNil: [ :s | s durationString: aDuration ]
+]
+
+{ #category : #logging }
 SoilActiveResident >> statusLine [
 	"the counters are cumulative here, where #reportWorkSinceLastTick reports a
 	delta: that one answers 'what is happening right now', this one 'what has
 	happened at all'. Read together over a series of reports they give the rate
 	as well, which is why the periodic line does not need to be a delta too."
-	^ super statusLine, ', ', (self count: stepCount of: 'step'),
-		', ', (self count: stepErrorCount of: 'error')
+	| line |
+	line := super statusLine, ', ', (self count: stepCount of: 'step'),
+		', ', (self count: stepErrorCount of: 'error').
+	self isWorking ifTrue: [
+		line := line, ', in step ', stepCount printString, ' for ',
+			(self durationString: self currentStepDuration) ].
+	^ line
+]
+
+{ #category : #logging }
+SoilActiveResident >> currentStepDuration [
+	"how long I have been in the step I am in. Only meaningful while #isWorking --
+	#stepStartedAt is deliberately not cleared when a step returns, because a field
+	that is set on the way in and cleared on the way out has a window in which a
+	reader finds nothing while #working already says yes"
+	^ DateAndTime now - stepStartedAt
 ]
 
 { #category : #logging }
@@ -292,10 +334,25 @@ SoilActiveResident >> reportWorkSinceLastTick [
 	mechanism was built to end - that one meant 'no idea'.
 
 	The counters are cumulative and the line is a delta, because what one wants to
-	read off a series of these is the rate."
+	read off a series of these is the rate.
+
+	The one silence that had to go is the one in the middle: a step that never
+	returns leaves the delta at zero, exactly like an idle resident, so 'nothing to
+	do' and 'stuck inside a work unit' read the same. #restartCount does not see it
+	either -- that one counts dead processes, and this process is alive and simply
+	not coming back. So when nothing finished and I am still in a step, I say which
+	step and since when.
+
+	Only when nothing finished: a busy resident is inside a step at most tick times
+	too, and saying 'still in step 4711, started 2 milliseconds ago' at every report
+	would be noise about a resident that is demonstrably making progress."
 	| done |
 	done := stepCount - reportedStepCount.
-	done = 0 ifTrue: [ ^ self ].
+	done = 0 ifTrue: [
+		self isWorking ifTrue: [
+			self emit: 'still in step ', stepCount printString, ', started ',
+				(self durationString: self currentStepDuration), ' ago' ].
+		^ self ].
 	reportedStepCount := stepCount.
 	self emit: (self count: done of: 'step'), ' since the last report, ',
 		(self count: stepErrorCount of: 'error'), ' in all'


### PR DESCRIPTION
A step that never returns left the tick silent, exactly like an idle resident: the delta between two reports is zero either way. The restart counter does not see it either -- that one counts dead processes, and a hanging one is alive and simply not coming back. The case is real: AGAccountsResident fetches from a foreign host outside its transaction, on the clock, with no timeout of its own.

An active resident now remembers when its current step started, next to the count it already raises on the way in. While it is working, the status line says which step it is in and for how long, and a report with nothing finished says so instead of staying quiet.

Only when nothing finished: a busy resident is inside a step at most tick times too, and saying so at every report would be noise about a resident that is demonstrably making progress.

Nothing acts on it. The supervisor gathers answers and passes them on; what a deadline should trigger is the embedder's decision.