### PR TITLE
Let a resident be switched off in its description

### DIFF
--- a/src/Soil-Resident-Tests/SoilResidentTest.class.st
+++ b/src/Soil-Resident-Tests/SoilResidentTest.class.st
@@ -40,6 +40,22 @@ SoilResidentTest >> restart: aSupervisor resident: aSymbol within: aDuration [
 		ensure: [ txn isAborted ifFalse: [ txn abort ] ]
 ]
 
+{ #category : #helpers }
+SoilResidentTest >> switchOff: aBoolean residentNamed: aSymbol [
+	"the embedder's half of the switch: the flag is persisted, so writing it is a
+	transaction of its own that the caller commits. Soil never writes a description
+	itself, and applying it to a running resident is the separate #restart:"
+	| txn |
+	txn := soil newTransaction.
+	[ | description |
+	description := (soil residentRegistryIn: txn) descriptionNamed: aSymbol.
+	aBoolean
+		ifTrue: [ description disable ]
+		ifFalse: [ description enable ].
+	txn commit ]
+		ensure: [ txn isAborted ifFalse: [ txn abort ] ]
+]
+
 { #category : #running }
 SoilResidentTest >> setUp [
 	super setUp.
@@ -129,6 +145,123 @@ SoilResidentTest >> testDummyResidentBlocksAndReleasesIdle [
 	self waitUntil: [ resident stepCount = 1 ] within: 5 seconds.
 	self waitUntil: [ supervisor isIdle ] within: 1 second.
 	self deny: supervisor hasPendingWork.
+	self stop: supervisor within: 5 seconds
+]
+
+{ #category : #tests }
+SoilResidentTest >> testADisabledDescriptionIsNotStarted [
+	"the point of a persisted flag: it is read before anybody starts, so a resident
+	that is switched off never runs a first work unit"
+	| supervisor resident |
+	self addResident: SoilTestActiveResidentDescription new.
+	self switchOff: true residentNamed: #active.
+	supervisor := self startedSupervisor.
+	resident := supervisor residentNamed: #active.
+
+	self assert: resident isDisabled.
+	self deny: resident isStarted.
+	self deny: resident hasRunningProcess.
+	self assert: resident prepareCount equals: 0.
+	self assert: (soil reportedMatching: 'resident active: disabled') size equals: 1.
+	self stop: supervisor within: 5 seconds
+]
+
+{ #category : #tests }
+SoilResidentTest >> testADisabledResidentIsIdleAndHasNoWork [
+	"otherwise a switched-off resident would keep the database from closing, which
+	is the opposite of what switching it off is for"
+	| supervisor resident |
+	self addResident: SoilTestActiveResidentDescription new.
+	self switchOff: true residentNamed: #active.
+	supervisor := self startedSupervisor.
+	resident := supervisor residentNamed: #active.
+	"even after somebody hands it work: it is not there to take it"
+	resident noteWork.
+
+	self assert: resident isIdle.
+	self deny: resident hasPendingWork.
+	self assert: supervisor isIdle.
+	self deny: supervisor hasPendingWork.
+	self stop: supervisor within: 5 seconds
+]
+
+{ #category : #tests }
+SoilResidentTest >> testTheTickDoesNotStartADisabledResident [
+	"an active resident brings its own process back in its tick without asking what
+	state it is in. Without the guard the very next tick would start the loop of a
+	resident that never ran #prepareIn: - and would undo the switch while doing it"
+	| supervisor resident |
+	self addResident: SoilTestActiveResidentDescription new.
+	self switchOff: true residentNamed: #active.
+	supervisor := self startedSupervisor.
+	resident := supervisor residentNamed: #active.
+
+	supervisor tick.
+	supervisor tick.
+
+	self assert: resident isDisabled.
+	self deny: resident hasRunningProcess.
+	self assert: resident restartCount equals: 0.
+	self assert: resident prepareCount equals: 0.
+	self stop: supervisor within: 5 seconds
+]
+
+{ #category : #tests }
+SoilResidentTest >> testSwitchingOffAndRestartingStopsTheResident [
+	"the runtime half, in the direction that matters most: a resident that is
+	running now is off after the flag is written and the restart applies it"
+	| supervisor resident |
+	self addResident: SoilTestActiveResidentDescription new.
+	supervisor := self startedSupervisor.
+	resident := supervisor residentNamed: #active.
+	self assert: resident isStarted.
+
+	self switchOff: true residentNamed: #active.
+	self restart: supervisor resident: #active within: 5 seconds.
+
+	self assert: resident isDisabled.
+	self deny: resident hasRunningProcess.
+	"and it did not run another work unit on the way out"
+	self assert: resident prepareCount equals: 1.
+	self stop: supervisor within: 5 seconds
+]
+
+{ #category : #tests }
+SoilResidentTest >> testSwitchingOnAndRestartingStartsTheResident [
+	"the way back, through the same call - and #prepareIn: running is the observable
+	that it really started rather than just changed state"
+	| supervisor resident |
+	self addResident: SoilTestActiveResidentDescription new.
+	self switchOff: true residentNamed: #active.
+	supervisor := self startedSupervisor.
+	resident := supervisor residentNamed: #active.
+	self assert: resident isDisabled.
+
+	self switchOff: false residentNamed: #active.
+	self restart: supervisor resident: #active within: 5 seconds.
+
+	self assert: resident isStarted.
+	self deny: resident isOutOfService.
+	self assert: resident hasRunningProcess.
+	self assert: resident prepareCount equals: 1.
+	self stop: supervisor within: 5 seconds
+]
+
+{ #category : #tests }
+SoilResidentTest >> testRestartingLeavesADisabledResidentDisabled [
+	"a restart is the apply-the-configuration call, not a way past it: as long as
+	the flag stands, no caller can start what it switched off"
+	| supervisor resident |
+	self addResident: SoilTestActiveResidentDescription new.
+	self switchOff: true residentNamed: #active.
+	supervisor := self startedSupervisor.
+	resident := supervisor residentNamed: #active.
+
+	self restart: supervisor resident: #active within: 5 seconds.
+
+	self assert: resident isDisabled.
+	self deny: resident hasRunningProcess.
+	self assert: resident prepareCount equals: 0.
 	self stop: supervisor within: 5 seconds
 ]
 

--- a/src/Soil-Resident/SoilResident.class.st
+++ b/src/Soil-Resident/SoilResident.class.st
@@ -16,6 +16,13 @@ My state machine:
 	created --startIn:--> started --requestStop--> stopping --> stopped
 	   |
 	   +--startIn: throws--> failed
+	   |
+	   +--my description says so--> disabled
+
+#failed and #disabled are the two I never leave on my own, and they answer the
+same three questions the same way -- see #isOutOfService. The way out of either
+is #restartIn:, which reads the description again and lands back in #disabled
+if the flag is still set.
 
 The transitions are driven by the supervisor, which isolates errors per resident;
 I keep the state and answer the questions about it. What I answer are questions
@@ -140,13 +147,45 @@ SoilResident >> hasPendingWork [
 	"is there unprocessed work? A question, not a decision -- the embedder reads
 	it, I never decide whether the database closes.
 
-	A #failed resident answers no here rather than leaving it to the subclass,
-	so it cannot block a decision it can no longer influence.
+	A resident that is #outOfService answers no here rather than leaving it to the
+	subclass, so it cannot block a decision it can no longer influence.
 
 	Whoever signals new work has to set the underlying flag synchronously, in the
 	signalling process -- not first in the woken resident process. Between signal
 	and scheduling is exactly the window in which the embedder's sweep strikes."
-	^ self hasFailed not and: [ self basicHasPendingWork ]
+	^ self isOutOfService not and: [ self basicHasPendingWork ]
+]
+
+{ #category : #testing }
+SoilResident >> isDisabled [
+	"switched off in my description and left that way. Not an error and not a stop:
+	I never ran this time round, and I will not until somebody clears the flag"
+	^ state = #disabled
+]
+
+{ #category : #testing }
+SoilResident >> isDisabledIn: aTransaction [
+	"what my description says, read now -- the persisted answer, where #isDisabled
+	is the live one. The two differ exactly between somebody writing the flag and
+	the restart that applies it.
+
+	Without a description there is nothing that could have switched me off. That is
+	a resident added straight to a supervisor, which happens in unit tests, and the
+	guard has the same reason as the one in #emit:."
+	^ descriptionId
+		ifNil: [ false ]
+		ifNotNil: [ (self descriptionIn: aTransaction) isDisabled ]
+]
+
+{ #category : #testing }
+SoilResident >> isOutOfService [
+	"I cannot work and will not become able to on my own -- broken or switched off.
+	It has a name because three different questions ask exactly this and all three
+	answer it the same way for both cases: whether a tick should reach me, whether
+	I count as idle, and whether I can still have work pending. A chain of #or: at
+	each of the three says less than one word does, and the next state of this kind
+	would have to be added to all three."
+	^ self hasFailed or: [ self isDisabled ]
 ]
 
 { #category : #testing }
@@ -177,9 +216,9 @@ SoilResident >> isIdle [
 	signals up, and you get n idle runs after n signals. A dirty flag beats the
 	signal counter.
 
-	A #failed resident answers idle for the same reason it answers no pending
-	work, and here too rather than in the subclass."
-	^ self hasFailed or: [ self basicIsIdle ]
+	A resident that is #outOfService answers idle for the same reason it answers no
+	pending work, and here too rather than in the subclass."
+	^ self isOutOfService or: [ self basicIsIdle ]
 ]
 
 { #category : #testing }
@@ -239,6 +278,15 @@ SoilResident >> markFailedAfterRestartLimit [
 		         restartCount: restartCount;
 		         yourself.
 	self emit: error messageText
+]
+
+{ #category : #accessing }
+SoilResident >> markDisabled [
+	"my description says I am switched off, so my start did not happen. Said out
+	loud, because a resident that is simply absent from the report is the silence
+	this whole mechanism exists to end -- 'disabled' is an answer, 'nothing' is not"
+	state := #disabled.
+	self emit: 'disabled'
 ]
 
 { #category : #accessing }
@@ -308,10 +356,20 @@ SoilResident >> restartIn: aTransaction [
 
 	Also the way back for a resident that is #failed, whether its first start threw
 	or a later guard put it there. A #startIn: that throws again lands in
-	#markFailed: exactly as it does in phase two."
+	#markFailed: exactly as it does in phase two.
+
+	And the way in and out of #disabled, which is why the flag is checked here
+	rather than answered by a call of its own: reading the description *is* what
+	this method does, and a switched-off resident is a piece of configuration like
+	any other. Both directions are therefore the same call -- write the flag and
+	restart to switch off, clear it and restart to switch on -- and no caller can
+	start something that the persisted flag says is off."
 	stopRequested := false.
-	[ self startIn: aTransaction.
-	self markStarted ]
+	[ (self isDisabledIn: aTransaction)
+		ifTrue: [ self markDisabled ]
+		ifFalse: [
+			self startIn: aTransaction.
+			self markStarted ] ]
 		on: Error
 		do: [ :err | self markFailed: err ]
 ]

--- a/src/Soil-Resident/SoilResidentDescription.class.st
+++ b/src/Soil-Resident/SoilResidentDescription.class.st
@@ -14,10 +14,37 @@ Class {
 	#name : #SoilResidentDescription,
 	#superclass : #Object,
 	#instVars : [
-		'workspace'
+		'workspace',
+		'disabled'
 	],
 	#category : #'Soil-Resident'
 }
+
+{ #category : #accessing }
+SoilResidentDescription >> disable [
+	"switch me off and keep me off. Whoever calls me is inside a transaction and
+	commits it -- the flag is persisted precisely so that it outlives the image,
+	which is what tells it apart from a #requestStop: a stop is a runtime fact and
+	is gone with the process.
+
+	Taking effect on a resident that is already running is a second step, and it is
+	SoilResident>>restartIn: -- the one place a description is read anyway."
+	disabled := true
+]
+
+{ #category : #accessing }
+SoilResidentDescription >> enable [
+	"the way back. Also a second step to take effect, and the same one"
+	disabled := false
+]
+
+{ #category : #testing }
+SoilResidentDescription >> isDisabled [
+	"Compared against true rather than answered straight: every description that
+	already sits in a database gets the new field as nil when Soil migrates it,
+	and nil means 'was never switched off'."
+	^ disabled == true
+]
 
 { #category : #testing }
 SoilResidentDescription >> hasWorkspace [

--- a/src/Soil-Resident/SoilResidentSupervisor.class.st
+++ b/src/Soil-Resident/SoilResidentSupervisor.class.st
@@ -256,13 +256,23 @@ SoilResidentSupervisor >> startAllIn: aTransaction tickEvery: aDuration reportEv
 	embedder may or may not make would leave it one send away from returning.
 
 	No residents, no tick: a tick process for an empty collection would wake up
-	forever to iterate nothing, once per open database."
+	forever to iterate nothing, once per open database. A database whose residents
+	are all switched off still gets one -- the tick is what keeps the periodic
+	report coming, and 'everything here is disabled' is exactly a thing somebody
+	should be able to read."
 	self residents do: [ :each |
 		"only what has not been started: a second start would create a second
 		process for a resident that already has one"
 		each isCreated ifTrue: [
-			[ each startIn: aTransaction.
-			each markStarted ]
+			[ "and only what is not switched off in its description. Asked before
+			the start rather than stopped after it: a resident whose first work unit
+			talks to a foreign host would otherwise have done that once before
+			anybody noticed it was meant to be off"
+			(each isDisabledIn: aTransaction)
+				ifTrue: [ each markDisabled ]
+				ifFalse: [
+					each startIn: aTransaction.
+					each markStarted ] ]
 				on: Error
 				do: [ :err | each markFailed: err ] ] ].
 	self hasResidents ifTrue: [
@@ -472,9 +482,12 @@ SoilResidentSupervisor >> tick [
 
 	A failed resident is by definition unusable -- whether that keeps the database
 	from opening is the embedder's decision, and until it decides, doing nothing is
-	the honest answer."
+	the honest answer. The same holds for one that is switched off, and for the same
+	measured reason: it never ran #prepareIn: either, so a tick that revived its
+	process would start a loop that was never prepared -- and would quietly undo the
+	switch while it was at it. Both are #isOutOfService."
 	self residents do: [ :each |
-		(each isStopping or: [ each isStopped or: [ each hasFailed ] ]) ifFalse: [
+		(each isStopping or: [ each isStopped or: [ each isOutOfService ] ]) ifFalse: [
 			[ each tick ]
 				on: Error
 				do: [ :err | each emit: 'failed on tick: ', err messageText ] ] ].


### PR DESCRIPTION
A stop is a runtime fact and is gone with the process. Switching a resident off has to outlive the image, so the flag is persisted, and the persisted half of a resident is its description.

Read before the start rather than acted on after it: a resident whose first work unit talks to a foreign host would otherwise have done that once before anybody noticed it was meant to be off.

A switched-off resident lands in #disabled instead of staying #created. That is not cosmetic. An active resident brings its own process back in its tick without asking what state it is in, so a #created one would have had its loop started by the very next tick, with a #prepareIn: that never ran -- and the switch quietly undone. #failed already had that guard; both are now #isOutOfService, which is also what #isIdle and #hasPendingWork ask, so a resident that is off cannot keep a database from closing.

No new call for the switch. #restartIn: already means "read the configuration again, then run", and being switched off is configuration like any other: write the flag and restart to switch off, clear it and restart to switch on. It also means no caller can start what the persisted flag says is off.

Existing descriptions migrate with nil in the new field, so #isDisabled compares against true rather than answering the field.