### PR TITLE
fix SoilPersistentDictionary to use TypeCode (and add CleanCodeTests to Serializer)

### DIFF
--- a/src/Soil-Serializer-Tests/SoilSerializationTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilSerializationTest.class.st
@@ -244,6 +244,21 @@ SoilSerializationTest >> testSerializationSet [
 ]
 
 { #category : #'tests-encoded-subclasses' }
+SoilSerializationTest >> testSerializationSoilPersistentDictionary [
+	"SortedCollection is a subclass of OrderedCollection, make sure it works"
+
+	| object serialized materialized |
+	object := SoilPersistentDictionary new.
+	serialized := self serializeToBytes: object.
+	
+	"this is serialized using TypeCodePersistentDictionary"
+	self assert: (serialized at: 7) equals: TypeCodePersistentDictionary.
+
+	materialized := self materializeFromBytes: serialized.
+	self assert: materialized dict equals: object dict
+]
+
+{ #category : #'tests-encoded-subclasses' }
 SoilSerializationTest >> testSerializationSortedCollection [
 	"SortedCollection is a subclass of OrderedCollection, make sure it works"
 

--- a/src/Soil-Serializer-Tests/SoilSerializerCleanCodeTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilSerializerCleanCodeTest.class.st
@@ -249,8 +249,7 @@ SoilSerializerCleanCodeTest >> testNoUnsentMessages [
 		validExceptions := {
 		SoilBasicMaterializer>>#nextUUID: .
 		SoilMaterializer>>#nextCompiledBlock12: . 
-		SoilMaterializer>>#nextCompiledMethod12: .
-		SoilSerializer>>#nextPutUUID:}
+		SoilMaterializer>>#nextCompiledMethod12: }
 	]. 
 
 	methods := methods asOrderedCollection

--- a/src/Soil-Serializer-Tests/SoilSerializerCleanCodeTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilSerializerCleanCodeTest.class.st
@@ -238,11 +238,25 @@ SoilSerializerCleanCodeTest >> testNoUnsentMessages [
 	"Fail if there are methods implemented whose selectors is not sent anywhere in Pharo.
 	Please add a test or remove the method!"
 
-	| found methods|
+	| found methods validExceptions |
 	found := self packageToCheck allUnsentMessages.
 	methods := self packageToCheck methods select: [ :method | found includes: method selector ].
 	methods := methods reject: [:method | method hasPragmaNamed: #inspectorPresentationOrder:title:
   ].
+  validExceptions := { }.
+	"No other exceptions beside the ones mentioned here should be allowed"
+	 SystemVersion current major = 11 ifTrue: [  
+		validExceptions := {
+		SoilBasicMaterializer>>#nextUUID: .
+		SoilMaterializer>>#nextCompiledBlock12: . 
+		SoilMaterializer>>#nextCompiledMethod12: .
+		SoilSerializer>>#nextPutUUID:}
+	]. 
+
+	methods := methods asOrderedCollection
+								removeAll: validExceptions;
+								yourself.
+
 	
 	self
 		assert: methods isEmpty

--- a/src/Soil-Serializer-Tests/SoilSerializerCleanCodeTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilSerializerCleanCodeTest.class.st
@@ -1,0 +1,340 @@
+Class {
+	#name : #SoilSerializerCleanCodeTest,
+	#superclass : #TestCase,
+	#pools : [
+		'SoilTypeCodes'
+	],
+	#category : #'Soil-Serializer-Tests'
+}
+
+{ #category : #cleanup }
+SoilSerializerCleanCodeTest class >> cleanupWhiteSpaceTrimRight [
+	<script>
+	| badCases |
+	badCases := (Soil
+	package methods, self package methods) select: [ :each | 
+		            each sourceCode trimRight size ~= each sourceCode size ].
+
+	badCases do: [ :each | 
+		| refactoring classOrTrait |
+		classOrTrait := each traitSource
+			                ifNil: [ each methodClass ]
+			                ifNotNil: [ each traitSource innerClass ].
+		refactoring := RBAddMethodChange
+			               compile: each sourceCode trimRight
+			               in: classOrTrait
+			               for: nil.
+		refactoring execute ]
+]
+
+{ #category : #accessing }
+SoilSerializerCleanCodeTest class >> defaultTimeLimit [
+
+	^ 30 seconds
+]
+
+{ #category : #running }
+SoilSerializerCleanCodeTest >> assertValidLintRule: aLintRule [
+	self assertValidLintRule: aLintRule withExceptions: #()
+]
+
+{ #category : #running }
+SoilSerializerCleanCodeTest >> assertValidLintRule: aLintRule withExceptions: someNames [
+	| runner results |
+	runner := ReSmalllintChecker new.
+	runner
+		rule: {aLintRule};
+		environment: ( RBBrowserEnvironment new
+		forClasses: self packageToCheck definedClasses);
+		run.
+
+	results := (runner criticsOf: aLintRule) reject: [ :critique | someNames includes: critique entity name ].
+	self
+		assert: results isEmpty
+		description: [ String
+				streamContents: [ :s |
+					s
+						<< aLintRule rationale;
+						lf;
+						<< 'Violations: ';
+						lf.
+					results
+						do: [ :e |
+							s
+								<< '- ';
+								print: e entity ]
+						separatedBy: [ s lf ] ] ]
+]
+
+{ #category : #running }
+SoilSerializerCleanCodeTest >> packageToCheck [
+	^ SoilSerializer package
+]
+
+{ #category : #helpers }
+SoilSerializerCleanCodeTest >> protocolNameOf: aMethod [
+		"how a method is asked for its protocol differs across the Pharo versions this
+		builds on. Try what is there -- and fail loudly rather than answer nil if
+		nothing is, because a silent nil would leave this check green and empty, which
+		is the failure mode it exists to prevent."
+		| protocol |
+		(aMethod respondsTo: #protocolName) ifTrue: [ ^ aMethod protocolName ].
+		(aMethod respondsTo: #protocol) ifTrue: [
+			protocol := aMethod protocol.
+			^ protocol ifNotNil: [
+				protocol isString
+					ifTrue: [ protocol ]
+					ifFalse: [ protocol name ] ] ].
+		self fail: 'no known way to ask a CompiledMethod for its protocol in this Pharo'
+]
+
+{ #category : #running }
+SoilSerializerCleanCodeTest >> soilTransientDeclarationPackages [
+	"the declaration protocol is implemented in Soil-Serializer and used from both packages,
+	also as extensions of classes defined elsewhere"
+
+	^ { Soil package. SoilBehaviorDescription package }
+]
+
+{ #category : #tests }
+SoilSerializerCleanCodeTest >> testCodeCoverage [
+
+	| collector methods coverage testClasses perMethodCoveragePercentage |
+	
+	self skip.
+	"take care: this test interferes with the run coverage feature in the testRunner, we should improve
+	it to not run test tagged <ignoreForCoverage>"
+	collector :=Smalltalk globals at: #CoverageCollector ifPresent: [:class | class new] ifAbsent: [self error: 'class CoverageCollector not found' ].
+	methods := self packageToCheck methods.
+	"Remove all the methods and classes we are not interested in"
+	
+	"subclassResponsibility methods"
+	methods := methods reject: [ :method | 
+		           method isAbstract ].
+	
+	"all methods tagged with <ignoreForCoverage>"
+	methods := methods reject: [ :method | 
+		           method hasPragmaNamed: #ignoreForCoverage ].
+
+	"remove all method from classes in #classNamesNotUnderTest"
+	methods := methods reject: [ :method | 
+		           SoilTest classNamesNotUnderTest includes:
+			           method methodClass instanceSide name ].
+
+	collector methods: methods.
+
+	testClasses := self class package definedClasses select: [ :each | 
+		               each isTestCase ].
+	"we need to remove this test, just remove the whole class for now
+	(we should ignore test tagged with <ignoreForCoverage>)"
+	testClasses := testClasses copyWithout: self class.
+
+	coverage := collector runOn: [ 
+		            testClasses do: [ :class | class buildSuite run ] ].
+	perMethodCoveragePercentage := (100.0 * coverage methods size / coverage collector methods size) rounded.
+	
+	self assert: perMethodCoveragePercentage >= 93.
+]
+
+{ #category : #tests }
+SoilSerializerCleanCodeTest >> testNoDuplicatedMethodInHierarchy [
+	"There should be no methods in the hierachy that are already in a superclass"
+	
+	| methods validExceptions |
+	methods := self packageToCheck methods reject: [:method | method isFromTrait].
+	methods := methods select: [:method |
+	method methodClass superclass
+ 		ifNotNil: [ :superclass | (superclass lookupSelector: method selector)
+ 			ifNotNil: [ :overridenMethod | method equivalentTo: overridenMethod ]
+ 			ifNil: [ false ] ]
+ 		ifNil: [ false ]].
+	
+	"No other exceptions beside the ones mentioned here should be allowed"
+	validExceptions := {WeakLayout>>#soilBasicSerialize:with:}. "Pharo11 needs it"
+
+	methods := methods asOrderedCollection
+								removeAll: validExceptions;
+								yourself.
+	
+	self 
+		assert: methods isEmpty 
+		description: ('the following methods are already in the superclass hierarchy and can be removed: ', methods asString)
+]
+
+{ #category : #tests }
+SoilSerializerCleanCodeTest >> testNoIgnoredSoilTransientDeclaration [
+	"Soil reads #soilTransientInstVars and nothing else. A declaration under the name
+	#soilTransientInstanceVariables is silently ignored, so the instance variables it names
+	stay persistent although they were meant to be kept out of the store."
+
+	| violating |
+	violating := (self soilTransientDeclarationPackages flatCollect: [ :each | 
+		              each methods ]) select: [ :method | 
+		             method selector = #soilTransientInstanceVariables or: [ 
+			             method messages includes: #soilTransientInstanceVariables ] ].
+	self 
+		assert: violating isEmpty 
+		description: 'the following methods use #soilTransientInstanceVariables, which Soil never sends. Use #soilTransientInstVars instead: ', violating asArray printString
+]
+
+{ #category : #tests }
+SoilSerializerCleanCodeTest >> testNoShadowedVariablesInMethods [
+	"Fail if there are methods who define shadowed temps or args"
+	| found validExceptions remaining |
+	found := self packageToCheck methods select: [ :m |
+		m isQuick not and: [ "quick methods do not define variables"
+			m ast variableDefinitionNodes anySatisfy: [ :node | node variable isShadowing ] ]].
+	"No other exceptions beside the ones mentioned here should be allowed"
+	validExceptions := { }.
+
+	remaining := found asOrderedCollection
+								removeAll: validExceptions;
+								yourself.
+
+	self
+		assert: remaining isEmpty
+		description: ('the following methods have shadowing variable definitions and should be cleaned: ', remaining asString)
+]
+
+{ #category : #tests }
+SoilSerializerCleanCodeTest >> testNoUncategorizedMethods [
+	"Asked per method rather than per class. The class-side variant that the
+	inherited version uses walks metaclasses, and #protocolNames is not on the
+	metaclass path in every Pharo of the build matrix -- which nobody noticed
+	because the inherited version never ran. Package>>methods covers both sides
+	anyway."
+	| uncategorized |
+	
+	uncategorized := self packageToCheck methods select: [ :method |
+		| protocol |
+		protocol := self protocolNameOf: method.
+		protocol isNil or: [ protocol asString = 'as yet unclassified' ] ].
+	self
+		assert: uncategorized isEmpty
+		description: 'the following methods are uncategorized: ' , uncategorized asString
+]
+
+{ #category : #tests }
+SoilSerializerCleanCodeTest >> testNoUnimplementedCalls [
+
+	| remaining |
+	"To tag selectors send that are not implemented that should not trigger this rule, use the pragma 
+	<ignoreNotImplementedSelectors: #(selector:to:be:ignored)>"
+	
+	remaining := self packageToCheck methods select: [ :meth | 
+		             | ignored |
+		             ignored := meth allIgnoredNotImplementedSelectors.
+						 meth messages anySatisfy: [ :m | 
+			             m isSelectorSymbol not and: [ 
+				             (ignored includes: m) not ] ] ].
+	
+	self assert: remaining isEmpty description: ('the following methods send selectors that do not exist', remaining asString)
+]
+
+{ #category : #tests }
+SoilSerializerCleanCodeTest >> testNoUnsentMessages [
+	"Fail if there are methods implemented whose selectors is not sent anywhere in Pharo.
+	Please add a test or remove the method!"
+
+	| found methods|
+	found := self packageToCheck allUnsentMessages.
+	methods := self packageToCheck methods select: [ :method | found includes: method selector ].
+	methods := methods reject: [:method | method hasPragmaNamed: #inspectorPresentationOrder:title:
+  ].
+	
+	self
+		assert: methods isEmpty
+		description: ('the following selectors are implemented, but never send', methods asString)
+]
+
+{ #category : #tests }
+SoilSerializerCleanCodeTest >> testNoUnusedClasses [
+	"Fail if there are Classes that are not used. They should either be tested or deleted.
+	(check how to override #isUsed for cases where classes are discovered reflectively)"
+	| found  knownviolations |
+
+	found := self packageToCheck definedClasses reject: [ :class | class isUsed]. 
+	
+	knownviolations := #(SoilSkipListDictionary SoilBTreeDictionary).
+	found := found reject: [:class | knownviolations includes: class name  ].
+	
+	self 
+		assert: found isEmpty 
+		description: ('the following classes are unused: ', found asString)
+]
+
+{ #category : #tests }
+SoilSerializerCleanCodeTest >> testNoUnusedInstanceVariablesLeft [
+	| variables classes validExceptions remaining |
+	classes := self packageToCheck definedClasses
+	           , (self packageToCheck definedClasses collect: [ :each | each classSide ]).
+	
+	variables := classes flatCollect: [ :each | each instanceVariables ].
+	variables := variables reject: [ :each | each isReferenced ].
+	
+	classes := variables collect: [ :each | each definingClass ] as: Set.
+	
+	validExceptions := {}.	
+	
+	remaining := classes asOrderedCollection removeAll: validExceptions; yourself.
+	self assert: remaining isEmpty description: ('the following classes have unused instance variables and should be cleaned: ', remaining asString)
+]
+
+{ #category : #tests }
+SoilSerializerCleanCodeTest >> testNoUnusedTemporaryVariablesLeft [
+	"Fail if there are methods who have unused temporary variables"
+	| found  |
+	found := self packageToCheck methods select: [ :m | 
+		m hasTemporaries and: [ m ast temporaries anySatisfy: [ :x | x binding isUsed not] ] ].
+							
+	self 
+		assert: found isEmpty 
+		description: ('the following methods have unused temporary variables and should be cleaned: ', found asString)
+]
+
+{ #category : #tests }
+SoilSerializerCleanCodeTest >> testNoVarsDefinedByClassesShadow [
+	"make sure no class vars or ivars shadow"
+	| classes |
+	classes := self packageToCheck definedClasses select: [ :class |
+		           class definedVariables anySatisfy: [ :var |
+			           var isShadowing ] ].
+
+	self assert: classes isEmpty description: classes asArray asString
+]
+
+{ #category : #tests }
+SoilSerializerCleanCodeTest >> testReDoNotSendSuperInitializeInClassSideRule [
+	self assertValidLintRule: ReDoNotSendSuperInitializeInClassSideRule new
+]
+
+{ #category : #tests }
+SoilSerializerCleanCodeTest >> testReInstanceVariableCapitalizationRule [
+	self assertValidLintRule: ReInstanceVariableCapitalizationRule new
+]
+
+{ #category : #tests }
+SoilSerializerCleanCodeTest >> testSoilTransientInstVarsNameInstanceVariables [
+	"Every name in a #soilTransientInstVars declaration has to be an instance variable of the 
+	declaring class or of one of its subclasses, which inherit the declaration. A name that 
+	matches no instance variable is a no-op and hides the intention to keep that variable out 
+	of the store."
+
+	| violating |
+	violating := OrderedCollection new.
+	(self soilTransientDeclarationPackages flatCollect: [ :each | each methods ]) 
+		do: [ :method | 
+			(method selector = #soilTransientInstVars and: [ 
+				method methodClass isClassSide and: [ 
+					method methodClass instanceSide isClass ] ]) ifTrue: [ 
+				| class |
+				class := method methodClass instanceSide.
+				class soilTransientInstVars do: [ :name | 
+					((class allInstVarNames includes: name asString) or: [ 
+						class allSubclasses anySatisfy: [ :each | 
+							each allInstVarNames includes: name asString ] ]) ifFalse: [ 
+						violating add: class name -> name ] ] ] ].
+	self 
+		assert: violating isEmpty 
+		description: 'the following #soilTransientInstVars entries do not name an instance variable: ', violating asArray printString
+]

--- a/src/Soil-Serializer-Tests/SoilSerializerCleanCodeTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilSerializerCleanCodeTest.class.st
@@ -247,7 +247,6 @@ SoilSerializerCleanCodeTest >> testNoUnsentMessages [
 	"No other exceptions beside the ones mentioned here should be allowed"
 	 SystemVersion current major = 11 ifTrue: [  
 		validExceptions := {
-		SoilBasicMaterializer>>#nextUUID: .
 		SoilMaterializer>>#nextCompiledBlock12: . 
 		SoilMaterializer>>#nextCompiledMethod12: }
 	]. 

--- a/src/Soil-Serializer-Tests/SoilSerializerCleanCodeTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilSerializerCleanCodeTest.class.st
@@ -150,7 +150,8 @@ SoilSerializerCleanCodeTest >> testNoDuplicatedMethodInHierarchy [
  		ifNil: [ false ]].
 	
 	"No other exceptions beside the ones mentioned here should be allowed"
-	validExceptions := {WeakLayout>>#soilBasicSerialize:with:}. "Pharo11 needs it"
+	 SystemVersion current major > 11 ifTrue: [  
+		validExceptions := {WeakLayout>>#soilBasicSerialize:with:}]. 
 
 	methods := methods asOrderedCollection
 								removeAll: validExceptions;

--- a/src/Soil-Serializer-Tests/SoilSerializerCleanCodeTest.class.st
+++ b/src/Soil-Serializer-Tests/SoilSerializerCleanCodeTest.class.st
@@ -149,6 +149,7 @@ SoilSerializerCleanCodeTest >> testNoDuplicatedMethodInHierarchy [
  			ifNil: [ false ] ]
  		ifNil: [ false ]].
 	
+	validExceptions := { }.
 	"No other exceptions beside the ones mentioned here should be allowed"
 	 SystemVersion current major > 11 ifTrue: [  
 		validExceptions := {WeakLayout>>#soilBasicSerialize:with:}]. 

--- a/src/Soil-Serializer/ByteArray.extension.st
+++ b/src/Soil-Serializer/ByteArray.extension.st
@@ -8,7 +8,7 @@ ByteArray >> soilBasicSerialize: serializer [
 
 { #category : #'*Soil-Serializer' }
 ByteArray >> soilMaterialize [
-	| stream registry a |
+	| stream registry |
 	stream := self readStream.
 	registry := SoilStandaloneObjectRegistry readFrom: stream.
 	^ SoilMaterializer new 

--- a/src/Soil-Serializer/SoilMaterializer.class.st
+++ b/src/Soil-Serializer/SoilMaterializer.class.st
@@ -11,7 +11,7 @@ Class {
 	#category : #'Soil-Serializer-Serializer/Materializer'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #public }
 SoilMaterializer >> behaviorDescriptionIsNotCurrent: aSoilBehaviorDescription [ 
 	includesMigratedObjects := true
 ]

--- a/src/Soil-Serializer/SoilPersistentDictionary.class.st
+++ b/src/Soil-Serializer/SoilPersistentDictionary.class.st
@@ -98,6 +98,11 @@ SoilPersistentDictionary >> detect: detectBlock ifNone: noneBlock [
 		ifNone: noneBlock 
 ]
 
+{ #category : #accessing }
+SoilPersistentDictionary >> dict [
+	^dict
+]
+
 { #category : #initialization }
 SoilPersistentDictionary >> ensureValuesAreRoot [
 	dict do: [:each | 
@@ -166,7 +171,7 @@ SoilPersistentDictionary >> soilBasicSerialize: aSerializer [
 	transaction ifNil: [
 		transaction := aSerializer transaction.
 		self ensureValuesAreRoot ].
-	super soilBasicSerialize: aSerializer 
+	aSerializer nextPutPersistentDictionary: self
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
- add SoilSerializerCleanCodeTest (copy of the one from Soil)
- fixe some trivialities
- fix SoilPersistentDictinary to use TypeCode

fixes #1247